### PR TITLE
Add tweetblocks

### DIFF
--- a/packages/2018-disaster-resilience/src/components/App/index.js
+++ b/packages/2018-disaster-resilience/src/components/App/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import '@hackoregon/component-library/assets/global.styles.css';
-import { PageLayout } from '@hackoregon/component-library';
+import { PageLayout, PullQuote } from '@hackoregon/component-library';
 import LifeAlteringEvent from '../LifeAlteringEvent';
 import ViolentShakingAndGroundDeformation from '../ViolentShakingAndGroundDeformation';
 import SignificantStructuralDamage from '../SignificantStructuralDamage';
@@ -20,11 +20,17 @@ const App = () => (
     {/* <ViolentShakingAndGroundDeformation /> */}
     {/* <SignificantStructuralDamage /> */}
     {/* <LifeAlteringEvent /> */}
-    <p>The first step in increasing disaster resiliency for most Portlanders will be to understand what the estimated impact is within their immediate vicinity.</p>
+    {/* <p classname="transition">The first step in increasing disaster resiliency for most Portlanders will be to understand what the estimated impact is within their immediate vicinity.</p> */}
     {/* <YouAndYourNeighbors /> */}
+    {/* <p className="transition">Preparedness and disaster resiliency go hand-in-hand.</p> */}
+    <PullQuote
+      quoteText="Does your family have a plan for earthquake preparedness? Here are the steps to help you get started."
+      url="http://civicplatform.org/cards/what-you-can-do-to-prepare-for-an-earthquake"
+    />
     <WhatYouCanDoToPrepare />
+    <p className="transition">Social capital is a statistic derived from measuring community engagement. Disaster resilience, measuring the ability for an entity to bounce back from a crisis and learn from it, increases dramatically when community members engage.</p>
     {/* <IncreasingSocialCapital /> */}
-    <p className="transition">Preparedness and disaster resiliency go hand-in-hand.</p>
+    <PullQuote quoteText="The #1 thing you can do to increase social capital is to meet your neighbors. Do you know 3 people within a 3 block radius of your house?" />
     <ProactivePlanning />
   </PageLayout>
 );

--- a/packages/2018-housing-affordability/src/components/App/index.js
+++ b/packages/2018-housing-affordability/src/components/App/index.js
@@ -27,7 +27,7 @@ const App = () => (
     <RentBurdenedHouseholds />
     <p className="transition">24% of all Portland Metro households were severely burdened in 2015</p>
     <PortlandNeedsAffordableRentalUnits />
-    <PullQuote quoteText="The Portland region needs 78,806 NEW affordable units" />
+    <PullQuote quoteText="The Portland region needs 78,806 new affordable units" />
     <WhoCanAffordToBuyAHome />
     <p className="transition">In 2016, Portland metro ranked in the bottom 10% of metropolitan areas in regards to home ownership affordability.</p>
     <PacificNorthwestTopsNationInSurgingHomePrices />

--- a/packages/2018-housing-affordability/src/components/App/index.js
+++ b/packages/2018-housing-affordability/src/components/App/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import '@hackoregon/component-library/assets/global.styles.css';
-import { PageLayout } from '@hackoregon/component-library';
+import { PageLayout, PullQuote } from '@hackoregon/component-library';
 import BuildingBoomInPortland from '../BuildingBoomInPortland';
 import WhatDoesAffordabilityMean from '../WhatDoesAffordabilityMean';
 import AffordableRentalUnitsDwindling from '../AffordableRentalUnitsDwindling';
@@ -23,15 +23,15 @@ const App = () => (
     {/* <WhatDoesAffordabilityMean /> */}
     <p className="transition">In the Portland Region, affordable means a monthly housing budget of $1,375 for a family of four.</p>
     <AffordableRentalUnitsDwindling />
-    <p className="transition">From 2005 to 2015, the Portland Metro lost 39,645 units below $1000/month.</p>
+    <PullQuote quoteText="From 2005 to 2015, the Portland Metro lost 39,645 units below $1000/month." />
     <RentBurdenedHouseholds />
     <p className="transition">24% of all Portland Metro households were severely burdened in 2015</p>
     <PortlandNeedsAffordableRentalUnits />
-    <p className="transition">The Portland region needs 78,806 NEW affordable units</p>
+    <PullQuote quoteText="The Portland region needs 78,806 NEW affordable units" />
     <WhoCanAffordToBuyAHome />
     <p className="transition">In 2016, Portland metro ranked in the bottom 10% of metropolitan areas in regards to home ownership affordability.</p>
     <PacificNorthwestTopsNationInSurgingHomePrices />
-    <p className="transition">Portland had the second highest growth rate in home prices out of 120 U.S metro-areas in 2016, exceeded only by Seattle</p>
+    <PullQuote quoteText="Portland had the second highest growth rate in home prices out of 120 U.S metro-areas in 2016, exceeded only by Seattle" />
     <MeasuringMarketValueOfHomesInPortland />
     {/* <AffordabilityInAComplexHousingMarket /> */}
     {/* <ExploreHousingPolicyImplementation /> */}

--- a/packages/component-library/es/BarChart/BarChart.js
+++ b/packages/component-library/es/BarChart/BarChart.js
@@ -43,6 +43,7 @@ var BarChart = function BarChart(_ref) {
       },
       React.createElement(VictoryAxis, {
         tickFormat: xNumberFormatter,
+        style: { grid: { stroke: 'none' } },
         title: 'X Axis'
       }),
       React.createElement(VictoryAxis, {

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -70,6 +70,7 @@
     "react-motion": "^0.4.7",
     "react-router": "^3.0.0",
     "react-selectize": "^2.1.0",
+    "react-share": "^2.2.0",
     "recharts": "^0.22.1",
     "victory": "^0.26.0",
     "webpack-blocks": "^1.0.0"

--- a/packages/component-library/src/PullQuote/PullQuote.js
+++ b/packages/component-library/src/PullQuote/PullQuote.js
@@ -27,9 +27,9 @@ const wrapperClass = css`
   margin: 1.5em auto;
 `;
 
-const PullQuote = ({ quoteText, quoteAttribution }) => (
+const PullQuote = ({ quoteText, quoteAttribution, url }) => (
   <div className={wrapperClass}>
-    <TwitterShareButton url={window.location.href} title={quoteText}>
+    <TwitterShareButton url={url || window.location.href} title={quoteText}>
       <blockquote className={quoteClass} >
           &#8220;{ quoteText }&#8221;<br />
         { quoteAttribution ? <span className={attributionClass}>&#8212; { quoteAttribution }</span> : null }
@@ -46,6 +46,7 @@ PullQuote.displayName = 'PullQuote';
 PullQuote.propTypes = {
   quoteText: React.PropTypes.string,
   quoteAttribution: React.PropTypes.string,
+  url: React.PropTypes.string,
 };
 
 export default PullQuote;

--- a/packages/component-library/src/PullQuote/PullQuote.js
+++ b/packages/component-library/src/PullQuote/PullQuote.js
@@ -4,9 +4,9 @@ import { TwitterShareButton, TwitterIcon } from 'react-share';
 
 const quoteClass = css`
   font-family: 'Merriweather', serif;
-  font-size: 40px;
+  font-size: 24px;
   color: #eb4d5f;
-  margin-bottom: 20px;
+  margin-bottom: 12px;
 `;
 
 const attributionClass = css`
@@ -22,9 +22,9 @@ const iconClass = css`
 `;
 
 const wrapperClass = css`
-  max-width: 1000px;
+  max-width: 700px;
   text-align: center;
-  margin: 1.5em auto;
+  margin: 80px auto;
 `;
 
 const PullQuote = ({ quoteText, quoteAttribution, url }) => (
@@ -35,7 +35,7 @@ const PullQuote = ({ quoteText, quoteAttribution, url }) => (
         { quoteAttribution ? <span className={attributionClass}>&#8212; { quoteAttribution }</span> : null }
       </blockquote>
       <div className={iconClass}>
-        <TwitterIcon size={40} round iconBgStyle={{ fill: '#eb4d5f' }} />
+        <TwitterIcon size={24} round iconBgStyle={{ fill: '#eb4d5f' }} />
       </div>
     </TwitterShareButton>
   </div>

--- a/packages/component-library/src/PullQuote/PullQuote.js
+++ b/packages/component-library/src/PullQuote/PullQuote.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { css } from 'emotion';
+import { TwitterShareButton, TwitterIcon } from 'react-share';
 
 const quoteClass = css`
   font-family: 'Merriweather', serif;
   font-size: 40px;
+  color: #eb4d5f;
+  margin-bottom: 20px;
 `;
 
 const attributionClass = css`
@@ -11,14 +14,31 @@ const attributionClass = css`
   text-align: center;
   display: flex;
   justify-content: center;
-  line-height: 56px;
+  line-height: 40px;
+`;
+
+const iconClass = css`
+  display: inline-block;
+`;
+
+const wrapperClass = css`
+  max-width: 1000px;
+  text-align: center;
+  margin: 1.5em auto;
 `;
 
 const PullQuote = ({ quoteText, quoteAttribution }) => (
-  <blockquote className={quoteClass} >
-      &#8220;{ quoteText }&#8221;<br/>
-    { quoteAttribution ? <span className={attributionClass}>&#8212; { quoteAttribution }</span> : null }
-  </blockquote>
+  <div className={wrapperClass}>
+    <TwitterShareButton url={window.location.href} title={quoteText}>
+      <blockquote className={quoteClass} >
+          &#8220;{ quoteText }&#8221;<br />
+        { quoteAttribution ? <span className={attributionClass}>&#8212; { quoteAttribution }</span> : null }
+      </blockquote>
+      <div className={iconClass}>
+        <TwitterIcon size={40} round iconBgStyle={{ fill: '#eb4d5f' }} />
+      </div>
+    </TwitterShareButton>
+  </div>
 );
 
 PullQuote.displayName = 'PullQuote';

--- a/packages/component-library/stories/PullQuote.story.js
+++ b/packages/component-library/stories/PullQuote.story.js
@@ -27,11 +27,21 @@ const altDemo = () => (
   />
 );
 
+const urlDemo = () => (
+  <PullQuote
+    quoteText={quoteText}
+    url={'http://www.hackoregon.org'}
+  />
+);
+
 const altTitle = 'without attribution';
+const urlTitle = 'with custom url';
 
 export default () => storiesOf(displayName, module)
   .add(
     title,
     demoCode
   )
-  .add(altTitle, altDemo);
+  .add(altTitle, altDemo)
+  .add(urlTitle, urlDemo);
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -4398,7 +4398,7 @@ debug@2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.1, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -7849,6 +7849,12 @@ jsonlint-lines-primitives@~1.6.0:
   dependencies:
     JSV ">= 4.0.x"
     nomnom ">= 1.5.x"
+
+jsonp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jsonp/-/jsonp-0.2.1.tgz#a65b4fa0f10bda719a05441ea7b94c55f3e15bae"
+  dependencies:
+    debug "^2.1.3"
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -11403,6 +11409,15 @@ react-selectize@^2.1.0:
     prelude-extension "^0.0.13"
     prelude-ls "^1.1.1"
     tether "^1.1.1"
+
+react-share@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-share/-/react-share-2.2.0.tgz#49fa2525409a030d94375f8b9926b0db916c3049"
+  dependencies:
+    babel-runtime "^6.6.1"
+    classnames "^2.2.5"
+    jsonp "^0.2.1"
+    prop-types "^15.5.8"
 
 react-side-effect@^1.1.0:
   version "1.1.5"


### PR DESCRIPTION
This PR adds Twitter sharing to the PullQuote component, and adds some PullQuotes to the Disaster Resiliance and Housing Affordability projects.

Notes on Twitter sharing:
- I used react-share, which should make adding sharing for other platforms simple. https://github.com/nygardk/react-share
- By default, PullQuote uses the quoteText and current page for the text and URL of the tweet. However, I added a URL prop to PullQuote in case the sharing link should be different than the current page URL.
- On desktop, you get a pop-up, on mobile it pops you into the app with tweet ready to go.

**Screenshots**
`Desktop
------------------------------------------------------------------------------------`
<img width="1427" alt="screen shot 2018-07-04 at 10 59 14 pm" src="https://user-images.githubusercontent.com/7065695/42305162-864c8d02-7fde-11e8-9b7e-ad186a3a2d9d.png">
`Interaction
------------------------------------------------------------------------------------`
<img width="1229" alt="screen shot 2018-07-04 at 11 00 05 pm" src="https://user-images.githubusercontent.com/7065695/42305164-86856be0-7fde-11e8-9f8f-072f35f56f1c.png">
`Mobile
------------------------------------------------------------------------------------`
<img width="383" alt="screen shot 2018-07-04 at 10 59 28 pm" src="https://user-images.githubusercontent.com/7065695/42305187-a5ceca32-7fde-11e8-968b-f1a210e9e67f.png">
