### PR TITLE
Bring back the missing fetch-adapter

### DIFF
--- a/packages/2018-housing-affordability/src/state/fetch-adapter.js
+++ b/packages/2018-housing-affordability/src/state/fetch-adapter.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const HOST = 'http://service.civicpdx.org/neighborhood-development/';
+const echo = a => a;
+
+const apiAdapter = (url, { encodeParams, start, success, failure }) => params => (dispatch) => {
+  dispatch(start());
+
+  const encode = encodeParams || echo;
+  const fullURL = encode(HOST + url, params);
+  return axios.get(fullURL).then((res) => {
+    dispatch(success(res.data));
+    return res;
+  }).catch((err) => {
+    dispatch(failure(err));
+  });
+};
+
+export default apiAdapter;


### PR DESCRIPTION
The `fetch-adapter.js` file in the housing package was removed in error. This brings it back and fixes the build 🎉 