### PR TITLE
Change from severely burdened to total burdened

### DIFF
--- a/packages/2018-housing-affordability/src/components/RentBurdenedHouseholds/index.js
+++ b/packages/2018-housing-affordability/src/components/RentBurdenedHouseholds/index.js
@@ -72,7 +72,7 @@ export class RentBurdenedHouseholds extends React.Component {
               A rank of 1 is the smallest percentage of burdened households, while a rank of 100 is the greatest percentage of burdened households.
             </p>
             <p>
-              <strong className={gradientLabel}>Less severely burdened</strong>
+              <strong className={gradientLabel}>Less burdened</strong>
               <GradientScale
                 domain={[1, selectedCityRank.total]}
                 primary={selectedCityRank.rank}

--- a/packages/2018-housing-affordability/src/state/rent-burden/selectors.js
+++ b/packages/2018-housing-affordability/src/state/rent-burden/selectors.js
@@ -33,17 +33,15 @@ export const getChartData = createSelector(
     const moderateBurden = +(data.find(d => d.datatype === 'Moderately Burdened Renters, Share of All Households') || _).value;
     const noBurden = 100 - severeBurden - moderateBurden;
 
-    const ret = [
+    return [
       { label: 'Severe Burden', value: severeBurden },
       { label: 'Moderate Burden', value: moderateBurden },
       { label: 'No Burden', value: noBurden },
     ];
-    console.log(ret);
-    return ret;
   }
 );
 
-const rankKey = 'Severely Burdened Renters, Share of All Households';
+const rankKey = 'Total Burdened Renters, Share of All Households';
 
 export const getSelectedCityRank = createSelector(
   getSelectedCityData,


### PR DESCRIPTION
Fixes a bug reported by @kmorrice where the Rend Burden ranker was using the wrong datatype.

Fixes #301