### PR TITLE
Set default mapbox token for BaseMap

### DIFF
--- a/packages/2018-example-farmers-markets/src/components/PortlandFarmersMarkets/index.js
+++ b/packages/2018-example-farmers-markets/src/components/PortlandFarmersMarkets/index.js
@@ -35,9 +35,6 @@ const mapWrapper = css`
   display: block;
 `;
 
-// Use Hack Oregon official mapbox token eventually
-const mapboxToken = 'pk.eyJ1IjoidGhlbWVuZG96YWxpbmUiLCJhIjoiY2o1aXdoem1vMWtpNDJ3bnpqaGF1bnlhNSJ9.sjTrNKLW9daDBIGvP3_W0w';
-
 export class PortlandFarmersMarkets extends React.Component {
   componentDidMount() {
     this.props.init();
@@ -63,7 +60,7 @@ export class PortlandFarmersMarkets extends React.Component {
         slug="portland-farmers-markets"
       >
         <div className={mapWrapper}>
-          <BaseMap mapboxToken={mapboxToken} mapboxStyle="mapbox://styles/themendozaline/cj8rrlv4tbtgs2rqnyhckuqva">
+          <BaseMap>
             <ScatterPlotMap
               data={portlandFarmersMarkets.features}
               autoHighlight={false}

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -4,6 +4,8 @@ import { css } from 'emotion';
 import PropTypes from 'prop-types';
 import './mapbox-gl.css';
 
+const MAPBOX_TOKEN = 'pk.eyJ1IjoiaGFja29yZWdvbiIsImEiOiJjamk0MGZhc2cwNDl4M3FsdHAwaG54a3BnIn0.Fq1KA0IUwpeKQlFIoaEn_Q';
+
 const mapWrapper = css`
   margin: 0 auto;
   padding: 0 2.5%;
@@ -123,4 +125,5 @@ BaseMap.propTypes = {
 
 BaseMap.defaultProps = {
   mapboxStyle: "mapbox://styles/hackoregon/cjiazbo185eib2srytwzleplg",
+  mapboxToken: "pk.eyJ1IjoiaGFja29yZWdvbiIsImEiOiJjamk0MGZhc2cwNDl4M3FsdHAwaG54a3BnIn0.Fq1KA0IUwpeKQlFIoaEn_Q",
 };

--- a/packages/component-library/src/BaseMap/BaseMap.test.js
+++ b/packages/component-library/src/BaseMap/BaseMap.test.js
@@ -3,9 +3,10 @@ import { shallow } from 'enzyme';
 import BaseMap from './BaseMap';
 import ScatterPlotMap from '../ScatterPlotMap/ScatterPlotMap';
 
+const MAPBOX_TOKEN = 'pk.eyJ1IjoiaGFja29yZWdvbiIsImEiOiJjamk0MGZhc2cwNDl4M3FsdHAwaG54a3BnIn0.Fq1KA0IUwpeKQlFIoaEn_Q';
+
 describe('BaseMap', () => {
-  const mapboxToken = 'pk.testmapboxtoken.sjTrNKLW9daDBIGvP3_W0w';
-  const defaultProps = { mapboxToken };
+  const defaultProps = { };
 
   it('should render a MapGL component', () => {
     const wrapper = shallow(<BaseMap {...defaultProps} />);
@@ -16,7 +17,7 @@ describe('BaseMap', () => {
   it('should include required prop mapboxApiAccessToken', () => {
     const wrapper = shallow(<BaseMap {...defaultProps} />);
 
-    expect(wrapper.find('.MapGL').prop('mapboxApiAccessToken')).to.eql(defaultProps.mapboxToken);
+    expect(wrapper.find('.MapGL').prop('mapboxApiAccessToken')).to.eql(MAPBOX_TOKEN);
   });
 
   it('should render child NavigationControl component', () => {


### PR DESCRIPTION
You can still pass in a Mapbox token if you want, but now you don't have to!

FAQ: Should we be hiding this? Nah, it’s readable in the source in the browser