### PR TITLE
Storybook Continuous Delivery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ matrix:
     - env: SUITE=COMPONENT_LIBRARY
 script:
   - yarn run travis
+after_success:
+  - make deploy

--- a/Makefile
+++ b/Makefile
@@ -67,4 +67,5 @@ deploy-2018:
 	echo "2018 build and deploy stub"
 
 deploy-component-library:
-	echo "Deploying the component library";
+	@echo "Deploying the component library";
+	yarn run deploy-storybook -- --ci;

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,29 @@ travis:
 	@if [ "$$SUITE" = "COMPONENT_LIBRARY" ]; then \
 		cd packages/component-library && yarn test && cd -; \
 	fi
+
+deploy:
+	@if [ -z "$$TRAVIS_PULL_REQUEST" ] || [ "$$TRAVIS_PULL_REQUEST" = "false" ]; then \
+		echo "Not a PR..."; \
+		if [ "$$TRAVIS_BRANCH" = "master" ]; then \
+			echo "On the master branch..."; \
+			if [ "$$SUITE" = "2017" ]; then \
+				make deploy-2017; \
+			fi; \
+			if [ "$$SUITE" = "2018" ]; then \
+				make deploy-2018; \
+			fi; \
+			if [ "$$SUITE" = "COMPONENT_LIBRARY" ]; then \
+				make deploy-component-library; \
+			fi \
+		fi \
+	fi
+
+deploy-2017:
+	echo "2017 build and deploy stub"
+
+deploy-2018:
+	echo "2018 build and deploy stub"
+
+deploy-component-library:
+	echo "Deploying the component library";


### PR DESCRIPTION
This sets up the framework for doing continuous delivery of our various artifacts as well as fills out the deployment steps for Storybook CD.

The way Storybook gets deployed is by building the static assets, committing them to the `gh-pages` branch, then pushing that change. From there, Github handles all the web servery bits. 

To get Travis to push to our git repo, a personal access token for a privileged user has to be added to the Travis environment. 

I didn't want to attach a personal PAT, so I created a bot user ([hacko-deploy](https://github.com/hacko-deploy)) and granted that user write access and whatnot.