### PR TITLE
Storycard links

### DIFF
--- a/packages/2018-disaster-resilience/src/components/IncreasingSocialCapital/index.js
+++ b/packages/2018-disaster-resilience/src/components/IncreasingSocialCapital/index.js
@@ -9,7 +9,10 @@ export class IncreasingSocialCapital extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Increasing Social Capital Leads to Increased Resilience">
+      <CivicStoryCard
+        title="Increasing Social Capital Leads to Increased Resilience"
+        slug="increasing-social-capital"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-disaster-resilience/src/components/IncreasingSocialCapital/index.js
+++ b/packages/2018-disaster-resilience/src/components/IncreasingSocialCapital/index.js
@@ -19,5 +19,7 @@ export class IncreasingSocialCapital extends React.Component {
   }
 }
 
+IncreasingSocialCapital.displayName = 'IncreasingSocialCapital';
+
 // Connect this to the redux store when necessary
 export default IncreasingSocialCapital;

--- a/packages/2018-disaster-resilience/src/components/LifeAlteringEvent/index.js
+++ b/packages/2018-disaster-resilience/src/components/LifeAlteringEvent/index.js
@@ -19,5 +19,7 @@ export class LifeAlteringEvent extends React.Component {
   }
 }
 
+LifeAlteringEvent.displayName = 'LifeAlteringEvent';
+
 // Connect this to the redux store when necessary
 export default LifeAlteringEvent;

--- a/packages/2018-disaster-resilience/src/components/LifeAlteringEvent/index.js
+++ b/packages/2018-disaster-resilience/src/components/LifeAlteringEvent/index.js
@@ -9,7 +9,10 @@ export class LifeAlteringEvent extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="A Life-Altering Event for Portlanders">
+      <CivicStoryCard
+        title="A Life-Altering Event for Portlanders"
+        slug="life-altering-event"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-disaster-resilience/src/components/ProactivePlanning/index.js
+++ b/packages/2018-disaster-resilience/src/components/ProactivePlanning/index.js
@@ -19,5 +19,7 @@ export class ProactivePlanning extends React.Component {
   }
 }
 
+ProactivePlanning.displayName = 'ProactivePlanning';
+
 // Connect this to the redux store when necessary
 export default ProactivePlanning;

--- a/packages/2018-disaster-resilience/src/components/ProactivePlanning/index.js
+++ b/packages/2018-disaster-resilience/src/components/ProactivePlanning/index.js
@@ -9,7 +9,10 @@ export class ProactivePlanning extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Proactive Planning for City-Wide Resilience">
+      <CivicStoryCard
+        title="Proactive Planning for City-Wide Resilience"
+        slug="proactive-planning-for-city-wide-resilience"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-disaster-resilience/src/components/SignificantStructuralDamage/index.js
+++ b/packages/2018-disaster-resilience/src/components/SignificantStructuralDamage/index.js
@@ -9,7 +9,10 @@ export class SignificantStructuralDamage extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Significant Structural Damage">
+      <CivicStoryCard
+        title="Significant Structural Damage"
+        slug="significant-structural-damage"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-disaster-resilience/src/components/SignificantStructuralDamage/index.js
+++ b/packages/2018-disaster-resilience/src/components/SignificantStructuralDamage/index.js
@@ -19,5 +19,7 @@ export class SignificantStructuralDamage extends React.Component {
   }
 }
 
+SignificantStructuralDamage.displayName = 'SignificantStructuralDamage';
+
 // Connect this to the redux store when necessary
 export default SignificantStructuralDamage;

--- a/packages/2018-disaster-resilience/src/components/ViolentShakingAndGroundDeformation/index.js
+++ b/packages/2018-disaster-resilience/src/components/ViolentShakingAndGroundDeformation/index.js
@@ -19,5 +19,7 @@ export class ViolentShakingAndGroundDeformation extends React.Component {
   }
 }
 
+ViolentShakingAndGroundDeformation.displayName = 'ViolentShakingAndGroundDeformation';
+
 // Connect this to the redux store when necessary
 export default ViolentShakingAndGroundDeformation;

--- a/packages/2018-disaster-resilience/src/components/ViolentShakingAndGroundDeformation/index.js
+++ b/packages/2018-disaster-resilience/src/components/ViolentShakingAndGroundDeformation/index.js
@@ -9,7 +9,10 @@ export class ViolentShakingAndGroundDeformation extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Violent Shaking and Ground Deformation">
+      <CivicStoryCard
+        title="Violent Shaking and Ground Deformation"
+        slug="violent-shaking-and-ground-deformation"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-disaster-resilience/src/components/WhatYouCanDoToPrepare/index.js
+++ b/packages/2018-disaster-resilience/src/components/WhatYouCanDoToPrepare/index.js
@@ -9,7 +9,10 @@ export class WhatYouCanDoToPrepare extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="What You Can Do to Prepare for an Earthquake">
+      <CivicStoryCard
+        title="What You Can Do to Prepare for an Earthquake"
+        slug="what-you-can-do-to-prepare-for-an-earthquake"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-disaster-resilience/src/components/WhatYouCanDoToPrepare/index.js
+++ b/packages/2018-disaster-resilience/src/components/WhatYouCanDoToPrepare/index.js
@@ -19,5 +19,7 @@ export class WhatYouCanDoToPrepare extends React.Component {
   }
 }
 
+WhatYouCanDoToPrepare.displayName = 'WhatYouCanDoToPrepare';
+
 // Connect this to the redux store when necessary
 export default WhatYouCanDoToPrepare;

--- a/packages/2018-disaster-resilience/src/components/YouAndYourNeighbors/index.js
+++ b/packages/2018-disaster-resilience/src/components/YouAndYourNeighbors/index.js
@@ -19,5 +19,7 @@ export class YouAndYourNeighbors extends React.Component {
   }
 }
 
+YouAndYourNeighbors.displayName = 'YouAndYourNeighbors';
+
 // Connect this to the redux store when necessary
 export default YouAndYourNeighbors;

--- a/packages/2018-disaster-resilience/src/components/YouAndYourNeighbors/index.js
+++ b/packages/2018-disaster-resilience/src/components/YouAndYourNeighbors/index.js
@@ -9,7 +9,10 @@ export class YouAndYourNeighbors extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="You and Your Neighbors in the Earthquake">
+      <CivicStoryCard
+        title="You and Your Neighbors in the Earthquake"
+        slug="you-and-your-neighbors-in-the-earthquake"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-disaster-resilience/src/index.js
+++ b/packages/2018-disaster-resilience/src/index.js
@@ -1,5 +1,6 @@
 import App from './components/App';
 import Routes from './routes';
 import Reducers from './state';
+import CardRegistry from './registry';
 
-export { App, Routes, Reducers };
+export { App, Routes, Reducers, CardRegistry };

--- a/packages/2018-disaster-resilience/src/registry.js
+++ b/packages/2018-disaster-resilience/src/registry.js
@@ -1,0 +1,38 @@
+import LifeAlteringEvent from './components/LifeAlteringEvent';
+import ViolentShakingAndGroundDeformation from './components/ViolentShakingAndGroundDeformation';
+import SignificantStructuralDamage from './components/SignificantStructuralDamage';
+import YouAndYourNeighbors from './components/YouAndYourNeighbors';
+import WhatYouCanDoToPrepare from './components/WhatYouCanDoToPrepare';
+import IncreasingSocialCapital from './components/IncreasingSocialCapital';
+import ProactivePlanning from './components/ProactivePlanning';
+
+export default [
+  {
+    slug: 'life-altering-event',
+    component: LifeAlteringEvent,
+  },
+  {
+    slug: 'violent-shaking-and-ground-deformation',
+    component: ViolentShakingAndGroundDeformation,
+  },
+  {
+    slug: 'significant-structural-damage',
+    component: SignificantStructuralDamage,
+  },
+  {
+    slug: 'you-and-your-neighbors-in-the-earthquake',
+    component: YouAndYourNeighbors,
+  },
+  {
+    slug: 'what-you-can-do-to-prepare-for-an-earthquake',
+    component: WhatYouCanDoToPrepare,
+  },
+  {
+    slug: 'increasing-social-capital',
+    component: IncreasingSocialCapital,
+  },
+  {
+    slug: 'proactive-planning-for-city-wide-resilience',
+    component: ProactivePlanning,
+  },
+];

--- a/packages/2018-example-farmers-markets/src/components/FarmersMarketsOverTime/index.js
+++ b/packages/2018-example-farmers-markets/src/components/FarmersMarketsOverTime/index.js
@@ -45,7 +45,10 @@ export class FarmersMarketsOverTime extends React.Component {
 
     return (
       <div>
-        <CivicStoryCard title="Farmers Markets Trending Upward">
+        <CivicStoryCard
+          title="Farmers Markets Trending Upward"
+          slug="farmers-markets-over-time"
+        >
           <p>
             Farmers' markets saw steady growth through the 1990s into the mid-2000s. The recession
             correlates with abnormal growth in the total number of Farmers' Markets. The last two

--- a/packages/2018-example-farmers-markets/src/components/PortlandFarmersMarkets/index.js
+++ b/packages/2018-example-farmers-markets/src/components/PortlandFarmersMarkets/index.js
@@ -58,7 +58,10 @@ export class PortlandFarmersMarkets extends React.Component {
     }
 
     return (
-      <CivicStoryCard title="Where are Portland's Farmers' Markets?">
+      <CivicStoryCard
+        title="Where are Portland's Farmers' Markets?"
+        slug="portland-farmers-markets"
+      >
         <div className={mapWrapper}>
           <BaseMap mapboxToken={mapboxToken} mapboxStyle="mapbox://styles/themendozaline/cj8rrlv4tbtgs2rqnyhckuqva">
             <ScatterPlotMap

--- a/packages/2018-example-farmers-markets/src/index.js
+++ b/packages/2018-example-farmers-markets/src/index.js
@@ -2,4 +2,18 @@ import App from './components/App';
 import Routes from './routes';
 import Reducers from './state';
 
-export { App, Routes, Reducers };
+import PortlandFarmersMarkets from './components/PortlandFarmersMarkets';
+import FarmersMarketsOverTime from './components/FarmersMarketsOverTime';
+
+const CardRegistry = [
+  {
+    slug: 'portland-farmers-markets',
+    component: PortlandFarmersMarkets,
+  },
+  {
+    slug: 'farmers-markets-over-time',
+    component: FarmersMarketsOverTime,
+  },
+];
+
+export { App, Routes, Reducers, CardRegistry };

--- a/packages/2018-housing-affordability/src/components/AffordabilityInAComplexHousingMarket/index.js
+++ b/packages/2018-housing-affordability/src/components/AffordabilityInAComplexHousingMarket/index.js
@@ -19,5 +19,7 @@ export class AffordabilityInAComplexHousingMarket extends React.Component {
   }
 }
 
+AffordabilityInAComplexHousingMarket.displayName = 'AffordabilityInAComplexHousingMarket';
+
 // Connect this to the redux store when necessary
 export default AffordabilityInAComplexHousingMarket;

--- a/packages/2018-housing-affordability/src/components/AffordabilityInAComplexHousingMarket/index.js
+++ b/packages/2018-housing-affordability/src/components/AffordabilityInAComplexHousingMarket/index.js
@@ -9,7 +9,10 @@ export class AffordabilityInAComplexHousingMarket extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="The Challenge of Affordability in a Complex Housing Market">
+      <CivicStoryCard
+        title="The Challenge of Affordability in a Complex Housing Market"
+        slug="affordability-in-a-complex-housing-market"
+      >
         <Placeholder issue="212" />
       </CivicStoryCard>
     );

--- a/packages/2018-housing-affordability/src/components/AffordableRentalUnitsDwindling/index.js
+++ b/packages/2018-housing-affordability/src/components/AffordableRentalUnitsDwindling/index.js
@@ -9,7 +9,10 @@ export class AffordableRentalUnitsDwindling extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Affordable Rental Units are Dwindling">
+      <CivicStoryCard
+        title="Affordable Rental Units are Dwindling"
+        slug="affordable-rental-units-are-dwindling"
+      >
         <Placeholder issue="56"/>
       </CivicStoryCard>
     );

--- a/packages/2018-housing-affordability/src/components/AffordableRentalUnitsDwindling/index.js
+++ b/packages/2018-housing-affordability/src/components/AffordableRentalUnitsDwindling/index.js
@@ -19,5 +19,7 @@ export class AffordableRentalUnitsDwindling extends React.Component {
   }
 }
 
+AffordableRentalUnitsDwindling.displayName = 'AffordableRentalUnitsDwindling';
+
 // Connect this to the redux store when necessary
 export default AffordableRentalUnitsDwindling;

--- a/packages/2018-housing-affordability/src/components/BuildingBoomInPortland/index.js
+++ b/packages/2018-housing-affordability/src/components/BuildingBoomInPortland/index.js
@@ -9,7 +9,10 @@ export class BuildingBoomInPortland extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="A Building Boom in Portland">
+      <CivicStoryCard
+        title="A Building Boom in Portland"
+        slug="building-boom-in-portland"
+      >
         <Placeholder issue="166" />
       </CivicStoryCard>
     );

--- a/packages/2018-housing-affordability/src/components/BuildingBoomInPortland/index.js
+++ b/packages/2018-housing-affordability/src/components/BuildingBoomInPortland/index.js
@@ -19,5 +19,7 @@ export class BuildingBoomInPortland extends React.Component {
   }
 }
 
+BuildingBoomInPortland.displayName = 'BuildingBoomInPortland';
+
 // Connect this to the redux store when necessary
 export default BuildingBoomInPortland;

--- a/packages/2018-housing-affordability/src/components/ExploreHousingPolicyImplementation/index.js
+++ b/packages/2018-housing-affordability/src/components/ExploreHousingPolicyImplementation/index.js
@@ -19,5 +19,7 @@ export class ExploreHousingPolicyImplementation extends React.Component {
   }
 }
 
+ExploreHousingPolicyImplementation.displayName = 'ExploreHousingPolicyImplementation';
+
 // Connect this to the redux store when necessary
 export default ExploreHousingPolicyImplementation;

--- a/packages/2018-housing-affordability/src/components/ExploreHousingPolicyImplementation/index.js
+++ b/packages/2018-housing-affordability/src/components/ExploreHousingPolicyImplementation/index.js
@@ -9,7 +9,10 @@ export class ExploreHousingPolicyImplementation extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Explore Housing Policy Implementation in the Portland Metro Area">
+      <CivicStoryCard
+        title="Explore Housing Policy Implementation in the Portland Metro Area"
+        slug="explore-housing-policy-implementation"
+      >
         <Placeholder issue="106" />
       </CivicStoryCard>
     );

--- a/packages/2018-housing-affordability/src/components/MeasuringMarketValueOfHomesInPortland/index.js
+++ b/packages/2018-housing-affordability/src/components/MeasuringMarketValueOfHomesInPortland/index.js
@@ -19,5 +19,7 @@ export class MeasuringMarketValueOfHomesInPortland extends React.Component {
   }
 }
 
+MeasuringMarketValueOfHomesInPortland.displayName = 'MeasuringMarketValueOfHomesInPortland';
+
 // Connect this to the redux store when necessary
 export default MeasuringMarketValueOfHomesInPortland;

--- a/packages/2018-housing-affordability/src/components/MeasuringMarketValueOfHomesInPortland/index.js
+++ b/packages/2018-housing-affordability/src/components/MeasuringMarketValueOfHomesInPortland/index.js
@@ -9,7 +9,10 @@ export class MeasuringMarketValueOfHomesInPortland extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Measuring Market Value of Homes in Portland">
+      <CivicStoryCard
+        title="Measuring Market Value of Homes in Portland"
+        slug="measuring-market-value-of-homes-in-portland"
+      >
         <Placeholder issue="215" />
       </CivicStoryCard>
     );

--- a/packages/2018-housing-affordability/src/components/PacificNorthwestTopsNationInSurgingHomePrices/index.js
+++ b/packages/2018-housing-affordability/src/components/PacificNorthwestTopsNationInSurgingHomePrices/index.js
@@ -19,5 +19,7 @@ export class PacificNorthwestTopsNationInSurgingHomePrices extends React.Compone
   }
 }
 
+PacificNorthwestTopsNationInSurgingHomePrices.displayName = 'PacificNorthwestTopsNationInSurgingHomePrices';
+
 // Connect this to the redux store when necessary
 export default PacificNorthwestTopsNationInSurgingHomePrices;

--- a/packages/2018-housing-affordability/src/components/PacificNorthwestTopsNationInSurgingHomePrices/index.js
+++ b/packages/2018-housing-affordability/src/components/PacificNorthwestTopsNationInSurgingHomePrices/index.js
@@ -9,7 +9,10 @@ export class PacificNorthwestTopsNationInSurgingHomePrices extends React.Compone
 
   render() {
     return (
-      <CivicStoryCard title="Pacific Northwest Tops the Nation in Surging Home Prices">
+      <CivicStoryCard
+        title="Pacific Northwest Tops the Nation in Surging Home Prices"
+        slug="pacific-northwest-tops-nation-in-surging-home-prices"
+      >
         <Placeholder issue="58" />
       </CivicStoryCard>
     );

--- a/packages/2018-housing-affordability/src/components/PortlandNeedsAffordableRentalUnits/index.js
+++ b/packages/2018-housing-affordability/src/components/PortlandNeedsAffordableRentalUnits/index.js
@@ -9,7 +9,10 @@ export class PortlandNeedsAffordableRentalUnits extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Portland Needs Affordable Rental Units">
+      <CivicStoryCard
+        title="Portland Needs Affordable Rental Units"
+        slug="portland-needs-affordable-rental-units"
+      >
         <Placeholder issue="55" />
       </CivicStoryCard>
     );

--- a/packages/2018-housing-affordability/src/components/PortlandNeedsAffordableRentalUnits/index.js
+++ b/packages/2018-housing-affordability/src/components/PortlandNeedsAffordableRentalUnits/index.js
@@ -19,5 +19,7 @@ export class PortlandNeedsAffordableRentalUnits extends React.Component {
   }
 }
 
+PortlandNeedsAffordableRentalUnits.displayName = 'PortlandNeedsAffordableRentalUnits';
+
 // Connect this to the redux store when necessary
 export default PortlandNeedsAffordableRentalUnits;

--- a/packages/2018-housing-affordability/src/components/RentBurdenedHouseholds/index.js
+++ b/packages/2018-housing-affordability/src/components/RentBurdenedHouseholds/index.js
@@ -9,7 +9,10 @@ export class RentBurdenedHouseholds extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Rent Burdened Households">
+      <CivicStoryCard
+        title="Rent Burdened Households"
+        slug="rent-burdened-households"
+      >
         <Placeholder issue = "194"/>
       </CivicStoryCard>
     );

--- a/packages/2018-housing-affordability/src/components/RentBurdenedHouseholds/index.js
+++ b/packages/2018-housing-affordability/src/components/RentBurdenedHouseholds/index.js
@@ -19,5 +19,7 @@ export class RentBurdenedHouseholds extends React.Component {
   }
 }
 
+RentBurdenedHouseholds.displayName = 'RentBurdenedHouseholds';
+
 // Connect this to the redux store when necessary
 export default RentBurdenedHouseholds;

--- a/packages/2018-housing-affordability/src/components/WhatDoesAffordabilityMean/index.js
+++ b/packages/2018-housing-affordability/src/components/WhatDoesAffordabilityMean/index.js
@@ -19,5 +19,7 @@ export class WhatDoesAffordabilityMean extends React.Component {
   }
 }
 
+WhatDoesAffordabilityMean.displayName = 'WhatDoesAffordabilityMean';
+
 // Connect this to the redux store when necessary
 export default WhatDoesAffordabilityMean;

--- a/packages/2018-housing-affordability/src/components/WhatDoesAffordabilityMean/index.js
+++ b/packages/2018-housing-affordability/src/components/WhatDoesAffordabilityMean/index.js
@@ -9,7 +9,10 @@ export class WhatDoesAffordabilityMean extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="What Does Affordability Mean?">
+      <CivicStoryCard
+        title="What Does Affordability Mean?"
+        slug="what-does-affordability-mean"
+      >
         <Placeholder issue="211" />
       </CivicStoryCard>
     );

--- a/packages/2018-housing-affordability/src/components/WhoCanAffordToBuyAHome/index.js
+++ b/packages/2018-housing-affordability/src/components/WhoCanAffordToBuyAHome/index.js
@@ -19,5 +19,7 @@ export class WhoCanAffordToBuyAHome extends React.Component {
   }
 }
 
+WhoCanAffordToBuyAHome.displayName = 'WhoCanAffordToBuyAHome';
+
 // Connect this to the redux store when necessary
 export default WhoCanAffordToBuyAHome;

--- a/packages/2018-housing-affordability/src/components/WhoCanAffordToBuyAHome/index.js
+++ b/packages/2018-housing-affordability/src/components/WhoCanAffordToBuyAHome/index.js
@@ -9,7 +9,10 @@ export class WhoCanAffordToBuyAHome extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Who Can Afford to Buy a Home in America?">
+      <CivicStoryCard
+        title="Who Can Afford to Buy a Home in America?"
+        slug="who-can-afford-to-buy-a-home"
+      >
         <Placeholder issue="57" />
       </CivicStoryCard>
     );

--- a/packages/2018-housing-affordability/src/index.js
+++ b/packages/2018-housing-affordability/src/index.js
@@ -1,5 +1,6 @@
 import App from './components/App';
 import Routes from './routes';
 import Reducers from './state';
+import CardRegistry from './registry';
 
-export { App, Routes, Reducers };
+export { App, Routes, Reducers, CardRegistry };

--- a/packages/2018-housing-affordability/src/registry.js
+++ b/packages/2018-housing-affordability/src/registry.js
@@ -1,0 +1,53 @@
+import BuildingBoomInPortland from './components/BuildingBoomInPortland';
+import WhatDoesAffordabilityMean from './components/WhatDoesAffordabilityMean';
+import AffordableRentalUnitsDwindling from './components/AffordableRentalUnitsDwindling';
+import RentBurdenedHouseholds from './components/RentBurdenedHouseholds';
+import PortlandNeedsAffordableRentalUnits from './components/PortlandNeedsAffordableRentalUnits';
+import WhoCanAffordToBuyAHome from './components/WhoCanAffordToBuyAHome';
+import PacificNorthwestTopsNationInSurgingHomePrices from './components/PacificNorthwestTopsNationInSurgingHomePrices';
+import MeasuringMarketValueOfHomesInPortland from './components/MeasuringMarketValueOfHomesInPortland';
+import AffordabilityInAComplexHousingMarket from './components/AffordabilityInAComplexHousingMarket';
+import ExploreHousingPolicyImplementation from './components/ExploreHousingPolicyImplementation';
+
+export default [
+  {
+    slug: 'building-boom-in-portland',
+    component: BuildingBoomInPortland,
+  },
+  {
+    slug: 'what-does-affordability-mean',
+    component: WhatDoesAffordabilityMean,
+  },
+  {
+    slug: 'affordable-rental-units-are-dwindling',
+    component: AffordableRentalUnitsDwindling,
+  },
+  {
+    slug: 'rent-burdened-households',
+    component: RentBurdenedHouseholds,
+  },
+  {
+    slug: 'portland-needs-affordable-rental-units',
+    component: PortlandNeedsAffordableRentalUnits,
+  },
+  {
+    slug: 'who-can-afford-to-buy-a-home',
+    component: WhoCanAffordToBuyAHome,
+  },
+  {
+    slug: 'pacific-northwest-tops-nation-in-surging-home-prices',
+    component: PacificNorthwestTopsNationInSurgingHomePrices,
+  },
+  {
+    slug: 'measuring-market-value-of-homes-in-portland',
+    component: MeasuringMarketValueOfHomesInPortland,
+  },
+  {
+    slug: 'affordability-in-a-complex-housing-market',
+    component: AffordabilityInAComplexHousingMarket,
+  },
+  {
+    slug: 'explore-housing-policy-implementation',
+    component: ExploreHousingPolicyImplementation,
+  },
+];

--- a/packages/2018-local-elections/src/components/HowMuchDoesMoneyMatterInElections/index.js
+++ b/packages/2018-local-elections/src/components/HowMuchDoesMoneyMatterInElections/index.js
@@ -19,5 +19,7 @@ export class HowMuchDoesMoneyMatterInElections extends React.Component {
   }
 }
 
+HowMuchDoesMoneyMatterInElections.displayName = 'HowMuchDoesMoneyMatterInElections';
+
 // Connect this to the redux store when necessary
 export default HowMuchDoesMoneyMatterInElections;

--- a/packages/2018-local-elections/src/components/HowMuchDoesMoneyMatterInElections/index.js
+++ b/packages/2018-local-elections/src/components/HowMuchDoesMoneyMatterInElections/index.js
@@ -9,7 +9,10 @@ export class HowMuchDoesMoneyMatterInElections extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="How Much Does Money Really Matter in Elections?">
+      <CivicStoryCard
+        title="How Much Does Money Really Matter in Elections?"
+        slug="how-much-does-money-matter-in-elections"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-local-elections/src/components/IncreasingVolumeOfMoney/index.js
+++ b/packages/2018-local-elections/src/components/IncreasingVolumeOfMoney/index.js
@@ -9,7 +9,10 @@ export class IncreasingVolumeOfMoney extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="The Increasing Volume of Money in Oregon Elections">
+      <CivicStoryCard
+        title="The Increasing Volume of Money in Oregon Elections"
+        slug="increasing-volume-of-money"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-local-elections/src/components/IncreasingVolumeOfMoney/index.js
+++ b/packages/2018-local-elections/src/components/IncreasingVolumeOfMoney/index.js
@@ -19,5 +19,7 @@ export class IncreasingVolumeOfMoney extends React.Component {
   }
 }
 
+IncreasingVolumeOfMoney.displayName = 'IncreasingVolumeOfMoney';
+
 // Connect this to the redux store when necessary
 export default IncreasingVolumeOfMoney;

--- a/packages/2018-local-elections/src/components/InfluentialContributorCohorts/index.js
+++ b/packages/2018-local-elections/src/components/InfluentialContributorCohorts/index.js
@@ -9,7 +9,10 @@ export class InfluentialContributorCohorts extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Influential Contributor Cohorts">
+      <CivicStoryCard
+        title="Influential Contributor Cohorts"
+        slug="influential-contributor-cohorts"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-local-elections/src/components/InfluentialContributorCohorts/index.js
+++ b/packages/2018-local-elections/src/components/InfluentialContributorCohorts/index.js
@@ -19,5 +19,7 @@ export class InfluentialContributorCohorts extends React.Component {
   }
 }
 
+InfluentialContributorCohorts.displayName = 'InfluentialContributorCohorts';
+
 // Connect this to the redux store when necessary
 export default InfluentialContributorCohorts;

--- a/packages/2018-local-elections/src/components/IsPartyAffiliationRelevant/index.js
+++ b/packages/2018-local-elections/src/components/IsPartyAffiliationRelevant/index.js
@@ -9,7 +9,10 @@ export class IsPartyAffiliationRelevant extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Is Party Affiliation Relevant?">
+      <CivicStoryCard
+        title="Is Party Affiliation Relevant?"
+        slug="is-party-affiliation-relevant"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-local-elections/src/components/IsPartyAffiliationRelevant/index.js
+++ b/packages/2018-local-elections/src/components/IsPartyAffiliationRelevant/index.js
@@ -19,5 +19,7 @@ export class IsPartyAffiliationRelevant extends React.Component {
   }
 }
 
+IsPartyAffiliationRelevant.displayName = 'IsPartyAffiliationRelevant';
+
 // Connect this to the redux store when necessary
 export default IsPartyAffiliationRelevant;

--- a/packages/2018-local-elections/src/components/MeasuringThePowerOfGrassroots/index.js
+++ b/packages/2018-local-elections/src/components/MeasuringThePowerOfGrassroots/index.js
@@ -9,7 +9,10 @@ export class MeasuringThePowerOfGrassroots extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Measuring the Power of Grassroots">
+      <CivicStoryCard
+        title="Measuring the Power of Grassroots"
+        slug="measuring-the-power-of-grassroots"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-local-elections/src/components/MeasuringThePowerOfGrassroots/index.js
+++ b/packages/2018-local-elections/src/components/MeasuringThePowerOfGrassroots/index.js
@@ -19,5 +19,7 @@ export class MeasuringThePowerOfGrassroots extends React.Component {
   }
 }
 
+MeasuringThePowerOfGrassroots.displayName = 'MeasuringThePowerOfGrassroots';
+
 // Connect this to the redux store when necessary
 export default MeasuringThePowerOfGrassroots;

--- a/packages/2018-local-elections/src/components/OutraisingYourOpponent/index.js
+++ b/packages/2018-local-elections/src/components/OutraisingYourOpponent/index.js
@@ -9,7 +9,10 @@ export class OutraisingYourOpponent extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Outraising Your Opponent">
+      <CivicStoryCard
+        title="Outraising Your Opponent"
+        slug="outraising-your-opponent"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-local-elections/src/components/OutraisingYourOpponent/index.js
+++ b/packages/2018-local-elections/src/components/OutraisingYourOpponent/index.js
@@ -19,5 +19,7 @@ export class OutraisingYourOpponent extends React.Component {
   }
 }
 
+OutraisingYourOpponent.displayName = 'OutraisingYourOpponent';
+
 // Connect this to the redux store when necessary
 export default OutraisingYourOpponent;

--- a/packages/2018-local-elections/src/components/PrimariesArePredictive/index.js
+++ b/packages/2018-local-elections/src/components/PrimariesArePredictive/index.js
@@ -19,5 +19,7 @@ export class PrimariesArePredictive extends React.Component {
   }
 }
 
+PrimariesArePredictive.displayName = 'PrimariesArePredictive';
+
 // Connect this to the redux store when necessary
 export default PrimariesArePredictive;

--- a/packages/2018-local-elections/src/components/PrimariesArePredictive/index.js
+++ b/packages/2018-local-elections/src/components/PrimariesArePredictive/index.js
@@ -9,7 +9,10 @@ export class PrimariesArePredictive extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Primaries are Predictive">
+      <CivicStoryCard
+        title="Primaries are Predictive"
+        slug="primaries-are-predictive"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-local-elections/src/components/RealTimeInformationOnPoliticalCampaigns/index.js
+++ b/packages/2018-local-elections/src/components/RealTimeInformationOnPoliticalCampaigns/index.js
@@ -19,5 +19,7 @@ export class RealTimeInformationOnPoliticalCampaigns extends React.Component {
   }
 }
 
+RealTimeInformationOnPoliticalCampaigns.displayName = 'RealTimeInformationOnPoliticalCampaigns';
+
 // Connect this to the redux store when necessary
 export default RealTimeInformationOnPoliticalCampaigns;

--- a/packages/2018-local-elections/src/components/RealTimeInformationOnPoliticalCampaigns/index.js
+++ b/packages/2018-local-elections/src/components/RealTimeInformationOnPoliticalCampaigns/index.js
@@ -9,7 +9,10 @@ export class RealTimeInformationOnPoliticalCampaigns extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Real-Time Information on Political Campaigns">
+      <CivicStoryCard
+        title="Real-Time Information on Political Campaigns"
+        slug="real-time-information-on-political-campaigns"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-local-elections/src/components/SuccessfulSpendingPatterns/index.js
+++ b/packages/2018-local-elections/src/components/SuccessfulSpendingPatterns/index.js
@@ -19,5 +19,7 @@ export class SuccessfulSpendingPatterns extends React.Component {
   }
 }
 
+SuccessfulSpendingPatterns.displayName = 'SuccessfulSpendingPatterns';
+
 // Connect this to the redux store when necessary
 export default SuccessfulSpendingPatterns;

--- a/packages/2018-local-elections/src/components/SuccessfulSpendingPatterns/index.js
+++ b/packages/2018-local-elections/src/components/SuccessfulSpendingPatterns/index.js
@@ -9,7 +9,10 @@ export class SuccessfulSpendingPatterns extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Successful Spending Patterns">
+      <CivicStoryCard
+        title="Successful Spending Patterns"
+        slug="successful-spending-patterns"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-local-elections/src/components/YourVoteHasAPriceTag/index.js
+++ b/packages/2018-local-elections/src/components/YourVoteHasAPriceTag/index.js
@@ -19,5 +19,7 @@ export class YourVoteHasAPriceTag extends React.Component {
   }
 }
 
+YourVoteHasAPriceTag.displayName = 'YourVoteHasAPriceTag';
+
 // Connect this to the redux store when necessary
 export default YourVoteHasAPriceTag;

--- a/packages/2018-local-elections/src/components/YourVoteHasAPriceTag/index.js
+++ b/packages/2018-local-elections/src/components/YourVoteHasAPriceTag/index.js
@@ -9,7 +9,10 @@ export class YourVoteHasAPriceTag extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Your Vote has a Price Tag">
+      <CivicStoryCard
+        title="Your Vote has a Price Tag"
+        slug="your-vote-has-a-price-tag"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-local-elections/src/index.js
+++ b/packages/2018-local-elections/src/index.js
@@ -1,5 +1,6 @@
 import App from './components/App';
 import Routes from './routes';
 import Reducers from './state';
+import CardRegistry from './registry';
 
-export { App, Routes, Reducers };
+export { App, Routes, Reducers, CardRegistry };

--- a/packages/2018-local-elections/src/registry.js
+++ b/packages/2018-local-elections/src/registry.js
@@ -1,0 +1,53 @@
+import IncreasingVolumeOfMoney from './components/IncreasingVolumeOfMoney';
+import HowMuchDoesMoneyMatterInElections from './components/HowMuchDoesMoneyMatterInElections';
+import OutraisingYourOpponent from './components/OutraisingYourOpponent';
+import SuccessfulSpendingPatterns from './components/SuccessfulSpendingPatterns';
+import InfluentialContributorCohorts from './components/InfluentialContributorCohorts';
+import MeasuringThePowerOfGrassroots from './components/MeasuringThePowerOfGrassroots';
+import YourVoteHasAPriceTag from './components/YourVoteHasAPriceTag';
+import PrimariesArePredictive from './components/PrimariesArePredictive';
+import IsPartyAffiliationRelevant from './components/IsPartyAffiliationRelevant';
+import RealTimeInformationOnPoliticalCampaigns from './components/RealTimeInformationOnPoliticalCampaigns';
+
+export default [
+  {
+    slug: 'increasing-volume-of-money',
+    component: IncreasingVolumeOfMoney,
+  },
+  {
+    slug: 'how-much-does-money-matter-in-elections',
+    component: HowMuchDoesMoneyMatterInElections,
+  },
+  {
+    slug: 'outraising-your-opponent',
+    component: OutraisingYourOpponent,
+  },
+  {
+    slug: 'successful-spending-patterns',
+    component: SuccessfulSpendingPatterns,
+  },
+  {
+    slug: 'influential-contributor-cohorts',
+    component: InfluentialContributorCohorts,
+  },
+  {
+    slug: 'measuring-the-power-of-grassroots',
+    component: MeasuringThePowerOfGrassroots,
+  },
+  {
+    slug: 'your-vote-has-a-price-tag',
+    component: YourVoteHasAPriceTag,
+  },
+  {
+    slug: 'primaries-are-predictive',
+    component: PrimariesArePredictive,
+  },
+  {
+    slug: 'is-party-affiliation-relevant',
+    component: IsPartyAffiliationRelevant,
+  },
+  {
+    slug: 'real-time-information-on-political-campaigns',
+    component: RealTimeInformationOnPoliticalCampaigns,
+  },
+];

--- a/packages/2018-neighborhood-development/src/components/ClassSizeAndQuality/index.js
+++ b/packages/2018-neighborhood-development/src/components/ClassSizeAndQuality/index.js
@@ -19,5 +19,7 @@ export class ClassSizeAndQuality extends React.Component {
   }
 }
 
+ClassSizeAndQuality.displayName = 'ClassSizeAndQuality';
+
 // Connect this to the redux store when necessary
 export default ClassSizeAndQuality;

--- a/packages/2018-neighborhood-development/src/components/ClassSizeAndQuality/index.js
+++ b/packages/2018-neighborhood-development/src/components/ClassSizeAndQuality/index.js
@@ -9,7 +9,10 @@ export class ClassSizeAndQuality extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Class Size and Quality">
+      <CivicStoryCard
+        title="Class Size and Quality"
+        slug="class-size-and-quality"
+      >
         <Placeholder issue="227"/>
       </CivicStoryCard>
     );

--- a/packages/2018-neighborhood-development/src/components/DiveDeeperIntoNeighborhoodData/index.js
+++ b/packages/2018-neighborhood-development/src/components/DiveDeeperIntoNeighborhoodData/index.js
@@ -22,5 +22,7 @@ export class DiveDeeperIntoNeighborhoodData extends React.Component {
   }
 }
 
+DiveDeeperIntoNeighborhoodData.displayName = 'DiveDeeperIntoNeighborhoodData';
+
 // Connect this to the redux store when necessary
 export default DiveDeeperIntoNeighborhoodData;

--- a/packages/2018-neighborhood-development/src/components/DiveDeeperIntoNeighborhoodData/index.js
+++ b/packages/2018-neighborhood-development/src/components/DiveDeeperIntoNeighborhoodData/index.js
@@ -9,7 +9,10 @@ export class DiveDeeperIntoNeighborhoodData extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Dive Deeper into Neighborhood Data">
+      <CivicStoryCard
+        title="Dive Deeper into Neighborhood Data"
+        slug="dive-deeper-into-neighborhood-data"
+      >
         <Placeholder>
           <h1>Sandbox Card</h1>
           <p>Don't worry about this one</p>

--- a/packages/2018-neighborhood-development/src/components/ExploreAgeDemographics/index.js
+++ b/packages/2018-neighborhood-development/src/components/ExploreAgeDemographics/index.js
@@ -22,5 +22,7 @@ export class ExploreAgeDemographics extends React.Component {
   }
 }
 
+ExploreAgeDemographics.displayName = 'ExploreAgeDemographics';
+
 // Connect this to the redux store when necessary
 export default ExploreAgeDemographics;

--- a/packages/2018-neighborhood-development/src/components/ExploreAgeDemographics/index.js
+++ b/packages/2018-neighborhood-development/src/components/ExploreAgeDemographics/index.js
@@ -9,7 +9,10 @@ export class ExploreAgeDemographics extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Explore Age Demographics of Portland Neighborhoods">
+      <CivicStoryCard
+        title="Explore Age Demographics of Portland Neighborhoods"
+        slug="explore-age-demographics"
+      >
         <Placeholder>
           <h1>Sandbox Card</h1>
           <p>Don't worry about this one</p>

--- a/packages/2018-neighborhood-development/src/components/ExploreUrbanCampsiteSweeps/index.js
+++ b/packages/2018-neighborhood-development/src/components/ExploreUrbanCampsiteSweeps/index.js
@@ -22,5 +22,7 @@ export class ExploreUrbanCampsiteSweeps extends React.Component {
   }
 }
 
+ExploreUrbanCampsiteSweeps.displayName = 'ExploreUrbanCampsiteSweeps';
+
 // Connect this to the redux store when necessary
 export default ExploreUrbanCampsiteSweeps;

--- a/packages/2018-neighborhood-development/src/components/ExploreUrbanCampsiteSweeps/index.js
+++ b/packages/2018-neighborhood-development/src/components/ExploreUrbanCampsiteSweeps/index.js
@@ -9,7 +9,10 @@ export class ExploreUrbanCampsiteSweeps extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Explore Urban Campsite Sweeps by Neighborhood">
+      <CivicStoryCard
+        title="Explore Urban Campsite Sweeps by Neighborhood"
+        slug="explore-urban-campsite-sweeps"
+      >
         <Placeholder>
           <h1>Sandbox Card</h1>
           <p>Don't worry about this one</p>

--- a/packages/2018-neighborhood-development/src/components/HumanImpactOfSweepingUrbanCampsites/index.js
+++ b/packages/2018-neighborhood-development/src/components/HumanImpactOfSweepingUrbanCampsites/index.js
@@ -20,5 +20,7 @@ export class HumanImpactOfSweepingUrbanCampsites extends React.Component {
   }
 }
 
+HumanImpactOfSweepingUrbanCampsites.displayName = 'HumanImpactOfSweepingUrbanCampsites';
+
 // Connect this to the redux store when necessary
 export default HumanImpactOfSweepingUrbanCampsites;

--- a/packages/2018-neighborhood-development/src/components/HumanImpactOfSweepingUrbanCampsites/index.js
+++ b/packages/2018-neighborhood-development/src/components/HumanImpactOfSweepingUrbanCampsites/index.js
@@ -9,7 +9,10 @@ export class HumanImpactOfSweepingUrbanCampsites extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Human Impact of Sweeping Urban Campsites">
+      <CivicStoryCard
+        title="Human Impact of Sweeping Urban Campsites"
+        slug="human-impact-of-sweeping-urban-campsites"
+      >
         <Placeholder issue="100"/>
         <Placeholder issue="102"/>
       </CivicStoryCard>

--- a/packages/2018-neighborhood-development/src/components/MagnitudeOfUrbanCampsiteSweeps/index.js
+++ b/packages/2018-neighborhood-development/src/components/MagnitudeOfUrbanCampsiteSweeps/index.js
@@ -9,7 +9,10 @@ export class MagnitudeOfUrbanCampsiteSweeps extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Magnitude of Urban Campsite Sweeps in Portland">
+      <CivicStoryCard
+        title="Magnitude of Urban Campsite Sweeps in Portland"
+        slug="magnitude-of-urban-campsite-sweeps"
+      >
         <Placeholder issue="85"/>
       </CivicStoryCard>
     );

--- a/packages/2018-neighborhood-development/src/components/MagnitudeOfUrbanCampsiteSweeps/index.js
+++ b/packages/2018-neighborhood-development/src/components/MagnitudeOfUrbanCampsiteSweeps/index.js
@@ -19,5 +19,7 @@ export class MagnitudeOfUrbanCampsiteSweeps extends React.Component {
   }
 }
 
+MagnitudeOfUrbanCampsiteSweeps.displayName = 'MagnitudeOfUrbanCampsiteSweeps';
+
 // Connect this to the redux store when necessary
 export default MagnitudeOfUrbanCampsiteSweeps;

--- a/packages/2018-neighborhood-development/src/components/NeighborhoodsThroughTheAges/index.js
+++ b/packages/2018-neighborhood-development/src/components/NeighborhoodsThroughTheAges/index.js
@@ -9,7 +9,10 @@ export class NeighborhoodsThroughTheAges extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Neighborhoods Through the Ages">
+      <CivicStoryCard
+        title="Neighborhoods Through the Ages"
+        slug="neighborhoods-through-the-ages"
+      >
         <Placeholder issue="192"/>
         <Placeholder issue="201"/>
       </CivicStoryCard>

--- a/packages/2018-neighborhood-development/src/components/NeighborhoodsThroughTheAges/index.js
+++ b/packages/2018-neighborhood-development/src/components/NeighborhoodsThroughTheAges/index.js
@@ -20,5 +20,7 @@ export class NeighborhoodsThroughTheAges extends React.Component {
   }
 }
 
+NeighborhoodsThroughTheAges.displayName = 'NeighborhoodsThroughTheAges';
+
 // Connect this to the redux store when necessary
 export default NeighborhoodsThroughTheAges;

--- a/packages/2018-neighborhood-development/src/components/StudentEnrollmentTrends/index.js
+++ b/packages/2018-neighborhood-development/src/components/StudentEnrollmentTrends/index.js
@@ -9,7 +9,10 @@ export class StudentEnrollmentTrends extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Student Enrollment Trends">
+      <CivicStoryCard
+        title="Student Enrollment Trends"
+        slug="student-enrollment-trends"
+      >
         <Placeholder issue="197"/>
       </CivicStoryCard>
     );

--- a/packages/2018-neighborhood-development/src/components/StudentEnrollmentTrends/index.js
+++ b/packages/2018-neighborhood-development/src/components/StudentEnrollmentTrends/index.js
@@ -19,5 +19,7 @@ export class StudentEnrollmentTrends extends React.Component {
   }
 }
 
+StudentEnrollmentTrends.displayName = 'StudentEnrollmentTrends';
+
 // Connect this to the redux store when necessary
 export default StudentEnrollmentTrends;

--- a/packages/2018-neighborhood-development/src/components/TheShapeOfANeighborhood/index.js
+++ b/packages/2018-neighborhood-development/src/components/TheShapeOfANeighborhood/index.js
@@ -9,7 +9,10 @@ export class TheShapeOfANeighborhood extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="The Shape of a Neighborhood">
+      <CivicStoryCard
+        title="The Shape of a Neighborhood"
+        slug="the-shape-of-a-neighborhood"
+      >
         <Placeholder issue="79"/>
       </CivicStoryCard>
     );

--- a/packages/2018-neighborhood-development/src/components/TheShapeOfANeighborhood/index.js
+++ b/packages/2018-neighborhood-development/src/components/TheShapeOfANeighborhood/index.js
@@ -19,5 +19,7 @@ export class TheShapeOfANeighborhood extends React.Component {
   }
 }
 
+TheShapeOfANeighborhood.displayName = 'TheShapeOfANeighborhood';
+
 // Connect this to the redux store when necessary
 export default TheShapeOfANeighborhood;

--- a/packages/2018-neighborhood-development/src/components/UnderstandingStaffCuts/index.js
+++ b/packages/2018-neighborhood-development/src/components/UnderstandingStaffCuts/index.js
@@ -19,5 +19,7 @@ export class UnderstandingStaffCuts extends React.Component {
   }
 }
 
+UnderstandingStaffCuts.displayName = 'UnderstandingStaffCuts';
+
 // Connect this to the redux store when necessary
 export default UnderstandingStaffCuts;

--- a/packages/2018-neighborhood-development/src/components/UnderstandingStaffCuts/index.js
+++ b/packages/2018-neighborhood-development/src/components/UnderstandingStaffCuts/index.js
@@ -9,7 +9,10 @@ export class UnderstandingStaffCuts extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Understanding Staff Cuts in Portland Public Schools">
+      <CivicStoryCard
+        title="Understanding Staff Cuts in Portland Public Schools"
+        slug="understanding-staff-cuts"
+      >
         <Placeholder issue="201" />
       </CivicStoryCard>
     );

--- a/packages/2018-neighborhood-development/src/components/VotersOnTheMove/index.js
+++ b/packages/2018-neighborhood-development/src/components/VotersOnTheMove/index.js
@@ -9,7 +9,10 @@ export class VotersOnTheMove extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Voters on the Move">
+      <CivicStoryCard
+        title="Voters on the Move"
+        slug="voters-on-the-move"
+      >
         <Placeholder issue="201"/>
       </CivicStoryCard>
     );

--- a/packages/2018-neighborhood-development/src/components/VotersOnTheMove/index.js
+++ b/packages/2018-neighborhood-development/src/components/VotersOnTheMove/index.js
@@ -19,5 +19,7 @@ export class VotersOnTheMove extends React.Component {
   }
 }
 
+VotersOnTheMove.displayName = 'VotersOnTheMove';
+
 // Connect this to the redux store when necessary
 export default VotersOnTheMove;

--- a/packages/2018-neighborhood-development/src/components/VulnerableStudentPopulations/index.js
+++ b/packages/2018-neighborhood-development/src/components/VulnerableStudentPopulations/index.js
@@ -19,5 +19,7 @@ export class VulnerableStudentPopulations extends React.Component {
   }
 }
 
+VulnerableStudentPopulations.displayName = 'VulnerableStudentPopulations';
+
 // Connect this to the redux store when necessary
 export default VulnerableStudentPopulations;

--- a/packages/2018-neighborhood-development/src/components/VulnerableStudentPopulations/index.js
+++ b/packages/2018-neighborhood-development/src/components/VulnerableStudentPopulations/index.js
@@ -9,7 +9,10 @@ export class VulnerableStudentPopulations extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Vulnerable Student Populations">
+      <CivicStoryCard
+        title="Vulnerable Student Populations"
+        slug="vulnerable-student-populations"
+      >
         <Placeholder issue="228"/>
       </CivicStoryCard>
     );

--- a/packages/2018-neighborhood-development/src/index.js
+++ b/packages/2018-neighborhood-development/src/index.js
@@ -1,5 +1,6 @@
 import App from './components/App';
 import Routes from './routes';
 import Reducers from './state';
+import CardRegistry from './registry';
 
-export { App, Routes, Reducers };
+export { App, Routes, Reducers, CardRegistry };

--- a/packages/2018-neighborhood-development/src/registry.js
+++ b/packages/2018-neighborhood-development/src/registry.js
@@ -1,0 +1,63 @@
+import TheShapeOfANeighborhood from './components/TheShapeOfANeighborhood';
+import MagnitudeOfUrbanCampsiteSweeps from './components/MagnitudeOfUrbanCampsiteSweeps';
+import HumanImpactOfSweepingUrbanCampsites from './components/HumanImpactOfSweepingUrbanCampsites';
+import ExploreUrbanCampsiteSweeps from './components/ExploreUrbanCampsiteSweeps';
+import StudentEnrollmentTrends from './components/StudentEnrollmentTrends';
+import VulnerableStudentPopulations from './components/VulnerableStudentPopulations';
+import ClassSizeAndQuality from './components/ClassSizeAndQuality';
+import UnderstandingStaffCuts from './components/UnderstandingStaffCuts';
+import NeighborhoodsThroughTheAges from './components/NeighborhoodsThroughTheAges';
+import ExploreAgeDemographics from './components/ExploreAgeDemographics';
+import VotersOnTheMove from './components/VotersOnTheMove';
+import DiveDeeperIntoNeighborhoodData from './components/DiveDeeperIntoNeighborhoodData';
+
+export default [
+  {
+    slug: 'the-shape-of-a-neighborhood',
+    component: TheShapeOfANeighborhood,
+  },
+  {
+    slug: 'magnitude-of-urban-campsite-sweeps',
+    component: MagnitudeOfUrbanCampsiteSweeps,
+  },
+  {
+    slug: 'human-impact-of-sweeping-urban-campsites',
+    component: HumanImpactOfSweepingUrbanCampsites,
+  },
+  {
+    slug: 'explore-urban-campsite-sweeps',
+    component: ExploreUrbanCampsiteSweeps,
+  },
+  {
+    slug: 'student-enrollment-trends',
+    component: StudentEnrollmentTrends,
+  },
+  {
+    slug: 'vulnerable-student-populations',
+    component: VulnerableStudentPopulations,
+  },
+  {
+    slug: 'class-size-and-quality',
+    component: ClassSizeAndQuality,
+  },
+  {
+    slug: 'understanding-staff-cuts',
+    component: UnderstandingStaffCuts,
+  },
+  {
+    slug: 'neighborhoods-through-the-ages',
+    component: NeighborhoodsThroughTheAges,
+  },
+  {
+    slug: 'explore-age-demographics',
+    component: ExploreAgeDemographics,
+  },
+  {
+    slug: 'voters-on-the-move',
+    component: VotersOnTheMove,
+  },
+  {
+    slug: 'dive-deeper-into-neighborhood-data',
+    component: DiveDeeperIntoNeighborhoodData,
+  },
+];

--- a/packages/2018-transportation-systems/src/components/DeclineInRidership/index.js
+++ b/packages/2018-transportation-systems/src/components/DeclineInRidership/index.js
@@ -19,5 +19,7 @@ export class DeclineInRidership extends React.Component {
   }
 }
 
+DeclineInRidership.displayName = 'DeclineInRidership';
+
 // Connect this to the redux store when necessary
 export default DeclineInRidership;

--- a/packages/2018-transportation-systems/src/components/DeclineInRidership/index.js
+++ b/packages/2018-transportation-systems/src/components/DeclineInRidership/index.js
@@ -9,7 +9,10 @@ export class DeclineInRidership extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Decline in Ridership">
+      <CivicStoryCard
+        title="Decline in Ridership"
+        slug="decline-in-ridership"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-transportation-systems/src/components/DiveDeeperIntoTransportationData/index.js
+++ b/packages/2018-transportation-systems/src/components/DiveDeeperIntoTransportationData/index.js
@@ -22,5 +22,7 @@ export class DiveDeeperIntoTransportationData extends React.Component {
   }
 }
 
+DiveDeeperIntoTransportationData.displayName = 'DiveDeeperIntoTransportationData';
+
 // Connect this to the redux store when necessary
 export default DiveDeeperIntoTransportationData;

--- a/packages/2018-transportation-systems/src/components/DiveDeeperIntoTransportationData/index.js
+++ b/packages/2018-transportation-systems/src/components/DiveDeeperIntoTransportationData/index.js
@@ -9,7 +9,10 @@ export class DiveDeeperIntoTransportationData extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Dive Deeper into Transportation Data">
+      <CivicStoryCard
+        title="Dive Deeper into Transportation Data"
+        slug="dive-deeper-into-transportation-data"
+      >
         <Placeholder>
           <h1>Sandbox Card</h1>
           <p>Don't worry about this one</p>

--- a/packages/2018-transportation-systems/src/components/DriversOfPublicTransitParticipation/index.js
+++ b/packages/2018-transportation-systems/src/components/DriversOfPublicTransitParticipation/index.js
@@ -9,7 +9,10 @@ export class DriversOfPublicTransitParticipation extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Drivers of Public Transit Participation">
+      <CivicStoryCard
+        title="Drivers of Public Transit Participation"
+        slug="drivers-of-public-transit-participation"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-transportation-systems/src/components/DriversOfPublicTransitParticipation/index.js
+++ b/packages/2018-transportation-systems/src/components/DriversOfPublicTransitParticipation/index.js
@@ -19,5 +19,7 @@ export class DriversOfPublicTransitParticipation extends React.Component {
   }
 }
 
+DriversOfPublicTransitParticipation.displayName = 'DriversOfPublicTransitParticipation';
+
 // Connect this to the redux store when necessary
 export default DriversOfPublicTransitParticipation;

--- a/packages/2018-transportation-systems/src/components/ExploreBusServiceAndEquity/index.js
+++ b/packages/2018-transportation-systems/src/components/ExploreBusServiceAndEquity/index.js
@@ -9,7 +9,10 @@ export class ExploreBusServiceAndEquity extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Explore Bus Service and Equity">
+      <CivicStoryCard
+        title="Explore Bus Service and Equity"
+        slug="explore-bus-service-and-equity"
+      >
         <Placeholder>
           <h1>Sandbox Card</h1>
           <p>Don't worry about this one</p>

--- a/packages/2018-transportation-systems/src/components/ExploreBusServiceAndEquity/index.js
+++ b/packages/2018-transportation-systems/src/components/ExploreBusServiceAndEquity/index.js
@@ -22,5 +22,7 @@ export class ExploreBusServiceAndEquity extends React.Component {
   }
 }
 
+ExploreBusServiceAndEquity.displayName = 'ExploreBusServiceAndEquity';
+
 // Connect this to the redux store when necessary
 export default ExploreBusServiceAndEquity;

--- a/packages/2018-transportation-systems/src/components/HistoricalChangesToBusService/index.js
+++ b/packages/2018-transportation-systems/src/components/HistoricalChangesToBusService/index.js
@@ -19,5 +19,7 @@ export class HistoricalChangesToBusService extends React.Component {
   }
 }
 
+HistoricalChangesToBusService.displayName = 'HistoricalChangesToBusService';
+
 // Connect this to the redux store when necessary
 export default HistoricalChangesToBusService;

--- a/packages/2018-transportation-systems/src/components/HistoricalChangesToBusService/index.js
+++ b/packages/2018-transportation-systems/src/components/HistoricalChangesToBusService/index.js
@@ -9,7 +9,10 @@ export class HistoricalChangesToBusService extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Historical Changes to Bus Service">
+      <CivicStoryCard
+        title="Historical Changes to Bus Service"
+        slug="historical-changes-to-bus-service"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-transportation-systems/src/components/MobilityTrendsUsingRealTimeData/index.js
+++ b/packages/2018-transportation-systems/src/components/MobilityTrendsUsingRealTimeData/index.js
@@ -19,5 +19,7 @@ export class MobilityTrendsUsingRealTimeData extends React.Component {
   }
 }
 
+MobilityTrendsUsingRealTimeData.displayName = 'MobilityTrendsUsingRealTimeData';
+
 // Connect this to the redux store when necessary
 export default MobilityTrendsUsingRealTimeData;

--- a/packages/2018-transportation-systems/src/components/MobilityTrendsUsingRealTimeData/index.js
+++ b/packages/2018-transportation-systems/src/components/MobilityTrendsUsingRealTimeData/index.js
@@ -9,7 +9,10 @@ export class MobilityTrendsUsingRealTimeData extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Mobility Trends Using Real-Time Data">
+      <CivicStoryCard
+        title="Mobility Trends Using Real-Time Data"
+        slug="mobility-trends-using-real-time-data"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-transportation-systems/src/components/ReducedServiceReducedRidership/index.js
+++ b/packages/2018-transportation-systems/src/components/ReducedServiceReducedRidership/index.js
@@ -9,7 +9,10 @@ export class ReducedServiceReducedRidership extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="Reduced Service, Reduced Ridership">
+      <CivicStoryCard
+        title="Reduced Service, Reduced Ridership"
+        slug="reduced-service-reduced-ridership"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-transportation-systems/src/components/ReducedServiceReducedRidership/index.js
+++ b/packages/2018-transportation-systems/src/components/ReducedServiceReducedRidership/index.js
@@ -19,5 +19,7 @@ export class ReducedServiceReducedRidership extends React.Component {
   }
 }
 
+ReducedServiceReducedRidership.displayName = 'ReducedServiceReducedRidership';
+
 // Connect this to the redux store when necessary
 export default ReducedServiceReducedRidership;

--- a/packages/2018-transportation-systems/src/components/TheSecretIsInTheSensors/index.js
+++ b/packages/2018-transportation-systems/src/components/TheSecretIsInTheSensors/index.js
@@ -9,7 +9,10 @@ export class TheSecretIsInTheSensors extends React.Component {
 
   render() {
     return (
-      <CivicStoryCard title="The Secret is in the Sensors">
+      <CivicStoryCard
+        title="The Secret is in the Sensors"
+        slug="the-secret-is-in-the-sensors"
+      >
         <Placeholder />
       </CivicStoryCard>
     );

--- a/packages/2018-transportation-systems/src/components/TheSecretIsInTheSensors/index.js
+++ b/packages/2018-transportation-systems/src/components/TheSecretIsInTheSensors/index.js
@@ -19,5 +19,7 @@ export class TheSecretIsInTheSensors extends React.Component {
   }
 }
 
+TheSecretIsInTheSensors.displayName = 'TheSecretIsInTheSensors';
+
 // Connect this to the redux store when necessary
 export default TheSecretIsInTheSensors;

--- a/packages/2018-transportation-systems/src/index.js
+++ b/packages/2018-transportation-systems/src/index.js
@@ -1,5 +1,6 @@
 import App from './components/App';
 import Routes from './routes';
 import Reducers from './state';
+import CardRegistry from './registry';
 
-export { App, Routes, Reducers };
+export { App, Routes, Reducers, CardRegistry };

--- a/packages/2018-transportation-systems/src/registry.js
+++ b/packages/2018-transportation-systems/src/registry.js
@@ -1,0 +1,43 @@
+import DeclineInRidership from './components/DeclineInRidership';
+import HistoricalChangesToBusService from './components/HistoricalChangesToBusService';
+import ReducedServiceReducedRidership from './components/ReducedServiceReducedRidership';
+import DriversOfPublicTransitParticipation from './components/DriversOfPublicTransitParticipation';
+import ExploreBusServiceAndEquity from './components/ExploreBusServiceAndEquity';
+import MobilityTrendsUsingRealTimeData from './components/MobilityTrendsUsingRealTimeData';
+import TheSecretIsInTheSensors from './components/TheSecretIsInTheSensors';
+import DiveDeeperIntoTransportationData from './components/DiveDeeperIntoTransportationData';
+
+export default [
+  {
+    slug: 'decline-in-ridership',
+    component: DeclineInRidership,
+  },
+  {
+    slug: 'historical-changes-to-bus-service',
+    component: HistoricalChangesToBusService,
+  },
+  {
+    slug: 'reduced-service-reduced-ridership',
+    component: ReducedServiceReducedRidership,
+  },
+  {
+    slug: 'drivers-of-public-transit-participation',
+    component: DriversOfPublicTransitParticipation,
+  },
+  {
+    slug: 'explore-bus-service-and-equity',
+    component: ExploreBusServiceAndEquity,
+  },
+  {
+    slug: 'mobility-trends-using-real-time-data',
+    component: MobilityTrendsUsingRealTimeData,
+  },
+  {
+    slug: 'the-secret-is-in-the-sensors',
+    component: TheSecretIsInTheSensors,
+  },
+  {
+    slug: 'dive-deeper-into-transportation-data',
+    component: DiveDeeperIntoTransportationData,
+  },
+];

--- a/packages/2018/mocha.opts
+++ b/packages/2018/mocha.opts
@@ -1,0 +1,7 @@
+--require mocha-clean
+--colors
+--recursive
+--reporter mochawesome
+--reporter-options reportDir=reports/mochawesome
+--require ./tools/testSetup
+--ui bdd

--- a/packages/2018/package.json
+++ b/packages/2018/package.json
@@ -8,7 +8,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server/dev.js",
     "start:prod": "yarn run build && cross-env NODE_ENV=production node server",
     "build": "rimraf dist && cross-env NODE_ENV=production webpack --progress --config ./webpack.config.js",
-    "test": "echo 'No tests!'"
+    "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/2018/src/card-registry.js
+++ b/packages/2018/src/card-registry.js
@@ -1,0 +1,23 @@
+import { CardRegistry as FarmersMarketsRegistry } from '@hackoregon/2018-example-farmers-markets';
+
+const registry = []
+  .concat(FarmersMarketsRegistry.map(c => ({ ...c, project: '@hackoregon/2018-example-farmers-markets' })));
+
+const cardSlugs = new Set();
+const duplicateCards = [];
+
+registry.forEach((card) => {
+  if (cardSlugs.has(card.slug)) {
+    duplicateCards.push(card.slug);
+  }
+  cardSlugs.add(card.slug);
+});
+
+duplicateCards.forEach((duplicate) => {
+  const labels = registry
+    .filter(card => card.slug === duplicate)
+    .map(card => `${card.slug} (${card.component}) in ${card.project}`);
+  throw new Error(`Duplicate slugs found. All card slugs must be unique\n\n${labels.join('\n')}`);
+});
+
+export default registry;

--- a/packages/2018/src/card-registry.js
+++ b/packages/2018/src/card-registry.js
@@ -1,23 +1,8 @@
 import { CardRegistry as FarmersMarketsRegistry } from '@hackoregon/2018-example-farmers-markets';
+import Registry from './utils/registry';
 
-const registry = []
+const allEntries = []
   .concat(FarmersMarketsRegistry.map(c => ({ ...c, project: '@hackoregon/2018-example-farmers-markets' })));
 
-const cardSlugs = new Set();
-const duplicateCards = [];
 
-registry.forEach((card) => {
-  if (cardSlugs.has(card.slug)) {
-    duplicateCards.push(card.slug);
-  }
-  cardSlugs.add(card.slug);
-});
-
-duplicateCards.forEach((duplicate) => {
-  const labels = registry
-    .filter(card => card.slug === duplicate)
-    .map(card => `${card.slug} (${card.component}) in ${card.project}`);
-  throw new Error(`Duplicate slugs found. All card slugs must be unique\n\n${labels.join('\n')}`);
-});
-
-export default registry;
+export default new Registry(allEntries);

--- a/packages/2018/src/card-registry.js
+++ b/packages/2018/src/card-registry.js
@@ -1,8 +1,20 @@
-import { CardRegistry as FarmersMarketsRegistry } from '@hackoregon/2018-example-farmers-markets';
+import { CardRegistry as FarmersMarkets } from '@hackoregon/2018-example-farmers-markets';
+import { CardRegistry as DisasterResilience } from '@hackoregon/2018-disaster-resilience';
+import { CardRegistry as HousingAffordability } from '@hackoregon/2018-housing-affordability';
+import { CardRegistry as LocalElections } from '@hackoregon/2018-local-elections';
+import { CardRegistry as NeighborhoodDevelopment } from '@hackoregon/2018-neighborhood-development';
+import { CardRegistry as TransportationSystems } from '@hackoregon/2018-transportation-systems';
 import Registry from './utils/registry';
 
+const decorate = project => obj => ({ ...obj, project });
+
 const allEntries = []
-  .concat(FarmersMarketsRegistry.map(c => ({ ...c, project: '@hackoregon/2018-example-farmers-markets' })));
+  .concat(FarmersMarkets.map(decorate('@hackoregon/2018-example-farmers-markets')))
+  .concat(DisasterResilience.map(decorate('@hackoregon/2018-disaster-resilience')))
+  .concat(HousingAffordability.map(decorate('@hackoregon/2018-housing-affordability')))
+  .concat(LocalElections.map(decorate('@hackoregon/2018-local-elections')))
+  .concat(NeighborhoodDevelopment.map(decorate('@hackoregon/2018-neighborhood-development')))
+  .concat(TransportationSystems.map(decorate('@hackoregon/2018-transportation-systems')));
 
 
 export default new Registry(allEntries);

--- a/packages/2018/src/components/CardDetailPage.js
+++ b/packages/2018/src/components/CardDetailPage.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Link } from 'react-router';
+import CardRegistry from '../card-registry';
+import { PageLayout } from '@hackoregon/component-library';
+
+const CardDetailPage = ({ params }) => {
+  const card = CardRegistry.find(c => c.slug === params.slug);
+
+  if (card && card.component) {
+    const CardComponent = card.component;
+    return (
+      <PageLayout>
+        <CardComponent />
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout>
+      <h1>Card not found</h1>
+      <p>
+        The card you are looking for doesn't exist.
+        <Link to="/cities/portland">
+          View the Portland Collection
+        </Link>
+      </p>
+    </PageLayout>
+  );
+};
+
+CardDetailPage.displayName = 'CardDetailPage';
+
+export default CardDetailPage;

--- a/packages/2018/src/components/CardDetailPage.js
+++ b/packages/2018/src/components/CardDetailPage.js
@@ -4,7 +4,7 @@ import CardRegistry from '../card-registry';
 import { PageLayout } from '@hackoregon/component-library';
 
 const CardDetailPage = ({ params }) => {
-  const card = CardRegistry.find(c => c.slug === params.slug);
+  const card = CardRegistry.find(params.slug);
 
   if (card && card.component) {
     const CardComponent = card.component;

--- a/packages/2018/src/index.js
+++ b/packages/2018/src/index.js
@@ -56,6 +56,7 @@ import SandboxPage from './components/SandboxPage';
 import PortlandCollectionPage from './components/PortlandCollectionPage';
 import CityNotFoundPage from './components/CityNotFoundPage';
 import StateNotFoundPage from './components/StateNotFoundPage';
+import CardDetailPage from './components/CardDetailPage';
 
 // Create a store by combining all project reducers and the routing reducer
 const configureStore = (initialState, history) => {
@@ -178,6 +179,10 @@ const routes = {
     {
       path: 'states/:state',
       component: StateNotFoundPage,
+    },
+    {
+      path: 'cards/:slug',
+      component: CardDetailPage,
     },
     {
       path: 'sandbox',

--- a/packages/2018/src/utils/registry.js
+++ b/packages/2018/src/utils/registry.js
@@ -1,0 +1,53 @@
+export default class Registry {
+  constructor(entries) {
+    this.entries = entries;
+    this.validateEntries();
+  }
+
+  // Ensure that there are no duplicate entries in the registry
+  validateEntries() {
+    const duplicates = [];
+    const slugs = new Set();
+
+    // Track every slug that is in entries more than once
+    this.entries.forEach((entry) => {
+      if (slugs.has(entry.slug)) {
+        duplicates.push(entry.slug);
+      }
+      slugs.add(entry.slug);
+    });
+
+    // Throw errors for every duplicate
+    duplicates.forEach((duplicate) => {
+      const labels = this.entries
+        .filter(entry => entry.slug === duplicate)
+        .map(entry => `${entry.slug}\n\t(${entry.component.displayName}) in ${entry.project}`);
+
+      throw new Error(
+        `Duplicate slugs found. All card slugs must be unique\n\n${labels.join('\n')}\n`
+      );
+    });
+  }
+
+  // Add a new entry to the registry and validate the set
+  add(entry) {
+    this.entries.push(entry);
+    this.validateEntries();
+  }
+
+  // Remove an entry (to have symmetry with Add)
+  remove(entryOrSlug) {
+    const toRemove = typeof entryOrSlug === 'string'
+      ? this.entries.find(entry => entry.slug === entryOrSlug)
+      : this.entries.find(entry => entry === entryOrSlug);
+
+    if (toRemove) {
+      this.entries.splice(this.entries.indexOf(toRemove), 1);
+    }
+  }
+
+  // Get an entry by slug
+  find(slug) {
+    return this.entries.find(entry => entry.slug === slug);
+  }
+}

--- a/packages/2018/src/utils/registry.js
+++ b/packages/2018/src/utils/registry.js
@@ -1,7 +1,11 @@
 export default class Registry {
   constructor(entries) {
-    this.entries = entries;
+    this.entries = entries.slice();
     this.validateEntries();
+  }
+
+  get length() {
+    return this.entries.length;
   }
 
   // Ensure that there are no duplicate entries in the registry
@@ -17,16 +21,22 @@ export default class Registry {
       slugs.add(entry.slug);
     });
 
-    // Throw errors for every duplicate
+    // Throw an error that lists all duplicates
+    const errors = [];
+
     duplicates.forEach((duplicate) => {
       const labels = this.entries
         .filter(entry => entry.slug === duplicate)
         .map(entry => `${entry.slug}\n\t(${entry.component.displayName}) in ${entry.project}`);
 
-      throw new Error(
-        `Duplicate slugs found. All card slugs must be unique\n\n${labels.join('\n')}\n`
-      );
+      errors.push(labels.join('\n'));
     });
+
+    if (errors.length) {
+      throw new Error(
+        `Duplicate slugs found. All card slugs must be unique\n\n${errors.join('\n\n')}\n`
+      );
+    }
   }
 
   // Add a new entry to the registry and validate the set

--- a/packages/2018/src/utils/registry.test.js
+++ b/packages/2018/src/utils/registry.test.js
@@ -1,0 +1,153 @@
+import React from 'react';
+import Registry from './registry';
+
+const ComponentOne = () => <div />;
+ComponentOne.displayName = 'ComponentOne';
+
+const ComponentTwo = () => <div />;
+ComponentTwo.displayName = 'ComponentTwo';
+
+const commonEntries = [
+  {
+    slug: 'slug-one',
+    component: ComponentOne,
+    project: '@hackoregon/project-one',
+  },
+  {
+    slug: 'slug-two',
+    component: ComponentTwo,
+    project: '@hackoregon/project-two',
+  },
+];
+
+describe('Registry class', () => {
+  describe('The constructor', () => {
+    it('takes a list of entries', () => {
+      const registry = new Registry(commonEntries);
+
+      expect(registry).to.have.lengthOf(commonEntries.length);
+    });
+
+    describe('when the entires contains duplicates', () => {
+      it('throws an error', () => {
+        const makeRegistry = () => new Registry(commonEntries.concat([
+          {
+            slug: 'slug-one',
+            component: ComponentTwo,
+            project: '@hackoregon/project-three',
+          },
+        ]));
+
+        expect(makeRegistry).to.throw(
+`Duplicate slugs found. All card slugs must be unique
+
+slug-one
+\t(ComponentOne) in @hackoregon/project-one
+slug-one
+\t(ComponentTwo) in @hackoregon/project-three
+`
+        );
+      });
+
+      it('throws an error for every duplicate', () => {
+        const makeRegistry = () => new Registry(commonEntries.concat([
+          {
+            slug: 'slug-one',
+            component: ComponentTwo,
+            project: '@hackoregon/project-three',
+          },
+          {
+            slug: 'slug-two',
+            component: ComponentOne,
+            project: '@hackoregon/project-four',
+          },
+        ]));
+
+        expect(makeRegistry).to.throw(
+`Duplicate slugs found. All card slugs must be unique
+
+slug-one
+\t(ComponentOne) in @hackoregon/project-one
+slug-one
+\t(ComponentTwo) in @hackoregon/project-three
+
+slug-two
+\t(ComponentTwo) in @hackoregon/project-two
+slug-two
+\t(ComponentOne) in @hackoregon/project-four
+`
+        );
+      });
+    });
+  });
+
+  describe('The add method', () => {
+    it('takes an entry', () => {
+      const registry = new Registry(commonEntries);
+
+      registry.add({
+        slug: 'slug-three',
+        component: ComponentTwo,
+        project: '@hackoregon/project-three',
+      });
+
+      expect(registry).to.have.lengthOf(commonEntries.length + 1);
+    });
+
+    describe('when the entry is a duplicate of an existing entry', () => {
+      it('throws an error', () => {
+        const registry = new Registry(commonEntries);
+
+        const addDuplicate = () => registry.add({
+          slug: 'slug-one',
+          component: ComponentTwo,
+          project: '@hackoregon/project-three',
+        });
+
+        expect(addDuplicate).to.throw(
+`Duplicate slugs found. All card slugs must be unique
+
+slug-one
+\t(ComponentOne) in @hackoregon/project-one
+slug-one
+\t(ComponentTwo) in @hackoregon/project-three
+`
+        );
+      });
+    });
+  });
+
+  describe('The remove method', () => {
+    it('takes a slug and removes the matching entry', () => {
+      const registry = new Registry(commonEntries);
+      registry.remove('slug-one');
+      expect(registry).to.have.lengthOf(commonEntries.length - 1);
+      expect(registry.entries.map(e => e.slug)).not.to.include('slug-one');
+    });
+
+    it('takes an object and removes the matching entry', () => {
+      const registry = new Registry(commonEntries);
+      registry.remove(commonEntries[0]);
+      expect(registry).to.have.lengthOf(commonEntries.length - 1);
+      expect(registry.entries.map(e => e.slug)).not.to.include('slug-one');
+    });
+
+    it('does nothing when there is no match', () => {
+      const registry = new Registry(commonEntries);
+      registry.remove('something-that-does-not-exist');
+      expect(registry).to.have.lengthOf(commonEntries.length);
+    });
+  });
+
+  describe('The find method', () => {
+    it('takes a slug and returns the matching entry', () => {
+      const registry = new Registry(commonEntries);
+      expect(registry.find('slug-one')).to.deep.equal(commonEntries[0]);
+    });
+
+    it('returns undefined when there is no matching entry', () => {
+      const registry = new Registry(commonEntries);
+      expect(registry.find('something-that-does-not-exist')).to.be.undefined;
+    });
+  });
+});

--- a/packages/2018/tools/testSetup.js
+++ b/packages/2018/tools/testSetup.js
@@ -1,0 +1,45 @@
+/* eslint-disable import/no-extraneous-dependencies */
+process.env.NODE_ENV = 'test';
+
+const identity = require('ramda').identity;
+
+['.css', '.png', '.jpg', '.svg', '.gif'].forEach((ext) => {
+  require.extensions[ext] = identity;
+});
+
+require('babel-register')();
+
+const chai           = require('chai');
+const sinon          = require('sinon');
+const jsdom          = require('jsdom').jsdom;
+const sinonChai      = require('sinon-chai');
+const chaiEnzyme     = require('chai-enzyme');
+const chaiAsPromised = require('chai-as-promised');
+
+const exposedProperties = ['window', 'navigator', 'document'];
+
+global.document = jsdom('');
+
+chai.should();
+chai.use(sinonChai);
+chai.use(chaiEnzyme());
+chai.use(chaiAsPromised);
+
+global.navigator = {
+  userAgent: 'node.js',
+  platform: 'Node',
+};
+global.assert = chai.assert;
+global.expect = chai.expect;
+global.chai   = chai;
+global.sinon  = sinon;
+global.window = document.defaultView;
+
+Object.keys(document.defaultView).forEach((property) => {
+  if (typeof global[property] === 'undefined') {
+    exposedProperties.push(property);
+    global[property] = document.defaultView[property];
+  }
+});
+
+documentRef = document;  // eslint-disable-line no-undef

--- a/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
@@ -34,7 +34,7 @@ const titleClass = css`
   margin-bottom:1em;
 `;
 
-const CivicStoryCard = ({ cardId, collectionId, title, children }) => (
+const CivicStoryCard = ({ slug, title, children }) => (
   <div className={cardClass}>
     <div className={watermarkContainer}>
       <svg width="134" height="135" xmlns="http://www.w3.org/2000/svg">
@@ -48,7 +48,7 @@ const CivicStoryCard = ({ cardId, collectionId, title, children }) => (
     <div className={descriptionClass}>
       {children}
     </div>
-    <CivicStoryFooter cardId={cardId} collectionId={collectionId} />
+    <CivicStoryFooter slug={slug} />
   </div>
 );
 
@@ -56,8 +56,7 @@ CivicStoryCard.displayName = 'CivicStoryCard';
 
 CivicStoryCard.propTypes = {
   title: PropTypes.string,
-  cardId: PropTypes.string,
-  collectionId: PropTypes.string,
+  slug: PropTypes.string,
   children: PropTypes.node,
 };
 

--- a/packages/component-library/src/CivicStoryCard/CivicStoryCard.test.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryCard.test.js
@@ -3,15 +3,14 @@ import { shallow } from 'enzyme';
 import CivicStoryCard from './CivicStoryCard';
 
 describe('CivicStoryCard', () => {
-  const { title, cardId, collectionId } = {
+  const { title, slug } = {
     title: 'Test Story Card Title',
-    cardId: 'card1',
-    collectionId: 'collection1',
+    slug: 'card1',
   };
 
   describe('common properties', () => {
     const wrapper = shallow(
-      <CivicStoryCard cardId={cardId} collectionId={collectionId} title={title} />,
+      <CivicStoryCard slug={slug} title={title} />,
     );
 
     it('should render the title as an h2', () => {
@@ -23,14 +22,13 @@ describe('CivicStoryCard', () => {
     it('should include a StoryFooter that references this CivicStoryCard', () => {
       const footer = wrapper.find('StoryFooter');
 
-      expect(footer.props().cardId).to.equal(cardId);
-      expect(footer.props().collectionId).to.equal(collectionId);
+      expect(footer.props().slug).to.equal(slug);
     });
   });
 
   describe('card children', () => {
     const wrapper = shallow(
-      <CivicStoryCard cardId={cardId} collectionId={collectionId} title={title}>
+      <CivicStoryCard slug={slug} title={title}>
         <div className="Description">Some content</div>
         <div>
           Some other stuff

--- a/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
@@ -24,13 +24,11 @@ const alignRight = css`
 export default class StoryFooter extends Component {
 
   static defaultProps = {
-    cardId: 'some-card-id',
-    collectionId: 'some-collection-id',
+    slug: 'some-card-id',
   }
 
   static propTypes = {
-    cardId: PropTypes.string,
-    collectionId: PropTypes.string,
+    slug: PropTypes.string,
   }
 
   constructor(props) {
@@ -45,22 +43,22 @@ export default class StoryFooter extends Component {
   switchState = ms => setTimeout(this.setToFalse, ms);
 
   handleCopy = () => {
-    const { collectionId, cardId } = this.props;
+    const { slug } = this.props;
     // NOTE: we need to make sure this will work on all browsers
-    copy(`${window.location.origin}/${collectionId}/${cardId}`);
+    copy(`${window.location.origin}/cards/${slug}`);
     this.switchState(MS_TO_SWITCH_TEXT);
     this.setState({ copied: true });
   }
 
   render() {
-    const { collectionId, cardId } = this.props;
+    const { slug } = this.props;
     const shareTxt = this.state.copied ? 'Link copied!' : 'Share card'; // if copied, show Link copied, otherwise, show Share card
     const shareIcon = this.state.copied ? ICONS.check : ICONS.link;
     return (
       <div className={actionsClass}>
-        <CivicStoryLink route={`/${collectionId}/${cardId}`} icon={ICONS.info}>Source</CivicStoryLink>
+        <CivicStoryLink route={`/cards/${slug}`} icon={ICONS.info}>Source</CivicStoryLink>
         <div className={alignRight}>
-          <CivicStoryLink additionalClassName={alignRight} route={`/${collectionId}/${cardId}`} icon={ICONS.eye}>View card</CivicStoryLink>
+          <CivicStoryLink additionalClassName={alignRight} route={`/cards/${slug}`} icon={ICONS.eye}>View card</CivicStoryLink>
           <CivicStoryLink additionalClassName={alignRight} action={this.handleCopy} icon={shareIcon}>{shareTxt}</CivicStoryLink>
         </div>
       </div>


### PR DESCRIPTION
This is the implementation of the Card Routes RFC proposed in #182. 

The interesting bits are in the 2018 package, but every package needed to be updated to include a card registry, and every card needed to be updated to include the correct slug to build the correct link.

If the registry detects duplicate slugs an error is immediately thrown and the app won't render. I tried making the error as helpful as possible. It looks like this:

<img width="531" alt="screen shot 2018-06-12 at 11 07 09 am" src="https://user-images.githubusercontent.com/174740/41308766-b95d02c6-6e31-11e8-81b6-8b61106faa30.png">

Closes #182 

