### PR TITLE
Remove filson and others

### DIFF
--- a/packages/2017/src/components/RootPage.js
+++ b/packages/2017/src/components/RootPage.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import Typekit from 'react-typekit';
 import { Header } from '@hackoregon/component-library';
 
 const isRoot = ({ pathname }) => pathname === '/';
 
 export const RootPage = props => (
   <div>
-    <Typekit kitId="mbf2sam" />
     <Header title="Civic" overlay={isRoot(props.location)} />
     {props.children}
   </div>

--- a/packages/2018/src/components/RootPage.js
+++ b/packages/2018/src/components/RootPage.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import Typekit from 'react-typekit';
 import { Header } from '@hackoregon/component-library';
 
 const menu = [
@@ -26,7 +25,6 @@ const isRoot = ({ pathname }) => pathname === '/';
 
 export const RootPage = props => (
   <div>
-    <Typekit kitId="mbf2sam" />
     <Header title="Civic" menu={menu} />
     {props.children}
   </div>

--- a/packages/component-library/assets/global.styles.css
+++ b/packages/component-library/assets/global.styles.css
@@ -140,7 +140,7 @@ h1,
   font-size: 2.25rem;
   line-height: 2.625rem;
   font-family: "Rubik", sans-serif;
-  font-weight: 900;
+  font-weight: 500;
 }
 h2,
 .h2 {
@@ -156,7 +156,7 @@ h3,
   font-size: 1.125rem;
   line-height: 1.625rem;
   font-family: "Rubik", sans-serif;
-  font-weight: 900;
+  font-weight: 500;
 }
 h4,
 .h4 {
@@ -164,7 +164,7 @@ h4,
   font-size: 1rem;
   line-height: 1.375rem;
   font-family: "Rubik", sans-serif;
-  font-weight: 900;
+  font-weight: 500;
 }
 h5,
 .h5 {
@@ -172,7 +172,7 @@ h5,
   font-size: 0.875rem;
   line-height: 1.125rem;
   font-family: "Rubik", sans-serif;
-  font-weight: 900;
+  font-weight: 500;
 }
 h6,
 .h6 {
@@ -180,7 +180,7 @@ h6,
   font-size: 0.75rem;
   line-height: 0.9375rem;
   font-family: "Rubik", sans-serif;
-  font-weight: 900;
+  font-weight: 500;
 }
 
 p {

--- a/packages/component-library/assets/global.styles.css
+++ b/packages/component-library/assets/global.styles.css
@@ -1,16 +1,10 @@
-/* Import Google Fonts */
-
-@import 'https://fonts.googleapis.com/css?family=Lato:300,400|Raleway:300,400|Open+Sans:300,400,600,800';
-
-@import url('https://fonts.googleapis.com/css?family=Merriweather:300,300i,400,400i,700,700i,900,900i');
-
 /* Base */
 
 html {
   font-size: 14px;
   line-height: 1.4;
   background-color: #fffefe;
-  font-family: 'Open Sans';
+  font-family: 'Merriweather';
   font-weight: 400;
   color: #001732;
   min-height: 100% /* [3] */;
@@ -39,24 +33,6 @@ html {
 
 .text-underline {
   text-decoration: underline;
-}
-
-.FilsonSoft {
-  font-family: "filson-soft", sans-serif;
-}
-
-.Lato, .panel {
-  font-family: "Lato", sans-serif;
-}
-.Raleway {
-  font-family: "Raleway", sans-serif;
-}
-.OpenSans {
-  font-family: "Open Sans", sans-serif;
-}
-
-.Merriweather {
-  font-family: "Merriweather", serif;
 }
 
 body {
@@ -153,8 +129,8 @@ a:hover {
 .Title {
   font-size: 50px;
   line-height: 1.2;
-  font-weight: 500;
-  font-family: "filson-soft", sans-serif;
+  font-weight: 300;
+  font-family: "Rubik", sans-serif;
   margin-bottom: 12px;
 }
 
@@ -163,7 +139,7 @@ h1,
   font-size: 36px;
   font-size: 2.25rem;
   line-height: 2.625rem;
-  font-family: "filson-soft", sans-serif;
+  font-family: "Rubik", sans-serif;
   font-weight: 900;
 }
 h2,
@@ -171,7 +147,7 @@ h2,
   font-size: 26px;
   font-size: 1.625rem;
   line-height: 2.125rem;
-  font-family: "filson-soft", sans-serif;
+  font-family: "Rubik", sans-serif;
   font-weight: 500;
 }
 h3,
@@ -179,7 +155,7 @@ h3,
   font-size: 18px;
   font-size: 1.125rem;
   line-height: 1.625rem;
-  font-family: "filson-soft", sans-serif;
+  font-family: "Rubik", sans-serif;
   font-weight: 900;
 }
 h4,
@@ -187,7 +163,7 @@ h4,
   font-size: 16px;
   font-size: 1rem;
   line-height: 1.375rem;
-  font-family: "filson-soft", sans-serif;
+  font-family: "Rubik", sans-serif;
   font-weight: 900;
 }
 h5,
@@ -195,7 +171,7 @@ h5,
   font-size: 14px;
   font-size: 0.875rem;
   line-height: 1.125rem;
-  font-family: "filson-soft", sans-serif;
+  font-family: "Rubik", sans-serif;
   font-weight: 900;
 }
 h6,
@@ -203,18 +179,16 @@ h6,
   font-size: 12px;
   font-size: 0.75rem;
   line-height: 0.9375rem;
-  font-family: "filson-soft", sans-serif;
+  font-family: "Rubik", sans-serif;
   font-weight: 900;
 }
 
 p {
-  font-family: "Merriweather", serif;
   font-size: 1em;
   color: #706371;
 }
 
 .Pullquote {
-  font-family: "Merriweather", serif;
   font-size: 40px;
 }
 

--- a/packages/component-library/src/ChartContainer/ChartContainer.js
+++ b/packages/component-library/src/ChartContainer/ChartContainer.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { css } from 'emotion';
 
 const titleStyle = css`
-  font-family: 'filson-soft', sans-serif;
   font-size: 40px;
   font-weight: 500;
   text-align: center;
@@ -11,7 +10,6 @@ const titleStyle = css`
 
 const subtitleStyle = css`
   display: block;
-  font-family: 'filson-soft', sans-serif;
   font-size: 18px;
   text-align: center;
 `;

--- a/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
@@ -17,7 +17,7 @@ const descriptionClass = css`
 
 const CivicStoryCard = ({ cardId, collectionId, title, children }) => (
   <div className={cardClass}>
-    { title ? <h2 className={'Title FilsonSoft'}>{title}</h2> : null}
+    { title ? <h2 className="Title">{title}</h2> : null}
     <div className={descriptionClass}>
       {children}
     </div>

--- a/packages/component-library/src/CivicStoryCard/CivicStoryCard.test.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryCard.test.js
@@ -19,7 +19,6 @@ describe('CivicStoryCard', () => {
 
       expect(h2.text()).to.contain(title);
       expect(h2.props().className).to.contain('Title');
-      expect(h2.props().className).to.contain('FilsonSoft');
     });
 
     it('should include a StoryFooter that references this CivicStoryCard', () => {

--- a/packages/component-library/src/StoryCard/StoryCard.js
+++ b/packages/component-library/src/StoryCard/StoryCard.js
@@ -16,7 +16,7 @@ const descriptionClass = css`
 
 const StoryCard = ({ cardId, collectionId, title, children }) => (
   <div className={cardClass}>
-    <h2 className={'Title FilsonSoft'}>{title}</h2>
+    <h2 className="Title">{title}</h2>
     <div className={descriptionClass}>
       {children}
     </div>

--- a/packages/component-library/src/StoryCard/StoryCard.test.js
+++ b/packages/component-library/src/StoryCard/StoryCard.test.js
@@ -19,7 +19,6 @@ describe('StoryCard', () => {
 
       expect(h2.text()).to.contain(title);
       expect(h2.props().className).to.contain('Title');
-      expect(h2.props().className).to.contain('FilsonSoft');
     });
 
     it('should include a StoryFooter that references this StoryCard', () => {


### PR DESCRIPTION
Typefaces on the chopping block:

  1. FilsonSoft
  2. Lato
  3. OpenSans

FilsonSoft is what we were using for titles, namely StoryCard titles. It has to go due to it requiring a TypeKit account.

Lato was only used in `.panel` elements and OpenSans was never really used. They are being removed because we don't need them. Merriweather is our body typeface and Rubik is our titles typeface.

This brings the font count down from six to three.

Closes #175 