### PR TITLE
Quick fix to neighborhoods - extend root selector

### DIFF
--- a/packages/2018-neighborhood-development/src/state/class-size-and-quality/selectors.js
+++ b/packages/2018-neighborhood-development/src/state/class-size-and-quality/selectors.js
@@ -38,7 +38,10 @@ export const getErrors = createSelector(
   ({ error }) => error,
 );
 
-export const getSelectedYear = state => state.classSizeAndQuality.selectedYear;
+export const getSelectedYear = createSelector(
+  getClassSizeAndQualityDomain,
+  ({ selectedYear }) => selectedYear,
+);
 
 export const getDataForSelectedYear = createSelector(
   getClassSizeAndQualityData,


### PR DESCRIPTION
Looks like a selector that didn't extend the root selector slipped into #317 - probably originating from when I did this on an earlier - doing this will break the project package when you're running the 2018 package.

Easy to do, so make sure to watch out for this.

I don't think our tests currently catch this - I ran tests for the 2018 and 2018-neighborhood-development packages and they pass, so I don't think this is a Travis issue, but tagging @DingoEatingFuzz anyways.