### PR TITLE
updates selector to get packages directly

### DIFF
--- a/packages/2018/src/index.js
+++ b/packages/2018/src/index.js
@@ -75,6 +75,7 @@ const configureStore = (initialState, history) => {
       neighborhood: NeighborhoodReducers(),
       transportation: TransportationReducers(),
       farmersMarkets: FarmersMarketsReducers(),
+      sandbox: SandboxReducers(),
     }),
     initialState,
     composeEnhancers(applyMiddleware(...middlewares))

--- a/packages/civic-sandbox/src/components/Packages/index.js
+++ b/packages/civic-sandbox/src/components/Packages/index.js
@@ -11,8 +11,8 @@ import {
 } from '../../state/sandbox/actions';
 import {
   isSandboxLoading,
+  getSandboxData,
   getSandboxError,
-  getPackages,
 } from '../../state/sandbox/selectors';
 
 const loader = css`
@@ -55,10 +55,10 @@ export class Packages extends React.Component {
     const {
       isLoading,
       isError,
-      packages,
+      sandbox,
     } = this.props;
 
-    const packageList = packages ? Object.keys(packages).map(p => ({ description: packages[p].description, title: capitalize(p) })) : [];
+    const packages = sandbox.packages ? Object.keys(sandbox.packages).map(p => ({ description: sandbox.packages[p].description, title: capitalize(p) })) : [];
 
     const Loader = () => <div className={loader}>Loading...</div>;
     const ErrorMessage = () => <div className={error}>Could not load data for the sandbox.</div>;
@@ -83,7 +83,7 @@ export class Packages extends React.Component {
           }`)}
         >
           {isLoading && <Loader />}
-          {packageList && (packageList.map(p => (<div
+          {packages && (packages.map(p => (<div
             key={p.title}
             className={css(`@media(min-width: 600px) {
             width: 33%;
@@ -153,7 +153,7 @@ export default connect(
   state => ({
     isLoading: isSandboxLoading(state),
     isError: getSandboxError(state),
-    packages: getPackages(state),
+    sandbox: getSandboxData(state),
   }),
   dispatch => ({
     fetchSandbox() {

--- a/packages/civic-sandbox/src/components/Packages/index.js
+++ b/packages/civic-sandbox/src/components/Packages/index.js
@@ -11,8 +11,8 @@ import {
 } from '../../state/sandbox/actions';
 import {
   isSandboxLoading,
-  getSandboxData,
   getSandboxError,
+  getPackages,
 } from '../../state/sandbox/selectors';
 
 const loader = css`
@@ -55,10 +55,10 @@ export class Packages extends React.Component {
     const {
       isLoading,
       isError,
-      sandbox,
+      packages,
     } = this.props;
 
-    const packages = sandbox.packages ? Object.keys(sandbox.packages).map(p => ({ description: sandbox.packages[p].description, title: capitalize(p) })) : [];
+    const packageList = packages ? Object.keys(packages).map(p => ({ description: packages[p].description, title: capitalize(p) })) : [];
 
     const Loader = () => <div className={loader}>Loading...</div>;
     const ErrorMessage = () => <div className={error}>Could not load data for the sandbox.</div>;
@@ -83,7 +83,7 @@ export class Packages extends React.Component {
           }`)}
         >
           {isLoading && <Loader />}
-          {packages && (packages.map(p => (<div
+          {packageList && (packageList.map(p => (<div
             key={p.title}
             className={css(`@media(min-width: 600px) {
             width: 33%;
@@ -153,7 +153,7 @@ export default connect(
   state => ({
     isLoading: isSandboxLoading(state),
     isError: getSandboxError(state),
-    sandbox: getSandboxData(state),
+    packages: getPackages(state),
   }),
   dispatch => ({
     fetchSandbox() {

--- a/packages/civic-sandbox/src/state/sandbox/selectors.js
+++ b/packages/civic-sandbox/src/state/sandbox/selectors.js
@@ -12,12 +12,12 @@ export const getState = createSelector(
 
 export const getSandbox = createSelector(
   rootState,
-  ({ sandbox }) => sandbox
+  ({ sandbox = {} }) => sandbox
 );
 
 const getProperty = key => createSelector(getState, state => state[key]);
 
-const getSandboxProperty = key => createSelector(getSandbox, state => state[key]);
+const getSandboxProperty = key => createSelector(getSandbox, sandbox => sandbox[key]);
 
 export const isSandboxLoading = getProperty('sandboxPending');
 export const isFoundationLoading = getProperty('foundationPending');

--- a/packages/civic-sandbox/src/state/sandbox/selectors.js
+++ b/packages/civic-sandbox/src/state/sandbox/selectors.js
@@ -17,48 +17,49 @@ export const getSandbox = createSelector(
 
 const getProperty = key => createSelector(getState, state => state[key]);
 
-const getSandboxProperty = key => createSelector(getSandbox, sandbox => sandbox[key]);
+const getSandboxProperty = key => createSelector(getSandbox, state => state[key]);
 
-export const isSandboxLoading = getProperty('sandboxPending');
-export const isFoundationLoading = getProperty('foundationPending');
-export const areSlidesLoading = getProperty('slidesPending');
-export const getSandboxError = getProperty('sandboxError');
-export const getSandboxData = getProperty('sandbox');
-export const getFoundations = getProperty('foundations');
-export const getFoundationError = getProperty('foundationError');
-export const getSelectedPackage = getProperty('selectedPackage');
+export const isSandboxLoading = getSandboxProperty('sandboxPending');
+export const isFoundationLoading = getSandboxProperty('foundationPending');
+export const areSlidesLoading = getSandboxProperty('slidesPending');
+export const getSandboxError = getSandboxProperty('sandboxError');
+export const getSandboxData = getSandboxProperty('sandbox');
+export const getFoundations = getSandboxProperty('foundations');
+export const getFoundationError = getSandboxProperty('foundationError');
+export const getSelectedPackage = getSandboxProperty('selectedPackage');
 export const getPackages = getSandboxProperty('packages');
-export const getSlidesSuccess = getProperty('slidesSuccess');
-export const isAnyError = getProperty('foundationError') || getProperty('slidesError');
-export const getSelectedFoundation = getProperty('selectedFoundation');
-export const getSelectedSlides = getProperty('selectedSlide');
+export const getSlidesSuccess = getSandboxProperty('slidesSuccess');
+export const isAnyError = getSandboxProperty('foundationError') || getSandboxProperty('slidesError');
+export const getSelectedFoundation = getSandboxProperty('selectedFoundation');
+export const getSelectedSlides = getSandboxProperty('selectedSlide');
 export const isAllSandboxLoading = isFoundationLoading || areSlidesLoading;
 
 
 export const getSelectedPackageData = createSelector(
-  getState,
-  state => state.sandbox.packages && state.sandbox.packages[state.selectedPackage]
+  getSandboxData,
+  getSelectedPackage,
+  (data, selectedPackage) => data.packages && data.packages[selectedPackage]
 );
 export const getFoundationData = createSelector(
-  getSandbox,
+  getSandboxData,
   getSelectedFoundation,
   (sandbox, foundation) => sandbox.foundations[foundation]
 );
 
 export const getSlidesData = createSelector(
-  getSandbox,
+  getSandboxData,
   getSelectedSlides,
   (sandbox, slides) => isArray(slides) ? slides.map(slide => sandbox.slides[slide]) : [sandbox.slides[slides]]
 );
 
 export const getSelectedFoundationData = createSelector(
-  getState,
-  state => state.foundationData
+  getSandbox,
+  sandbox => sandbox.foundationData
 );
 
 export const getSelectedSlidesData = createSelector(
-  getState,
-  state => state.slidesData
+  getSandbox,
+  sandbox => sandbox.slidesData
 );
 
 


### PR DESCRIPTION
Not sure why the old way wasn't working, as it is fine locally, but trying use a selector for packages will hopefully fix it.

-- update. the state wasn't being added to the 2018 package. and after it was added, selectors needed to be updated to look at the correct level