### PR TITLE
Add the redux actions logger to the 2018 package

### DIFF
--- a/packages/2018/package.json
+++ b/packages/2018/package.json
@@ -43,6 +43,7 @@
     "react-router-redux": "^4.0.8",
     "react-typekit": "^1.1.3",
     "redux": "^3.6.0",
+    "redux-logger": "^3.0.6",
     "redux-thunk": "^2.1.0",
     "webpack": "^2.5.1",
     "webpack-blocks": "^1.0.0",

--- a/packages/2018/src/index.js
+++ b/packages/2018/src/index.js
@@ -6,6 +6,7 @@ import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
 import { routerReducer, routerMiddleware, syncHistoryWithStore } from 'react-router-redux';
+import { createLogger } from 'redux-logger';
 
 // Import routes, reducers, and root component from each project
 import {
@@ -59,6 +60,9 @@ import StateNotFoundPage from './components/StateNotFoundPage';
 // Create a store by combining all project reducers and the routing reducer
 const configureStore = (initialState, history) => {
   const middlewares = [thunk, routerMiddleware(history)];
+  if (process.env.NODE_ENV !== 'production') {
+    middlewares.push(createLogger());
+  }
 
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE_ || compose;
   const store = createStore(


### PR DESCRIPTION
This little thing helps a ton when working with redux. It's already in the project packages ala MockWrapper, but this adds it to 2018 (but not in prod builds) since using the 2018 package to do development isn't uncommon.