### PR TITLE
Isolates bar chart storybook variables off storybook global scope

### DIFF
--- a/packages/component-library/stories/BarChart.story.js
+++ b/packages/component-library/stories/BarChart.story.js
@@ -16,19 +16,19 @@ const description = `
   This is some basic usage with the button with providing a label to show the text.
   Clicking should trigger an action.`;
 
-const data = array('Data', [
-  { sortOrder: 1, population: 2000, label: 'Labrador Retriever' },
-  { sortOrder: 2, population: 8000, label: 'Standard Poodle' },
-  { sortOrder: 3, population: 6000, label: 'French Bulldog' },
-  { sortOrder: 4, population: 3000, label: 'Afghan Hound' },
-  { sortOrder: 5, population: 1000, label: 'Jack Russell Terrier' }
-]);
-const dataKey = text('Data key', 'sortOrder');
-const dataValue = text('Data values', 'population');
-const dataKeyLabel = text('Data key labels', 'label');
-
 export default () => storiesOf(displayName, module).addDecorator(withKnobs)
   .add('Basic Usage', (() => {
+    const data = array('Data', [
+      { sortOrder: 1, population: 2000, label: 'Labrador Retriever' },
+      { sortOrder: 2, population: 8000, label: 'Standard Poodle' },
+      { sortOrder: 3, population: 6000, label: 'French Bulldog' },
+      { sortOrder: 4, population: 3000, label: 'Afghan Hound' },
+      { sortOrder: 5, population: 1000, label: 'Jack Russell Terrier' }
+    ]);
+    const dataKey = text('Data key', 'sortOrder');
+    const dataValue = text('Data values', 'population');
+    const dataKeyLabel = text('Data key labels', 'label');
+    
     return (
       <BarChart
         data={data}
@@ -39,12 +39,4 @@ export default () => storiesOf(displayName, module).addDecorator(withKnobs)
         subtitle={'As of January 2017'}
       />
     );
-  }))
-  .add('No title', (() => (
-    <BarChart
-      data={data}
-      dataKey={dataKey}
-      dataValue={dataValue}
-      dataKeyLabel={dataKeyLabel}
-    />
-  )))
+  }));


### PR DESCRIPTION
Looks like this snuck back in recently. Defining storybook variables outside of an add function results in those variables getting assigned to all cards.