### PR TITLE
Remove duplicate imports of stories

### DIFF
--- a/packages/component-library/stories/index.js
+++ b/packages/component-library/stories/index.js
@@ -26,8 +26,6 @@ import pullQuoteStory from './PullQuote.story';
 import screenGridMapStory from './ScreenGridMap.story';
 import pathMapStory from './PathMap.story';
 import iconMapStory from './IconMap.story';
-import mapOverlayStory from './MapOverlay.story';
-import hexOverlayStory from './HexOverlay.story';
 import { checkA11y } from '@storybook/addon-a11y';
 import '../assets/global.styles.css';
 

--- a/packages/component-library/stories/index.js
+++ b/packages/component-library/stories/index.js
@@ -26,6 +26,7 @@ import pullQuoteStory from './PullQuote.story';
 import screenGridMapStory from './ScreenGridMap.story';
 import pathMapStory from './PathMap.story';
 import iconMapStory from './IconMap.story';
+import boundaryMapStory from './BoundaryMap.story';
 import { checkA11y } from '@storybook/addon-a11y';
 import '../assets/global.styles.css';
 


### PR DESCRIPTION
`mapOverlayStory` and `hexOverlayStory` were imported twice, causing an error when running yarn storybook.

This PR fixes that error.