### PR TITLE
Removed HorizontalBarChart knobs from storybooks global scope

### DIFF
--- a/packages/component-library/stories/HorizontalBarChart.story.js
+++ b/packages/component-library/stories/HorizontalBarChart.story.js
@@ -16,19 +16,18 @@ const description = `
   This is some basic usage with the button with providing a label to show the text.
   Clicking should trigger an action.`;
 
-const data = array('Data',[
-{sortOrder: 1, population: 2000, label: 'Labrador Retriever'},
-{sortOrder: 2, population: 8000, label: 'Standard Poodle'},
-{sortOrder: 3, population: 6000, label: 'French Bulldog'},
-{sortOrder: 4, population: 3000, label: 'Afghan Hound'},
-{sortOrder: 5, population: 1000, label: 'Jack Russell Terrier'}
-]);
-const dataKey = text('Data key', 'sortOrder');
-const dataValue = text('Data values', 'population');
-const dataKeyLabel = text('Data key labels', 'label');
-
 export default () => storiesOf(displayName, module).addDecorator(withKnobs)
       .add('Basic Usage', (() => {
+        const data = array('Data',[
+          {sortOrder: 1, population: 2000, label: 'Labrador Retriever'},
+          {sortOrder: 2, population: 8000, label: 'Standard Poodle'},
+          {sortOrder: 3, population: 6000, label: 'French Bulldog'},
+          {sortOrder: 4, population: 3000, label: 'Afghan Hound'},
+          {sortOrder: 5, population: 1000, label: 'Jack Russell Terrier'}
+          ]);
+          const dataKey = text('Data key', 'sortOrder');
+          const dataValue = text('Data values', 'population');
+          const dataKeyLabel = text('Data key labels', 'label');
         return (
           <HorizontalBarChart
             data={data}


### PR DESCRIPTION
If these knobs aren't wrapped in the add's callback then they get added to all other storybook cards as well.