### PR TITLE
Add missing mobile meta tag

### DIFF
--- a/packages/2018/server/index.js
+++ b/packages/2018/server/index.js
@@ -24,6 +24,7 @@ app.get('/*', (req, res) => console.log('Servicing request for', req.url) || res
   <head>
     <title>Civic 2018 - A Hack Oregon Project</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta charset="utf-8"/>
     <style>html, body { padding: 0; margin: 0; }</style>
     <!-- FontAwesome -->

--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -84,6 +84,7 @@ module.exports = function() {
     <head>
       <title>Civic 2017 - A Hack Oregon Project</title>
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <meta name="viewport" content="width=device-width,initial-scale=1">
       <meta charset="utf-8"/>
       <style>html, body { padding: 0; margin: 0; }</style>
       <!-- FontAwesome -->


### PR DESCRIPTION
The mobile styles for the header and navigation have gone unutilized due to this missing meta tag.

**Before**
<img width="451" alt="screen shot 2018-06-12 at 7 31 22 pm" src="https://user-images.githubusercontent.com/174740/41327240-863b38ae-6e77-11e8-9016-0c223d537bb6.png">


**After**
<img width="462" alt="screen shot 2018-06-12 at 7 30 55 pm" src="https://user-images.githubusercontent.com/174740/41327244-8a09c2b6-6e77-11e8-9757-5142e03e3efb.png">

Still not the best mobile experience, but definitely better.