### PR TITLE
Fix component library imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ travis:
 		\
 		echo "\n--- 2017 Tests\n"; \
 		cd packages/2017 && yarn test; cd -; \
+		\
+		echo "\n--- Build 2017\n"; \
+		cd packages/2017 && yarn build; cd -; \
 	fi
 
 	@if [ "$$SUITE" = "2018" ]; then \
@@ -43,6 +46,9 @@ travis:
 		\
 		echo "\n--- 2018 Tests\n"; \
 		cd packages/2018 && yarn test; cd -; \
+		\
+		echo "\n--- Build 2018\n"; \
+		cd packages/2018 && yarn build; cd -; \
 	fi
 
 	@if [ "$$SUITE" = "COMPONENT_LIBRARY" ]; then \

--- a/packages/component-library/es/index.js
+++ b/packages/component-library/es/index.js
@@ -44,9 +44,9 @@ export { default as HexOverlay } from './HexOverlay/HexOverlay';
 export { default as BoundaryMap } from './BoundaryMap/BoundaryMap';
 export { default as MapTooltip } from './MapTooltip/MapTooltip';
 export { default as CivicSandboxMap } from './CivicSandboxMap/CivicSandboxMap';
+export { default as PackageSelectorBox } from './PackageSelectorBox/PackageSelectorBox';
 export { default as CanvasParticles } from './LandingPage/CanvasParticles';
 export { default as CivicSandboxDashboard } from './CivicSandboxDashboard/CivicSandboxDashboard';
 export { default as Collapsable } from './Collapsable/Collapsable';
+export { default as Sandbox } from './Sandbox/Sandbox';
 export { default as StackedAreaChart } from './StackedAreaChart/StackedAreaChart';
-
-import './fonts.css';

--- a/packages/component-library/src/Sandbox/Sandbox.js
+++ b/packages/component-library/src/Sandbox/Sandbox.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { Dropdown, BaseMap, CivicSandboxMap } from '../../src';
-import CivicSandboxTooltip from '../../src/CivicSandboxMap/CivicSandboxTooltip';
+import Dropdown from '../Dropdown/Dropdown';
+import BaseMap from '../BaseMap/BaseMap';
+import CivicSandboxMap from '../CivicSandboxMap/CivicSandboxMap';
+import CivicSandboxTooltip from '../CivicSandboxMap/CivicSandboxTooltip';
 import SandboxDrawer from './SandboxDrawer';
 
 const Sandbox = ({

--- a/packages/component-library/src/Sandbox/SandboxDateSelector.js
+++ b/packages/component-library/src/Sandbox/SandboxDateSelector.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { rangeRight } from 'lodash';
-import { Dropdown } from '../../src';
-
+import Dropdown from '../Dropdown/Dropdown';
 
 const dateHelper = (meta) => {
   let dates = [];

--- a/packages/component-library/src/Sandbox/SandboxDrawer.js
+++ b/packages/component-library/src/Sandbox/SandboxDrawer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { Dropdown } from '../../src';
+import Dropdown from '../Dropdown/Dropdown';
 import SandboxDateSelector from './SandboxDateSelector';
 
 const SandboxDrawer = ({


### PR DESCRIPTION
Referencing the `src` directory from within the `src` directory when importing results in the build artifact depending on the un-transpiled source code. This breaks things.

The solution is to use relative paths from components to other components.

I also added `yarn build` to the testing portion of our travis configuration so these types of bugs get caught before merging to master.