### PR TITLE
Scale icons based on zoom level on IconMap

### DIFF
--- a/packages/component-library/src/IconMap/IconMap.js
+++ b/packages/component-library/src/IconMap/IconMap.js
@@ -18,7 +18,7 @@ const IconMap = (props) => {
     visible,
   } = props;
 
-  const size = getSize(viewport.zoom);
+  const sizeScale = iconSizeScale(viewport.zoom);
 
   return (
     <div>
@@ -34,15 +34,15 @@ const IconMap = (props) => {
           opacity={opacity}
           iconAtlas={iconAtlas}
           iconMapping={iconMapping}
-          sizeScale={iconSizeScale}
+          sizeScale={sizeScale}
           getPosition={getPosition}
           getIcon={getIcon}
-          getSize={f => size}
+          getSize={getSize}
           getColor={getColor}
           autoHighlight={autoHighlight}
           onClick={onLayerClick}
           visible={visible}
-          updateTriggers={{getSize: size}}
+          updateTriggers={{getSize: getSize}}
         />
       </DeckGL>
     </div>
@@ -55,7 +55,7 @@ IconMap.propTypes = {
   opacity: PropTypes.number,
   iconAtlas: PropTypes.string,
   iconMapping: PropTypes.object,
-  iconSizeScale: PropTypes.number,
+  iconSizeScale: PropTypes.func,
   getPosition: PropTypes.func,
   getIcon: PropTypes.func,
   getSize: PropTypes.func,

--- a/packages/component-library/src/IconMap/IconMap.js
+++ b/packages/component-library/src/IconMap/IconMap.js
@@ -18,7 +18,8 @@ const IconMap = (props) => {
     visible,
   } = props;
 
-  const sizeScale = iconSizeScale(viewport.zoom);
+  const zoom = viewport.zoom;
+  const sizeScale = iconSizeScale(zoom);
 
   return (
     <div>

--- a/packages/component-library/src/IconMap/IconMap.js
+++ b/packages/component-library/src/IconMap/IconMap.js
@@ -55,7 +55,7 @@ IconMap.propTypes = {
   opacity: PropTypes.number,
   iconAtlas: PropTypes.string,
   iconMapping: PropTypes.object,
-  iconSizeScale: PropTypes.func,
+  sizeScale: PropTypes.number,
   getPosition: PropTypes.func,
   getIcon: PropTypes.func,
   getSize: PropTypes.func,
@@ -67,7 +67,7 @@ IconMap.propTypes = {
 
 IconMap.defaultProps = {
   opacity: 1,
-  iconSizeScale: 1,
+  sizeScale: 1,
   getPosition: d => d.geometry.coordinates,
   getSize: d => 10,
   getColor: d => [0,0,0],

--- a/packages/component-library/src/IconMap/IconMap.js
+++ b/packages/component-library/src/IconMap/IconMap.js
@@ -15,7 +15,10 @@ const IconMap = (props) => {
     getColor,
     autoHighlight,
     onLayerClick,
+    visible,
   } = props;
+
+  const size = getSize(viewport.zoom);
 
   return (
     <div>
@@ -34,10 +37,12 @@ const IconMap = (props) => {
           sizeScale={iconSizeScale}
           getPosition={getPosition}
           getIcon={getIcon}
-          getSize={getSize}
+          getSize={f => size}
           getColor={getColor}
           autoHighlight={autoHighlight}
           onClick={onLayerClick}
+          visible={visible}
+          updateTriggers={{getSize: size}}
         />
       </DeckGL>
     </div>
@@ -57,6 +62,7 @@ IconMap.propTypes = {
   getColor: PropTypes.func,
   autoHighlight: PropTypes.bool,
   onClick: PropTypes.func,
+  visible: PropTypes.bool,
 };
 
 IconMap.defaultProps = {
@@ -65,6 +71,7 @@ IconMap.defaultProps = {
   getPosition: d => d.geometry.coordinates,
   getSize: d => 10,
   getColor: d => [0,0,0],
+  visible: true,
 };
 
 export default IconMap;

--- a/packages/component-library/src/IconMap/IconMap.test.js
+++ b/packages/component-library/src/IconMap/IconMap.test.js
@@ -19,7 +19,11 @@ describe('IconMap', () => {
     }
   ];
 
-  const defaultProps = { data };
+  const viewport = { zoom: 9.5 };
+
+  const iconSizeScale = zoom => zoom > 9.5 ? 25 : 5;
+
+  const defaultProps = { data, viewport, iconSizeScale };
 
   it('should render a DeckGL component', () => {
     const wrapper = shallow(<IconMap {...defaultProps} />);

--- a/packages/component-library/src/IconMap/IconMap.test.js
+++ b/packages/component-library/src/IconMap/IconMap.test.js
@@ -23,7 +23,11 @@ describe('IconMap', () => {
 
   const iconSizeScale = zoom => zoom > 9.5 ? 25 : 5;
 
-  const defaultProps = { data, viewport, iconSizeScale };
+  const defaultProps = {
+    data,
+    viewport,
+    iconSizeScale,
+  };
 
   it('should render a DeckGL component', () => {
     const wrapper = shallow(<IconMap {...defaultProps} />);

--- a/packages/component-library/src/PathMap/PathMap.js
+++ b/packages/component-library/src/PathMap/PathMap.js
@@ -14,6 +14,7 @@ const PathMap = (props) => {
     autoHighlight,
     highlightColor,
     onLayerClick,
+    visible,
   } = props;
 
   return (
@@ -39,6 +40,7 @@ const PathMap = (props) => {
           onClick={onLayerClick}
           parameters={{depthTest: false}}
           updateTriggers={{instanceColors: getColor}}
+          visible={visible}
         />
       </DeckGL>
     </div>
@@ -57,6 +59,7 @@ PathMap.propTypes = {
   autoHighlight: PropTypes.bool,
   highlightColor: PropTypes.array,
   onLayerClick: PropTypes.func,
+  visible: PropTypes.bool,
 };
 
 PathMap.defaultProps = {
@@ -65,7 +68,9 @@ PathMap.defaultProps = {
   getPath: d => d.geometry.coordinates,
   getWidth: d => 10,
   widthScale: 1,
-  rounded: true,
+  rounded: false,
+  autoHighlight: true,
+  visible: true,
 };
 
 export default PathMap;

--- a/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
+++ b/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
@@ -14,6 +14,7 @@ const ScatterPlotMap = (props) => {
     strokeWidth,
     autoHighlight,
     onLayerClick,
+    visible,
   } = props;
 
   return (
@@ -39,6 +40,8 @@ const ScatterPlotMap = (props) => {
           autoHighlight={autoHighlight}
           onClick={onLayerClick}
           parameters={{depthTest: false}}
+          visible={visible}
+          updateTriggers={{instanceColors: getColor}}
         />
       </DeckGL>
     </div>
@@ -57,6 +60,7 @@ ScatterPlotMap.propTypes = {
   strokeWidth: PropTypes.number,
   autoHighlight: PropTypes.bool,
   onLayerClick: PropTypes.func,
+  visible: PropTypes.bool,
 };
 
 ScatterPlotMap.defaultProps = {
@@ -67,6 +71,7 @@ ScatterPlotMap.defaultProps = {
   radiusScale: 1,
   outline: false,
   strokeWidth: 1,
+  visible: true,
 };
 
 export default ScatterPlotMap;

--- a/packages/component-library/src/ScreenGridMap/ScreenGridMap.js
+++ b/packages/component-library/src/ScreenGridMap/ScreenGridMap.js
@@ -11,6 +11,7 @@ const ScreenGridMap = (props) => {
     cellSizePixels,
     autoHighlight,
     onLayerClick,
+    visible,
   } = props;
 
   return (
@@ -31,6 +32,7 @@ const ScreenGridMap = (props) => {
           autoHighlight={autoHighlight}
           onClick={onLayerClick}
           updateTriggers={{instanceColors: colorRange}}
+          visible={visible}
         />
       </DeckGL>
     </div>
@@ -46,6 +48,7 @@ ScreenGridMap.propTypes = {
   cellSizePixels: PropTypes.number,
   autoHighlight: PropTypes.bool,
   onLayerClick: PropTypes.func,
+  visible: PropTypes.bool,
 };
 
 ScreenGridMap.defaultProps = {
@@ -54,6 +57,7 @@ ScreenGridMap.defaultProps = {
   colorRange: [[255,255,204],[161,218,180],[65,182,196],[34,94,168]],
   cellSizePixels: 25,
   autoHighlight: true,
+  visible: true,
 };
 
 export default ScreenGridMap;

--- a/packages/component-library/stories/IconMap.story.js
+++ b/packages/component-library/stories/IconMap.story.js
@@ -98,6 +98,8 @@ const demoMap = () => {
 
   const autoHighlight = boolean('Auto Highlight:', false);
 
+  const visible = boolean('Visible:', true);
+
   return (
     <BaseMap
       mapboxToken={mapboxToken}
@@ -115,6 +117,7 @@ const demoMap = () => {
         getColor={getColor}
         autoHighlight={autoHighlight}
         onLayerClick={info => action('Layer clicked:', { depth: 2 })(info, info.object)}
+        visible={visible}
       />
     </BaseMap>
   );

--- a/packages/component-library/stories/IconMap.story.js
+++ b/packages/component-library/stories/IconMap.story.js
@@ -66,13 +66,9 @@ const demoMap = () => {
     },
   };
 
-  const zoomScale = zoom => zoom > 15.5 ? 65 :
-    zoom > 14.5 ? 55 :
-    zoom > 13.5 ? 45 :
-    zoom > 12.5 ? 35 :
-    zoom > 11.5 ? 25 :
-    zoom > 10.5 ? 15 :
-    zoom > 9.5 ? 10 :
+  const zoomScale = zoom => zoom > 11.5 ? 12.5 :
+    zoom > 10.5 ? 10 :
+    zoom > 9.5 ? 7.5 :
     zoom > 8.5 ? 5 :
     zoom > 7.5 ? 2.5 :
     1;
@@ -84,10 +80,10 @@ const demoMap = () => {
   const iconSizeOptions = {
      range: true,
      min: 1,
-     max: 10,
+     max: 15,
      step: 1,
   };
-  const iconSize = number('Icon Size:', 5, iconSizeOptions);
+  const iconSize = number('Icon Size:', 10, iconSizeOptions);
 
   const getSize = f => iconSize;
 

--- a/packages/component-library/stories/IconMap.story.js
+++ b/packages/component-library/stories/IconMap.story.js
@@ -66,28 +66,30 @@ const demoMap = () => {
     },
   };
 
-  const iconSizeScaleOptions = {
-     range: true,
-     min: 0.5,
-     max: 10,
-     step: 0.5,
-  };
-  const iconSizeScale = number('Icon Size Scale:', 1, iconSizeScaleOptions);
+  const zoomScale = zoom => zoom > 15.5 ? 65 :
+    zoom > 14.5 ? 55 :
+    zoom > 13.5 ? 45 :
+    zoom > 12.5 ? 35 :
+    zoom > 11.5 ? 25 :
+    zoom > 10.5 ? 15 :
+    zoom > 9.5 ? 10 :
+    zoom > 8.5 ? 5 :
+    zoom > 7.5 ? 2.5 :
+    1;
 
   const getPosition = d => d.geometry.coordinates;
 
   const getIcon = d => d.properties.ICON;
 
-  const getSize = zoom => zoom > 15.5 ? 300 :
-    zoom > 14.5 ? 250 :
-    zoom > 13.5 ? 200 :
-    zoom > 12.5 ? 150 :
-    zoom > 11.5 ? 125 :
-    zoom > 10.5 ? 100 :
-    zoom > 9.5 ? 75 :
-    zoom > 8.5 ? 50 :
-    zoom > 7.5 ? 25 :
-    10;
+  const iconSizeOptions = {
+     range: true,
+     min: 1,
+     max: 15,
+     step: 1,
+  };
+  const iconSize = number('Icon Size:', 5, iconSizeOptions);
+
+  const getSize = f => iconSize;
 
   const getColor = d => d.properties.ICON === 'Hospital' ? [30,144,255] :
     d.properties.ICON === 'School' ? [255,165,0] :
@@ -106,7 +108,7 @@ const demoMap = () => {
         opacity={opacity}
         iconAtlas={iconAtlas}
         iconMapping={iconMapping}
-        iconSizeScale={iconSizeScale}
+        iconSizeScale={zoomScale}
         getPosition={getPosition}
         getIcon={getIcon}
         getSize={getSize}

--- a/packages/component-library/stories/IconMap.story.js
+++ b/packages/component-library/stories/IconMap.story.js
@@ -84,7 +84,7 @@ const demoMap = () => {
   const iconSizeOptions = {
      range: true,
      min: 1,
-     max: 15,
+     max: 10,
      step: 1,
   };
   const iconSize = number('Icon Size:', 5, iconSizeOptions);

--- a/packages/component-library/stories/IconMap.story.js
+++ b/packages/component-library/stories/IconMap.story.js
@@ -68,9 +68,9 @@ const demoMap = () => {
 
   const iconSizeScaleOptions = {
      range: true,
-     min: 1,
-     max: 15,
-     step: 1,
+     min: 0.5,
+     max: 10,
+     step: 0.5,
   };
   const iconSizeScale = number('Icon Size Scale:', 1, iconSizeScaleOptions);
 
@@ -78,7 +78,16 @@ const demoMap = () => {
 
   const getIcon = d => d.properties.ICON;
 
-  const getSize = d => 100;
+  const getSize = zoom => zoom > 15.5 ? 300 :
+    zoom > 14.5 ? 250 :
+    zoom > 13.5 ? 200 :
+    zoom > 12.5 ? 150 :
+    zoom > 11.5 ? 125 :
+    zoom > 10.5 ? 100 :
+    zoom > 9.5 ? 75 :
+    zoom > 8.5 ? 50 :
+    zoom > 7.5 ? 25 :
+    10;
 
   const getColor = d => d.properties.ICON === 'Hospital' ? [30,144,255] :
     d.properties.ICON === 'School' ? [255,165,0] :

--- a/packages/component-library/stories/PathMap.story.js
+++ b/packages/component-library/stories/PathMap.story.js
@@ -70,6 +70,8 @@ const demoMap = () => {
 
   const highlightColor = [125,125,125,125];
 
+  const visible = boolean('Visible:', true);
+
   return (
     <BaseMap
       mapboxToken={mapboxToken}
@@ -89,6 +91,7 @@ const demoMap = () => {
         autoHighlight={autoHighlight}
         highlightColor={highlightColor}
         onLayerClick={info => action('Layer clicked:', { depth: 2 })(info, info.object)}
+        visible={visible}
       />
     </BaseMap>
   );

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -60,6 +60,8 @@ const demoMap = () => {
 
   const autoHighlight = boolean('Auto Highlight:', false);
 
+  const visible = boolean('Visible:', true);
+
   return (
     <BaseMap
       mapboxToken={mapboxToken}
@@ -76,6 +78,7 @@ const demoMap = () => {
         strokeWidth={strokeWidth}
         autoHighlight={autoHighlight}
         onLayerClick={info => action('Layer clicked:', { depth: 2 })(info, info.object)}
+        visible={visible}
       />
     </BaseMap>
   );

--- a/packages/component-library/stories/ScreenGridMap.story.js
+++ b/packages/component-library/stories/ScreenGridMap.story.js
@@ -53,6 +53,8 @@ const demoMap = () => {
 
   const autoHighlight = boolean('Auto Highlight:', false);
 
+  const visible = boolean('Visible:', true);
+
   return (
     <BaseMap
       mapboxToken={mapboxToken}
@@ -66,6 +68,7 @@ const demoMap = () => {
         cellSizePixels={cellSize}
         autoHighlight={autoHighlight}
         onLayerClick={info => action('Layer clicked:', { depth: 2 })(info, info.object)}
+        visible={visible}
       />
     </BaseMap>
   );


### PR DESCRIPTION
Currently the icons on the IconMap stay the same size when you zoom in or out. This changes that so icons get smaller when you zoom out and bigger as you zoom in. It also adds visibility props. And I updated the unit tests.