### PR TITLE
Axis labels, tooltips, styling/layout fixes for BarChart, HorizontalBarChart, Scatterplot, LineChart

### DIFF
--- a/packages/component-library/es/StoryCard/StoryCard.js
+++ b/packages/component-library/es/StoryCard/StoryCard.js
@@ -22,7 +22,7 @@ var StoryCard = function StoryCard(_ref) {
     { className: cardClass },
     React.createElement(
       'h2',
-      { className: 'Title FilsonSoft' },
+      { className: 'Title' },
       title
     ),
     React.createElement(

--- a/packages/component-library/es/StoryCard/StoryCard.test.js
+++ b/packages/component-library/es/StoryCard/StoryCard.test.js
@@ -21,7 +21,6 @@ describe('StoryCard', function () {
 
       expect(h2.text()).to.contain(title);
       expect(h2.props().className).to.contain('Title');
-      expect(h2.props().className).to.contain('FilsonSoft');
     });
 
     it('should include a StoryFooter that references this StoryCard', function () {

--- a/packages/component-library/es/index.js
+++ b/packages/component-library/es/index.js
@@ -31,8 +31,10 @@ export { default as CivicVictoryTheme } from "./VictoryTheme/VictoryThemeIndex";
 export { default as CollectionHero } from './Hero/CollectionHero';
 export { default as BaseMap } from './BaseMap/BaseMap';
 export { default as ScatterPlotMap } from './ScatterPlotMap/ScatterPlotMap';
+export { default as PullQuote } from './PullQuote/PullQuote';
 export { default as ScreenGridMap } from './ScreenGridMap/ScreenGridMap';
 export { default as PathMap } from './PathMap/PathMap';
 export { default as IconMap } from './IconMap/IconMap';
+export { default as BoundaryMap } from './BoundaryMap/BoundaryMap';
 
 import './fonts.css';

--- a/packages/component-library/src/BarChart/BarChart.js
+++ b/packages/component-library/src/BarChart/BarChart.js
@@ -79,6 +79,7 @@ BarChart.propTypes = {
   dataKey: PropTypes.string.isRequired,
   dataValue: PropTypes.string.isRequired,
   dataKeyLabel: PropTypes.string,
+  domain: PropTypes.objectOf(PropTypes.array),  
   title: PropTypes.string,
   subtitle: PropTypes.string,
   xLabel: PropTypes.string,

--- a/packages/component-library/src/BarChart/BarChart.js
+++ b/packages/component-library/src/BarChart/BarChart.js
@@ -5,6 +5,8 @@ import {
   VictoryAxis,
   VictoryBar,
   VictoryChart,
+  VictoryLabel,
+  VictoryPortal
 } from 'victory';
 
 import ChartContainer from '../ChartContainer';
@@ -13,32 +15,64 @@ import { assign } from "lodash";
 import { css } from 'emotion';
 import CivicVictoryTheme from '../VictoryTheme/VictoryThemeIndex';
 
-const BarChart = ({ data, dataKey, dataValue, dataKeyLabel, title, subtitle }) =>
-  <ChartContainer title={title} subtitle={subtitle}>
-    <VictoryChart
-      padding={{ left: 75, right: 50, bottom: 50, top: 50 }}
-      domainPadding={20}
-      animate={{ duration: 300 }}
-      theme={CivicVictoryTheme.civic}
-    >
-      <VictoryAxis
-        // tickValues specifies both the number of ticks and where
-        // they are placed on the axis
-        tickValues={data.map(a => a[dataKey])}
-        tickFormat={data.map(a => a[dataKeyLabel])}
-      />
-      <VictoryAxis
-        dependentAxis
-        // tickFormat specifies how ticks should be displayed
-        tickFormat={x => dollars(numeric(x))}
-      />
-      <VictoryBar
-        data={data.map(a => ({ dataKey: a[dataKey], dataValue: a[dataValue] }))}
-        x={'dataKey'}
-        y={'dataValue'}
-      />
-    </VictoryChart>
-  </ChartContainer>;
+const BarChart = ({ data, dataKey, dataValue, dataKeyLabel, domain, title, subtitle, xLabel, yLabel }) => {
+
+  const axisLabelStyle = {
+    fontFamily: "'Roboto Condensed', 'Helvetica Neue', Helvetica, sans-serif",
+    fontSize: '14px',
+    fontWeight: 'bold',
+  };
+
+  return (
+    <ChartContainer title={title} subtitle={subtitle}>
+      <VictoryChart
+        padding={{ left: 75, right: 50, bottom: 50, top: 50 }}
+        domainPadding={20}
+        animate={{ duration: 300 }}
+        theme={CivicVictoryTheme.civic}
+      >
+        <VictoryAxis
+          // tickValues specifies both the number of ticks and where
+          // they are placed on the axis
+          tickValues={data.map(a => a[dataKey])}
+          tickFormat={data.map(a => a[dataKeyLabel])}
+        />
+        <VictoryAxis
+          dependentAxis
+          // tickFormat specifies how ticks should be displayed
+          tickFormat={x => dollars(numeric(x))}
+        />
+        <VictoryPortal>
+          <VictoryLabel
+            style={axisLabelStyle}
+            text={yLabel}
+            textAnchor="middle"
+            title="Y Axis Label"
+            verticalAnchor="end"
+            x={50}
+            y={45}
+          />
+        </VictoryPortal>
+        <VictoryPortal>
+          <VictoryLabel
+            style={axisLabelStyle}
+            text={xLabel}
+            textAnchor="end"
+            title="X Axis Label"
+            verticalAnchor="end"
+            x={600}
+            y={295}
+          />
+        </VictoryPortal>
+        <VictoryBar
+          data={data.map(a => ({ dataKey: a[dataKey], dataValue: a[dataValue] }))}
+          x={'dataKey'}
+          y={'dataValue'}
+        />
+      </VictoryChart>
+    </ChartContainer>
+  );
+};
 
 BarChart.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -47,6 +81,8 @@ BarChart.propTypes = {
   dataKeyLabel: PropTypes.string,
   title: PropTypes.string,
   subtitle: PropTypes.string,
+  xLabel: PropTypes.string,
+  yLabel: PropTypes.string
 };
 
 export default BarChart;

--- a/packages/component-library/src/BarChart/BarChart.js
+++ b/packages/component-library/src/BarChart/BarChart.js
@@ -6,7 +6,8 @@ import {
   VictoryBar,
   VictoryChart,
   VictoryLabel,
-  VictoryPortal
+  VictoryPortal,
+  VictoryTooltip
 } from 'victory';
 
 import ChartContainer from '../ChartContainer';
@@ -14,6 +15,36 @@ import { dollars, numeric } from '../utils/formatters';
 import { assign } from "lodash";
 import { css } from 'emotion';
 import CivicVictoryTheme from '../VictoryTheme/VictoryThemeIndex';
+
+const chartEvents = [
+  {
+    target: 'data',
+    eventHandlers: {
+      onMouseOver: () => {
+        return [
+          {
+            target: 'data',
+            mutation: () => ({ style: { fill: 'tomato', width: 40 } }),
+          }, {
+            target: 'labels',
+            mutation: () => ({ active: true }),
+          },
+        ];
+      },
+      onMouseOut: () => {
+        return [
+          {
+            target: 'data',
+            mutation: () => { },
+          }, {
+            target: 'labels',
+            mutation: () => ({ active: false }),
+          },
+        ];
+      },
+    },
+  },
+];
 
 const BarChart = ({ data, dataKey, dataValue, dataKeyLabel, domain, title, subtitle, xLabel, yLabel }) => {
 
@@ -65,7 +96,17 @@ const BarChart = ({ data, dataKey, dataValue, dataKeyLabel, domain, title, subti
           />
         </VictoryPortal>
         <VictoryBar
-          data={data.map(a => ({ dataKey: a[dataKey], dataValue: a[dataValue] }))}
+          labelComponent={
+            <VictoryTooltip
+              x={325}
+              y={0}
+              orientation="bottom"
+              pointerLength={0}
+              cornerRadius={0}
+            />
+          }
+          data={data.map(d => ({ dataKey: d[dataKey], dataValue: d[dataValue], label: `${d[dataKeyLabel]}: ${numeric(d[dataValue])}` }))}
+          events={chartEvents}
           x={'dataKey'}
           y={'dataValue'}
         />

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
@@ -103,7 +103,7 @@ const HorizontalBarChart = ({ data, dataKey, dataValue, dataKeyLabel, domain, ti
               cornerRadius={0}
             />
           }
-          data={data.map(a => ({ dataKey: a[dataKey], dataValue: a[dataValue], label: `${a[dataKeyLabel]}: ${numeric(a[dataValue])}` }))}
+          data={data.map(d => ({ dataKey: d[dataKey], dataValue: d[dataValue], label: `${d[dataKeyLabel]}: ${numeric(d[dataValue])}` }))}
           x="dataKey"
           y="dataValue"
           events={chartEvents}

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
@@ -4,6 +4,8 @@ import {
   VictoryAxis,
   VictoryBar,
   VictoryChart,
+  VictoryLabel,
+  VictoryPortal,
   VictoryTooltip,
 } from 'victory';
 
@@ -41,51 +43,86 @@ const chartEvents = [
   },
 ];
 
-const HorizontalBarChart = ({ data, dataKey, dataValue, dataKeyLabel, title, subtitle }) =>
-  <ChartContainer title={title} subtitle={subtitle}>
-    <VictoryChart
-      padding={{ left: 115, right: 50, bottom: 50, top: 50 }}
-      domainPadding={20}
-      animate={{ duration: 300 }}
-      theme={CivicVictoryTheme.civic}
-    >
-      <VictoryAxis
-        dependentAxis
-        // tickValues specifies both the number of ticks and where
-        // they are placed on the axis
-        tickValues={data.map(a => a[dataKey])}
-        tickFormat={data.map(a => a[dataKeyLabel])}
-      />
-      <VictoryAxis
-        // tickFormat specifies how ticks should be displayed
-        tickFormat={x => dollars(numeric(x))}
-      />
-      <VictoryBar
-        horizontal
-        labelComponent={
-          <VictoryTooltip
-            x={325}
-            y={0}
-            orientation="bottom"
-            pointerLength={0}
-            cornerRadius={0}
+const HorizontalBarChart = ({ data, dataKey, dataValue, dataKeyLabel, domain, title, subtitle, xLabel, yLabel }) => {
+
+  const axisLabelStyle = {
+    fontFamily: "'Roboto Condensed', 'Helvetica Neue', Helvetica, sans-serif",
+    fontSize: '14px',
+    fontWeight: 'bold',
+  };
+
+  return (
+    <ChartContainer title={title} subtitle={subtitle}>
+      <VictoryChart
+        padding={{ left: 115, right: 50, bottom: 50, top: 50 }}
+        domainPadding={20}
+        animate={{ duration: 300 }}
+        theme={CivicVictoryTheme.civic}
+      >
+        <VictoryAxis
+          dependentAxis
+          // tickValues specifies both the number of ticks and where
+          // they are placed on the axis
+          tickValues={data.map(a => a[dataKey])}
+          tickFormat={data.map(a => a[dataKeyLabel])}
+        />
+        <VictoryAxis
+          // tickFormat specifies how ticks should be displayed
+          tickFormat={x => dollars(numeric(x))}
+        />
+        <VictoryPortal>
+          <VictoryLabel
+            style={axisLabelStyle}
+            text={yLabel}
+            textAnchor="middle"
+            title="Y Axis Label"
+            verticalAnchor="end"
+            x={50}
+            y={45}
           />
-        }
-        data={data.map(a => ({ dataKey: a[dataKey], dataValue: a[dataValue], label: `${a[dataKeyLabel]}: ${numeric(a[dataValue])}` }))}
-        x="dataKey"
-        y="dataValue"
-        events={chartEvents}
-      />
-    </VictoryChart>
-  </ChartContainer>;
+        </VictoryPortal>
+        <VictoryPortal>
+          <VictoryLabel
+            style={axisLabelStyle}
+            text={xLabel}
+            textAnchor="end"
+            title="X Axis Label"
+            verticalAnchor="end"
+            x={600}
+            y={295}
+          />
+        </VictoryPortal>
+        <VictoryBar
+          horizontal
+          labelComponent={
+            <VictoryTooltip
+              x={325}
+              y={0}
+              orientation="bottom"
+              pointerLength={0}
+              cornerRadius={0}
+            />
+          }
+          data={data.map(a => ({ dataKey: a[dataKey], dataValue: a[dataValue], label: `${a[dataKeyLabel]}: ${numeric(a[dataValue])}` }))}
+          x="dataKey"
+          y="dataValue"
+          events={chartEvents}
+        />
+      </VictoryChart>
+    </ChartContainer>
+  );
+};
 
 HorizontalBarChart.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
   dataKey: PropTypes.string.isRequired,
   dataValue: PropTypes.string.isRequired,
   dataKeyLabel: PropTypes.string,
+  domain: PropTypes.objectOf(PropTypes.array),  
   title: PropTypes.string,
   subtitle: PropTypes.string,
+  xLabel: PropTypes.string,
+  yLabel: PropTypes.string
 };
 
 export default HorizontalBarChart;

--- a/packages/component-library/src/LineChart/LineChart.js
+++ b/packages/component-library/src/LineChart/LineChart.js
@@ -6,12 +6,43 @@ import {
   VictoryLine,
   VictoryAxis,
   VictoryPortal,
-  VictoryLabel
+  VictoryLabel,
+  VictoryTooltip
 } from 'victory';
 
 import ChartContainer from '../ChartContainer';
-import { numeric } from '../utils/formatters';
+import { dollars, numeric } from '../utils/formatters';
 import CivicVictoryTheme from '../VictoryTheme/VictoryThemeIndex';
+
+const chartEvents = [
+  {
+    target: 'data',
+    eventHandlers: {
+      onMouseOver: () => {
+        return [
+          {
+            target: 'data',
+            mutation: () => ({ style: { fill: 'tomato', width: 40 } }),
+          }, {
+            target: 'labels',
+            mutation: () => ({ active: true }),
+          },
+        ];
+      },
+      onMouseOut: () => {
+        return [
+          {
+            target: 'data',
+            mutation: () => { },
+          }, {
+            target: 'labels',
+            mutation: () => ({ active: false }),
+          },
+        ];
+      },
+    },
+  },
+];
 
 const LineChart = ({
   title,
@@ -77,7 +108,17 @@ const LineChart = ({
           y="dataValue"
         />
         <VictoryScatter
-          data={data.map(d => ({ dataKey: d[dataKey], dataValue: d[dataValue] }))}
+          data={data.map(d => ({ dataKey: d[dataKey], dataValue: d[dataValue], label: `${d[dataKeyLabel]}: ${numeric(d[dataValue])}` }))}
+          events={chartEvents}
+          labelComponent={
+            <VictoryTooltip
+              x={325}
+              y={0}
+              orientation="bottom"
+              pointerLength={0}
+              cornerRadius={0}
+            />
+          }
           x="dataKey"
           y="dataValue"
         />

--- a/packages/component-library/src/LineChart/LineChart.js
+++ b/packages/component-library/src/LineChart/LineChart.js
@@ -5,6 +5,8 @@ import {
   VictoryChart,
   VictoryLine,
   VictoryAxis,
+  VictoryPortal,
+  VictoryLabel
 } from 'victory';
 
 import ChartContainer from '../ChartContainer';
@@ -15,50 +17,85 @@ const LineChart = ({
   title,
   subtitle,
   data,
+  domain,
   xLabel,
+  yLabel,
   dataKey,
   dataValue,
   dataKeyLabel,
-}) => (
-  <ChartContainer title={title} subtitle={subtitle}>
-    <VictoryChart
-      padding={{ left: 75, right: 50, bottom: 50, top: 50 }}
-      domainPadding={20}
-      animate={{ duration: 300 }}
-      theme={CivicVictoryTheme.civic}
-    >
-      <VictoryAxis
-        label={xLabel}
-        tickValues={data.map(d => d[dataKey])}
-        tickFormat={data.map(d => d[dataKeyLabel])}
-      />
-      <VictoryAxis
-        dependentAxis
-        tickValues={data.map(d => d[dataValue])}
-        tickFormat={data.map(d => numeric(d[dataValue]))}
-      />
-      <VictoryLine
-        data={data.map(d => ({ dataKey: d[dataKey], dataValue: d[dataValue] }))}
-        x="dataKey"
-        y="dataValue"
-      />
-      <VictoryScatter
-        data={data.map(d => ({ dataKey: d[dataKey], dataValue: d[dataValue] }))}
-        x="dataKey"
-        y="dataValue"
-      />
-    </VictoryChart>
-  </ChartContainer>
-);
+}) => {
+
+  const axisLabelStyle = {
+    fontFamily: "'Roboto Condensed', 'Helvetica Neue', Helvetica, sans-serif",
+    fontSize: '14px',
+    fontWeight: 'bold',
+  };
+  
+  return (
+    <ChartContainer title={title} subtitle={subtitle}>
+      <VictoryChart
+        padding={{ left: 75, right: 50, bottom: 50, top: 50 }}
+        domainPadding={20}
+        animate={{ duration: 300 }}
+        theme={CivicVictoryTheme.civic}
+      >
+        <VictoryAxis
+          label={xLabel}
+          tickValues={data.map(d => d[dataKey])}
+          tickFormat={data.map(d => d[dataKeyLabel])}
+        />
+        <VictoryAxis
+          dependentAxis
+          tickValues={data.map(d => d[dataValue])}
+          tickFormat={data.map(d => numeric(d[dataValue]))}
+        />
+        <VictoryPortal>
+          <VictoryLabel
+            style={axisLabelStyle}
+            text={yLabel}
+            textAnchor="middle"
+            title="Y Axis Label"
+            verticalAnchor="end"
+            x={50}
+            y={45}
+          />
+        </VictoryPortal>
+        <VictoryPortal>
+          <VictoryLabel
+            style={axisLabelStyle}
+            text={xLabel}
+            textAnchor="end"
+            title="X Axis Label"
+            verticalAnchor="end"
+            x={600}
+            y={295}
+          />
+        </VictoryPortal>
+        <VictoryLine
+          data={data.map(d => ({ dataKey: d[dataKey], dataValue: d[dataValue] }))}
+          x="dataKey"
+          y="dataValue"
+        />
+        <VictoryScatter
+          data={data.map(d => ({ dataKey: d[dataKey], dataValue: d[dataValue] }))}
+          x="dataKey"
+          y="dataValue"
+        />
+      </VictoryChart>
+    </ChartContainer>
+  );
+};
 
 LineChart.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
   xLabel: PropTypes.string,
+  yLabel: PropTypes.string,
   title: PropTypes.string,
   subtitle: PropTypes.string,
   dataKey: PropTypes.string.isRequired,
   dataValue: PropTypes.string.isRequired,
   dataKeyLabel: PropTypes.string,
+  domain: PropTypes.objectOf(PropTypes.array),
 };
 
 LineChart.defaultProps = {

--- a/packages/component-library/src/Scatterplot/Scatterplot.js
+++ b/packages/component-library/src/Scatterplot/Scatterplot.js
@@ -9,6 +9,7 @@ import {
   VictoryTooltip
 } from 'victory';
 
+import ChartContainer from '../ChartContainer';
 import { dollars, numeric } from '../utils/formatters';
 import CivicVictoryTheme from '../VictoryTheme/VictoryThemeIndex';
 
@@ -48,7 +49,7 @@ const SimpleLegend = ({ legendData }) => {
     font-size: 14px;
     font-weight: bold;
     text-align: center;
-    margin: 10px 0 -40px 0;
+    margin: 10px 0 0 0;
   `;
 
   if (legendData.length) {
@@ -119,6 +120,7 @@ const getDefaultStyle = dataSeries => {
  * @param  {String}    dataKey      X key in `data`
  * @param  {Array}     dataKeyLabel Optional overrides for x-axis tick labels
  * @param  {String}    dataValue    Y key in `data`
+ * @param  {Array}     dataValueLabel Optional overrides for y-axis tick labels
  * @param  {Array}     dataSeries   Series options for multiseries data
  * @param  {Object}    domain       Scaling for chart axes (defaults to data range)
  * @param  {Object}    size         Data `key` or exact `value` to use for data point size
@@ -133,6 +135,7 @@ const Scatterplot = ({
   dataKey,
   dataKeyLabel,
   dataValue,
+  dataValueLabel,
   dataSeries,
   domain,
   size,
@@ -174,9 +177,7 @@ const Scatterplot = ({
   `;
 
   return (
-    <div>
-      {title && <span className={titleStyle}>{title}</span>}
-      {subtitle && <span className={subtitleStyle}>{subtitle}</span>}
+    <ChartContainer title={title} subtitle={subtitle}>
       {legendData && (
         <SimpleLegend className="legend" legendData={legendData} />
       )}
@@ -231,7 +232,7 @@ const Scatterplot = ({
           data={data.map(d => ({
             dataKey: d[dataKey],
             dataValue: d[dataValue],
-            label: `${d[dataKeyLabel]}: ${numeric(d[dataValue])}`,
+            label: `${dataKeyLabel ? d[dataKeyLabel] : xLabel}: ${numeric(d[dataKey])} | ${dataValueLabel ? d[dataValueLabel] : yLabel}: ${numeric(d[dataValue])}`,
             series: d.series,
             size: size ? d[size.key] || size.value : 3,
           }))}
@@ -252,7 +253,7 @@ const Scatterplot = ({
           y="dataValue"
         />
       </VictoryChart>
-    </div>
+    </ChartContainer>
   );
 };
 
@@ -263,6 +264,7 @@ Scatterplot.propTypes = {
   dataKey: PropTypes.string,
   dataKeyLabel: PropTypes.arrayOf(PropTypes.string),
   dataValue: PropTypes.string,
+  dataValueLabel: PropTypes.arrayOf(PropTypes.string),
   dataSeries: PropTypes.arrayOf(PropTypes.string),
   domain: PropTypes.objectOf(PropTypes.array),
   size: PropTypes.shape({ key: PropTypes.string, value: PropTypes.string }),
@@ -278,6 +280,7 @@ Scatterplot.defaultProps = {
   dataKey: 'x',
   dataKeyLabel: null,
   dataValue: 'y',
+  dataValueLabel: null,
   dataSeries: null,
   domain: null,
   size: null,

--- a/packages/component-library/src/Scatterplot/Scatterplot.js
+++ b/packages/component-library/src/Scatterplot/Scatterplot.js
@@ -4,6 +4,7 @@ import {
   VictoryAxis,
   VictoryChart,
   VictoryLabel,
+  VictoryPortal,
   VictoryScatter,
 } from 'victory';
 
@@ -170,24 +171,28 @@ const Scatterplot = ({
           }}
           title="Y Axis"
         />
-        <VictoryLabel
-          style={axisLabelStyle}
-          text={yLabel}
-          textAnchor="middle"
-          title="Y Axis Label"
-          verticalAnchor="end"
-          x={50}
-          y={45}
-        />
-        <VictoryLabel
-          style={axisLabelStyle}
-          text={xLabel}
-          textAnchor="end"
-          title="X Axis Label"
-          verticalAnchor="end"
-          x={600}
-          y={295}
-        />
+        <VictoryPortal>
+          <VictoryLabel
+            style={axisLabelStyle}
+            text={yLabel}
+            textAnchor="middle"
+            title="Y Axis Label"
+            verticalAnchor="end"
+            x={50}
+            y={45}
+          />
+        </VictoryPortal>
+        <VictoryPortal>
+          <VictoryLabel
+            style={axisLabelStyle}
+            text={xLabel}
+            textAnchor="end"
+            title="X Axis Label"
+            verticalAnchor="end"
+            x={600}
+            y={295}
+          />
+        </VictoryPortal>
         <VictoryScatter
           animate={{ onEnter: { duration: 500 } }}
           categories={{ x: dataKeyLabel }}

--- a/packages/component-library/src/Scatterplot/Scatterplot.js
+++ b/packages/component-library/src/Scatterplot/Scatterplot.js
@@ -6,9 +6,41 @@ import {
   VictoryLabel,
   VictoryPortal,
   VictoryScatter,
+  VictoryTooltip
 } from 'victory';
 
+import { dollars, numeric } from '../utils/formatters';
 import CivicVictoryTheme from '../VictoryTheme/VictoryThemeIndex';
+
+const chartEvents = [
+  {
+    target: 'data',
+    eventHandlers: {
+      onMouseOver: () => {
+        return [
+          {
+            target: 'data',
+            mutation: () => ({ style: { fill: 'tomato', width: 40 } }),
+          }, {
+            target: 'labels',
+            mutation: () => ({ active: true }),
+          },
+        ];
+      },
+      onMouseOut: () => {
+        return [
+          {
+            target: 'data',
+            mutation: () => { },
+          }, {
+            target: 'labels',
+            mutation: () => ({ active: false }),
+          },
+        ];
+      },
+    },
+  },
+];
 
 const SimpleLegend = ({ legendData }) => {
   const legendStyle = css`
@@ -199,9 +231,20 @@ const Scatterplot = ({
           data={data.map(d => ({
             dataKey: d[dataKey],
             dataValue: d[dataValue],
+            label: `${d[dataKeyLabel]}: ${numeric(d[dataValue])}`,
             series: d.series,
             size: size ? d[size.key] || size.value : 3,
           }))}
+          events={chartEvents}
+          labelComponent={
+            <VictoryTooltip
+              x={325}
+              y={0}
+              orientation="bottom"
+              pointerLength={0}
+              cornerRadius={0}
+            />
+          }
           size={d => d.size}
           style={scatterPlotStyle}
           title="Scatter Plot"

--- a/packages/component-library/src/Scatterplot/Scatterplot.js
+++ b/packages/component-library/src/Scatterplot/Scatterplot.js
@@ -287,8 +287,8 @@ Scatterplot.defaultProps = {
   style: null,
   subtitle: null,
   title: null,
-  xLabel: null,
-  yLabel: null,
+  xLabel: "X",
+  yLabel: "Y",
 };
 
 export default Scatterplot;

--- a/packages/component-library/src/Scatterplot/Scatterplot.test.js
+++ b/packages/component-library/src/Scatterplot/Scatterplot.test.js
@@ -27,10 +27,10 @@ describe('Scatterplot', () => {
     const wrapper = shallow(<Scatterplot data={simpleData} />);
     expect(wrapper.find({ title: 'Scatter Plot' }).length).to.eql(1);
     expect(wrapper.find({ title: 'Scatter Plot' }).props().data).to.eql([
-      { dataKey: 100, dataValue: 1, series: undefined, size: 3 },
-      { dataKey: 200, dataValue: 2, series: undefined, size: 3 },
-      { dataKey: 300, dataValue: 3, series: undefined, size: 3 },
-      { dataKey: 400, dataValue: 4, series: undefined, size: 3 },
+      { dataKey: 100, dataValue: 1, label: "X: 100 | Y: 1", series: undefined, size: 3 },
+      { dataKey: 200, dataValue: 2, label: "X: 200 | Y: 2", series: undefined, size: 3 },
+      { dataKey: 300, dataValue: 3, label: "X: 300 | Y: 3", series: undefined, size: 3 },
+      { dataKey: 400, dataValue: 4, label: "X: 400 | Y: 4", series: undefined, size: 3 },
     ]);
   });
 
@@ -65,10 +65,10 @@ describe('Scatterplot', () => {
     };
     const wrapper = shallow(<Scatterplot {...props} />);
     expect(wrapper.find({ title: 'Scatter Plot' }).props().data).to.eql([
-      { dataKey: 100, dataValue: 1, series: 'first', size: 3 },
-      { dataKey: 200, dataValue: 2, series: 'first', size: 3 },
-      { dataKey: 100, dataValue: 3, series: 'second', size: 3 },
-      { dataKey: 200, dataValue: 3, series: 'second', size: 3 },
+      { dataKey: 100, dataValue: 1, label: "X: 100 | Y: 1", series: 'first', size: 3 },
+      { dataKey: 200, dataValue: 2, label: "X: 200 | Y: 2", series: 'first', size: 3 },
+      { dataKey: 100, dataValue: 3, label: "X: 100 | Y: 3", series: 'second', size: 3 },
+      { dataKey: 200, dataValue: 3, label: "X: 200 | Y: 3", series: 'second', size: 3 },
     ]);
   });
 
@@ -95,19 +95,19 @@ describe('Scatterplot', () => {
     };
     const wrapper = shallow(<Scatterplot {...props} />);
     expect(wrapper.find({ title: 'Scatter Plot' }).props().data).to.eql([
-      { dataKey: 100, dataValue: 1, series: undefined, size: 3 },
-      { dataKey: 200, dataValue: 2, series: undefined, size: 3 },
-      { dataKey: 300, dataValue: 3, series: undefined, size: 3 },
-      { dataKey: 400, dataValue: 4, series: undefined, size: 3 },
+      { dataKey: 100, dataValue: 1, label: "X: 100 | Y: 1", series: undefined, size: 3 },
+      { dataKey: 200, dataValue: 2, label: "X: 200 | Y: 2", series: undefined, size: 3 },
+      { dataKey: 300, dataValue: 3, label: "X: 300 | Y: 3", series: undefined, size: 3 },
+      { dataKey: 400, dataValue: 4, label: "X: 400 | Y: 4", series: undefined, size: 3 },
     ]);
 
     wrapper.setProps({ size: { key: 'y' } });
 
     expect(wrapper.find({ title: 'Scatter Plot' }).props().data).to.eql([
-      { dataKey: 100, dataValue: 1, series: undefined, size: 1 },
-      { dataKey: 200, dataValue: 2, series: undefined, size: 2 },
-      { dataKey: 300, dataValue: 3, series: undefined, size: 3 },
-      { dataKey: 400, dataValue: 4, series: undefined, size: 4 },
+      { dataKey: 100, dataValue: 1, label: "X: 100 | Y: 1", series: undefined, size: 1 },
+      { dataKey: 200, dataValue: 2, label: "X: 200 | Y: 2", series: undefined, size: 2 },
+      { dataKey: 300, dataValue: 3, label: "X: 300 | Y: 3", series: undefined, size: 3 },
+      { dataKey: 400, dataValue: 4, label: "X: 400 | Y: 4", series: undefined, size: 4 },
     ]);
   });
 });

--- a/packages/component-library/stories/BarChart.story.js
+++ b/packages/component-library/stories/BarChart.story.js
@@ -37,6 +37,8 @@ export default () => storiesOf(displayName, module).addDecorator(withKnobs)
         dataKeyLabel={dataKeyLabel}
         title={'Dogs and their Money'}
         subtitle={'As of January 2017'}
+        xLabel={'Dogs'}
+        yLabel={'Dollars'}
       />
     );
   }));

--- a/packages/component-library/stories/BarChart.story.js
+++ b/packages/component-library/stories/BarChart.story.js
@@ -18,7 +18,7 @@ const description = `
 
 export default () => storiesOf(displayName, module).addDecorator(withKnobs)
   .add('Basic Usage', (() => {
-    const data = array('Data', [
+    const data = object('Data', [
       { sortOrder: 1, population: 2000, label: 'Labrador Retriever' },
       { sortOrder: 2, population: 8000, label: 'Standard Poodle' },
       { sortOrder: 3, population: 6000, label: 'French Bulldog' },
@@ -28,6 +28,8 @@ export default () => storiesOf(displayName, module).addDecorator(withKnobs)
     const dataKey = text('Data key', 'sortOrder');
     const dataValue = text('Data values', 'population');
     const dataKeyLabel = text('Data key labels', 'label');
+    const xLabel = text('xLabel', 'Dogs');
+    const yLabel = text('yLabel', 'Dollars');
     
     return (
       <BarChart
@@ -37,8 +39,8 @@ export default () => storiesOf(displayName, module).addDecorator(withKnobs)
         dataKeyLabel={dataKeyLabel}
         title={'Dogs and their Money'}
         subtitle={'As of January 2017'}
-        xLabel={'Dogs'}
-        yLabel={'Dollars'}
+        xLabel={xLabel}
+        yLabel={yLabel}
       />
     );
   }));

--- a/packages/component-library/stories/HorizontalBarChart.story.js
+++ b/packages/component-library/stories/HorizontalBarChart.story.js
@@ -20,7 +20,7 @@ export default () => storiesOf(displayName, module)
   .addDecorator(checkA11y)
   .addDecorator(withKnobs)
   .add('Basic Usage', (() => {
-    const data = array('Data',[
+    const data = object('Data',[
       {sortOrder: 1, population: 2000, label: 'Labrador Retriever'},
       {sortOrder: 2, population: 8000, label: 'Standard Poodle'},
       {sortOrder: 3, population: 6000, label: 'French Bulldog'},
@@ -30,6 +30,9 @@ export default () => storiesOf(displayName, module)
       const dataKey = text('Data key', 'sortOrder');
       const dataValue = text('Data values', 'population');
       const dataKeyLabel = text('Data key labels', 'label');
+      const xLabel = text('xLabel', 'Dollars');
+      const yLabel = text('yLabel', 'Dogs');
+
     return (
       <HorizontalBarChart
         data={data}
@@ -38,6 +41,8 @@ export default () => storiesOf(displayName, module)
         dataKeyLabel={dataKeyLabel}
         title={'Dogs and their Money'}
         subtitle={'As of January 2017'}
+        xLabel={xLabel}
+        yLabel={yLabel}
       />
     );
   }))
@@ -47,5 +52,6 @@ export default () => storiesOf(displayName, module)
     dataKey={dataKey}
     dataValue={dataValue}
     dataKeyLabel={dataKeyLabel}
+    
   />
 )))


### PR DESCRIPTION
#171 

Added x/yLabels as per issue to BarChart, HorizontalBarChart, and LineChart. Also updated stories to use labels w/ knobs.

Note: I have not modified the x/y coordinates for label locations. I kept them same as the scatter.