### PR TITLE
Feature/horizontal bar chart improvements

### DIFF
--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
@@ -10,12 +10,23 @@ import {
 } from 'victory';
 
 import ChartContainer from '../ChartContainer';
-import { dollars, numeric } from '../utils/formatters';
+import { numeric, unformatted } from '../utils/formatters';
 import { chartEvents } from '../utils/chartHelpers';
 import CivicVictoryTheme from '../VictoryTheme/VictoryThemeIndex';
 
-const HorizontalBarChart = ({ data, sortOrder, dataValue, dataLabel, domain, title, subtitle, xLabel, yLabel, xNumberFormatter }) => {
-
+const HorizontalBarChart = ({
+    data,
+    sortOrder,
+    dataValue,
+    dataLabel,
+    domain,
+    title,
+    subtitle,
+    xLabel,
+    yLabel,
+    dataValueFormatter,
+    dataLabelFormatter,
+}) => {
   const barData =
     sortOrder && sortOrder.length
       ? data
@@ -41,13 +52,13 @@ const HorizontalBarChart = ({ data, sortOrder, dataValue, dataLabel, domain, tit
           // tickValues specifies both the number of ticks and where
           // they are placed on the axis
           tickValues={barData.map(a => a[sortOrderKey])}
-          tickFormat={barData.map(a => a[dataLabel])}
+          tickFormat={barData.map(a => dataLabelFormatter(a[dataLabel]))}
           title="Y Axis"
         />
         <VictoryAxis
           // tickFormat specifies how ticks should be displayed
           orientation="top"
-          tickFormat={xNumberFormatter}
+          tickFormat={dataValueFormatter}
           title="X Axis"
         />
         <VictoryPortal>
@@ -84,7 +95,7 @@ const HorizontalBarChart = ({ data, sortOrder, dataValue, dataLabel, domain, tit
               theme={CivicVictoryTheme.civic}
             />
           }
-          data={barData.map(d => ({ sortOrder: d[sortOrderKey], dataValue: d[dataValue], label: `${d[dataLabel]}: ${xNumberFormatter(d[dataValue])}` }))}
+          data={barData.map(d => ({ sortOrder: d[sortOrderKey], dataValue: d[dataValue], label: `${d[dataLabel]}: ${dataValueFormatter(d[dataValue])}` }))}
           title="Horizontal Bar Chart"
           x="sortOrder"
           y="dataValue"
@@ -107,7 +118,8 @@ HorizontalBarChart.propTypes = {
   subtitle: PropTypes.string,
   xLabel: PropTypes.string,
   yLabel: PropTypes.string,
-  xNumberFormatter: PropTypes.func,
+  dataValueFormatter: PropTypes.func,
+  dataLabelFormatter: PropTypes.func,
 };
 
 HorizontalBarChart.defaultProps = {
@@ -120,7 +132,8 @@ HorizontalBarChart.defaultProps = {
   subtitle: null,
   xLabel: "X",
   yLabel: "Y",
-  xNumberFormatter: numeric,
+  dataValueFormatter: numeric,
+  dataLabelFormatter: unformatted,
 };
 
 export default HorizontalBarChart;

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
@@ -7,6 +7,7 @@ import {
   VictoryLabel,
   VictoryPortal,
   VictoryTooltip,
+  Bar,
 } from 'victory';
 
 import ChartContainer from '../ChartContainer';
@@ -26,6 +27,7 @@ const HorizontalBarChart = ({
     yLabel,
     dataValueFormatter,
     dataLabelFormatter,
+    minimalist,
 }) => {
   const barData =
     sortOrder && sortOrder.length
@@ -33,34 +35,44 @@ const HorizontalBarChart = ({
       : data.map((d, index) => {
         return { ...d, defaultSort: index + 1 };
       });
-
   const sortOrderKey =
     sortOrder && sortOrder.length
       ? sortOrder
       : 'defaultSort';
+  const padding =
+    minimalist
+      ? { left: 115, right: 50, bottom: 25, top: 40 }
+      : { left: 115, right: 50, bottom: 50, top: 70 };
+  const bars = data.length;
+  const spaces = bars - 1;
+  const barHeight = CivicVictoryTheme.civic.bar.style.data.width;
+  const spaceHeight = CivicVictoryTheme.civic.bar.style.data.padding * 2;
+  const dataHeight = (bars * barHeight) + (spaces * spaceHeight);
+  const additionalHeight = padding.bottom + padding.top;
 
   return (
     <ChartContainer title={title} subtitle={subtitle}>
       <VictoryChart
+        height={dataHeight + additionalHeight}
         domain={domain}
-        padding={{ left: 115, right: 50, bottom: 50, top: 70 }}
+        padding={padding}
         domainPadding={0}
         theme={CivicVictoryTheme.civic}
       >
         <VictoryAxis
           dependentAxis
-          // tickValues specifies both the number of ticks and where
-          // they are placed on the axis
           tickValues={barData.map(a => a[sortOrderKey])}
           tickFormat={barData.map(a => dataLabelFormatter(a[dataLabel]))}
           title="Y Axis"
         />
+      {!minimalist && (
         <VictoryAxis
-          // tickFormat specifies how ticks should be displayed
           orientation="top"
           tickFormat={dataValueFormatter}
           title="X Axis"
         />
+      )}
+      {!minimalist && (
         <VictoryPortal>
           <VictoryLabel
             style={{ ...CivicVictoryTheme.civic.axisLabel.style }}
@@ -72,15 +84,16 @@ const HorizontalBarChart = ({
             y={65}
           />
         </VictoryPortal>
+      )}
         <VictoryPortal>
           <VictoryLabel
             style={{ ...CivicVictoryTheme.civic.axisLabel.style }}
             text={xLabel}
-            textAnchor="end"
+            textAnchor={minimalist ? 'middle' : 'end'}
             title="X Axis Label"
-            verticalAnchor="end"
-            x={600}
-            y={85}
+            verticalAnchor={minimalist ? 'middle' : 'end'}
+            x={minimalist ? 325 : 600}
+            y={minimalist ? 20 : 85}
           />
         </VictoryPortal>
         <VictoryBar
@@ -120,6 +133,7 @@ HorizontalBarChart.propTypes = {
   yLabel: PropTypes.string,
   dataValueFormatter: PropTypes.func,
   dataLabelFormatter: PropTypes.func,
+  minimalist: PropTypes.boolean,
 };
 
 HorizontalBarChart.defaultProps = {
@@ -134,6 +148,7 @@ HorizontalBarChart.defaultProps = {
   yLabel: "Y",
   dataValueFormatter: numeric,
   dataLabelFormatter: unformatted,
+  minimalist: false,
 };
 
 export default HorizontalBarChart;

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.test.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.test.js
@@ -63,6 +63,28 @@ describe('HorizontalBarChart', () => {
     ]);
   });
 
+  it('should render a VictoryBar inside a ChartContainer', () => {
+    const wrapper = shallow(<HorizontalBarChart data={simpleData} />);
+    expect(wrapper.find('ChartContainer')).to.have.length(1);
+    expect(wrapper.find('ChartContainer').children().find('VictoryBar')).to.have.length(1);
+  });
+
+  it('conditionally passes title to ChartContainer', () => {
+    const sampleTitle = 'Hey there';
+    const titlelessWrapper = shallow(<HorizontalBarChart data={simpleData} />);
+    const titledWrapper = shallow(<HorizontalBarChart data={simpleData} title={sampleTitle} />);
+    expect(titlelessWrapper.find('ChartContainer').prop('title')).to.equal(null);
+    expect(titledWrapper.find('ChartContainer').prop('title')).to.equal(sampleTitle);
+  });
+
+  it('conditionally passes subtitle to ChartContainer', () => {
+    const sampleSubtitle = 'Almost as good as a title!';
+    const noSubtitleWrapper = shallow(<HorizontalBarChart data={simpleData} />);
+    const subtitleWrapper = shallow(<HorizontalBarChart data={simpleData} subtitle={sampleSubtitle} />);
+    expect(noSubtitleWrapper.find('ChartContainer').prop('subtitle')).to.equal(null);
+    expect(subtitleWrapper.find('ChartContainer').prop('subtitle')).to.equal(sampleSubtitle);
+  });
+
   it('renders both axes', () => {
     const wrapper = shallow(<HorizontalBarChart data={simpleData} />);
 
@@ -73,6 +95,13 @@ describe('HorizontalBarChart', () => {
     expect(axes.length).to.eql(2);
     expect(xAxis.length).to.eql(1);
     expect(yAxis.length).to.eql(1);
+  });
+
+  it('renders two axis and a VictoryBar within VictoryChart', () => {
+    const wrapper = shallow(<HorizontalBarChart data={simpleData} />);
+    const victoryComponents = wrapper.find('VictoryChart').children();
+    expect(victoryComponents.find('VictoryAxis')).to.have.length(2);
+    expect(victoryComponents.find('VictoryBar')).to.have.length(1);
   });
 
   it('should properly set a domain if provided with one', () => {
@@ -94,5 +123,19 @@ describe('HorizontalBarChart', () => {
       { sortOrder: 2, dataValue: 8000, label: "Standard Poodle: 8,000" },
       { sortOrder: 3, dataValue: 6000, label: "French Bulldog: 6,000" },
     ]);
+  });
+
+  it('sends in data in usable format', () => {
+    const wrapper = shallow(<HorizontalBarChart data={simpleData} />);
+    const dataProp = wrapper.find('VictoryBar').prop('data');
+    expect(dataProp).to.have.length(4);
+    const firstDataProp = dataProp[0];
+    expect(firstDataProp).to.have.property('sortOrder');
+    expect(firstDataProp).to.have.property('dataValue');
+    expect(firstDataProp).to.have.property('label');
+    const xProp = wrapper.find('VictoryBar').prop('x');
+    const yProp = wrapper.find('VictoryBar').prop('y');
+    expect(xProp).to.eql('sortOrder');
+    expect(yProp).to.eql('dataValue');
   });
 });

--- a/packages/component-library/src/VictoryTheme/CivicVictoryTheme.js
+++ b/packages/component-library/src/VictoryTheme/CivicVictoryTheme.js
@@ -3,13 +3,11 @@ import { assign } from "lodash";
 // *
 // * Colors
 // *
-const civicPrimary = "#201024";
-const civicSecondary = "#706371";
-const civicTertiary = "#EE495C";
-const civicSecondaryLighter = "AAA4AB";
-const civicSecondaryLightest = "F3F2F3";
-
-
+const civicPrimary = "#1f1123";
+const civicSecondary = "#eb4d5f";
+const civicTertiary = "#716470";
+const civicSecondaryLighter = "aaa4ab";
+const civicSecondaryLightest = "f3f2f3";
 
 const civicCategoricalColor1 = "#DC4556";
 const civicCategoricalColor2 = "#19B7AA";
@@ -49,6 +47,7 @@ const fontWeight = "normal";
 // * Layout
 // *
 const padding = 8;
+const horizontalBarPadding = 2;
 const baseProps = {
   width: 650,
   height: 350,
@@ -141,11 +140,11 @@ export default {
   bar: assign({
     style: {
       data: {
-        fill: "#756172",
-        padding,
+        fill: civicPrimary,
+        padding: horizontalBarPadding,
         stroke: "transparent",
         strokeWidth: 0,
-        width: 40
+        width: 40,
       },
       labels: baseLabelStyles
     }
@@ -247,6 +246,7 @@ export default {
         strokeWidth: 0
       },
       labels: centeredLabelStyles,
+      customHoverColor: civicSecondary,
     },
     flyoutStyle: {
       stroke: "transparent",
@@ -256,7 +256,7 @@ export default {
     flyoutProps: {
       cornerRadius: 10,
       pointerLength: 10
-    }
+    },
   }, tooltipProps),
   voronoi: assign({
     style: {

--- a/packages/component-library/src/VictoryTheme/CivicVictoryTheme.js
+++ b/packages/component-library/src/VictoryTheme/CivicVictoryTheme.js
@@ -140,7 +140,7 @@ export default {
   bar: assign({
     style: {
       data: {
-        fill: civicPrimary,
+        fill: civicTertiary,
         padding: horizontalBarPadding,
         stroke: "transparent",
         strokeWidth: 0,

--- a/packages/component-library/src/utils/chartHelpers.js
+++ b/packages/component-library/src/utils/chartHelpers.js
@@ -1,5 +1,7 @@
 import CivicVictoryTheme from '../VictoryTheme/VictoryThemeIndex';
 
+const tooltipColor = CivicVictoryTheme.civic.tooltip.style.customHoverColor;
+
 const chartEvents = [
   {
     target: 'data',
@@ -8,7 +10,7 @@ const chartEvents = [
         return [
           {
             target: 'data',
-            mutation: () => ({ style: { fill: 'tomato', width: 40 } }),
+            mutation: () => ({ style: { fill: tooltipColor, width: 40 } }),
           }, {
             target: 'labels',
             mutation: () => ({ active: true }),

--- a/packages/component-library/src/utils/formatters.js
+++ b/packages/component-library/src/utils/formatters.js
@@ -37,3 +37,4 @@ export const numeric = (d) => {
 export const year = format('.0f');
 export const percentage = format('.0%');
 export const dollars = d => `$${d}`;
+export const unformatted = d => d;

--- a/packages/component-library/stories/HorizontalBarChart.story.js
+++ b/packages/component-library/stories/HorizontalBarChart.story.js
@@ -23,6 +23,11 @@ const sampleData = [
       {sortOrder: 5, population: 1000, label: 'Jack Russell Terrier'},
     ];
 
+const sampleMinimalistData = [
+      {sortOrder: 1, population: 2000, label: 'Labrador Retriever'},
+      {sortOrder: 2, population: 8000, label: 'Standard Poodle'},
+    ];
+
 const sampleUnsortedData = [
       {population: 2000, label: 'Labrador Retriever'},
       {population: 8000, label: 'Standard Poodle'},
@@ -40,12 +45,12 @@ export default () => storiesOf(displayName, module)
     const dataLabel = text('Data series labels', 'label');
 
     return (
-        <HorizontalBarChart
-          data={data}
-          dataValue={dataValue}
-          dataLabel={dataLabel}
-        />
-      );
+      <HorizontalBarChart
+        data={data}
+        dataValue={dataValue}
+        dataLabel={dataLabel}
+      />
+    );
   })
   .add('No title', () => {
     const data = object('Data', sampleData);
@@ -54,13 +59,29 @@ export default () => storiesOf(displayName, module)
     const dataLabel = text('Data series labels', 'label');
 
     return (
-        <HorizontalBarChart
-          data={data}
-          sortOrder={sortOrder}
-          dataValue={dataValue}
-          dataLabel={dataLabel}
-        />
-      );
+      <HorizontalBarChart
+        data={data}
+        sortOrder={sortOrder}
+        dataValue={dataValue}
+        dataLabel={dataLabel}
+      />
+    );
+  })
+  .add('minimalist', () => {
+    const data = object('Data', sampleMinimalistData);
+    const sortOrder = text('Data series', 'sortOrder');
+    const dataValue = text('Data values', 'population');
+    const dataLabel = text('Data series labels', 'label');
+
+    return (
+      <HorizontalBarChart
+        data={data}
+        sortOrder={sortOrder}
+        dataValue={dataValue}
+        dataLabel={dataLabel}
+        minimalist
+      />
+    );
   })
   .add('Basic Usage', () => {
     const data = object('Data', sampleData);


### PR DESCRIPTION
Improvements to the horizontal bar chart including:

- Incorporating @AlexanderNull's tests and labelFormatter improvements from #137 and #202
- Synchronize prop naming for consistency with other charts
- Dynamically set height based on number of items
- Styling updates to the Civic theme, including changing hover color to use platform color and tighter spacing
- Added a "minimalist" prop for use in the Sandbox

minimalist:
<img width="841" alt="screen shot 2018-06-15 at 5 19 35 pm" src="https://user-images.githubusercontent.com/7065695/41493834-67214864-70c0-11e8-9534-784cccd5bc30.png">
![image](https://user-images.githubusercontent.com/7065695/41493835-68b08942-70c0-11e8-8c71-7abc11ee044d.png)

normal:
<img width="857" alt="screen shot 2018-06-15 at 5 21 34 pm" src="https://user-images.githubusercontent.com/7065695/41493843-9c575690-70c0-11e8-9f14-a0e2ce518ca4.png">


