### PR TITLE
Horizontal bar chart styling updates

### DIFF
--- a/packages/component-library/es/BarChart/BarChart.js
+++ b/packages/component-library/es/BarChart/BarChart.js
@@ -43,6 +43,7 @@ var BarChart = function BarChart(_ref) {
       },
       React.createElement(VictoryAxis, {
         tickFormat: xNumberFormatter,
+        style: { grid: { stroke: 'none' } },
         title: 'X Axis'
       }),
       React.createElement(VictoryAxis, {

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
@@ -64,14 +64,15 @@ const HorizontalBarChart = ({
       <VictoryChart
         height={dataHeight + additionalHeight}
         domain={domain}
+        domainPadding={{ x: 20, y: 11 }}
         padding={padding}
         theme={CivicVictoryTheme.civic}
       >
         <VictoryAxis
           dependentAxis
-          domainPadding={{ x: 20 }}
           style={{
             tickLabels: { fill: 'none' },
+            ticks: { stroke: 'none' },
             grid: { stroke: 'none' },
           }}
           title="Y Axis"

--- a/packages/component-library/src/VictoryTheme/CivicVictoryTheme.js
+++ b/packages/component-library/src/VictoryTheme/CivicVictoryTheme.js
@@ -160,7 +160,7 @@ export default {
         padding: horizontalBarPadding,
         stroke: "transparent",
         strokeWidth: 0,
-        width: 40,
+        width: 20,
       },
       labels: baseLabelStyles
     }


### PR DESCRIPTION
Tightens up Horizontal Bar Chart styling, reducing bar width and spacing. Screengrabs of updated styling below.

<img width="1032" alt="screen shot 2018-07-03 at 2 52 25 pm" src="https://user-images.githubusercontent.com/7065695/42246493-ab62a486-7ed1-11e8-9380-dd5e836dcbbc.png">
<img width="1023" alt="screen shot 2018-07-03 at 2 52 46 pm" src="https://user-images.githubusercontent.com/7065695/42246495-ab8e1c92-7ed1-11e8-94c4-17f183482b30.png">

