### PR TITLE
Quick fix, card width in example component

### DIFF
--- a/packages/2018-example-farmers-markets/src/components/App/index.js
+++ b/packages/2018-example-farmers-markets/src/components/App/index.js
@@ -75,7 +75,7 @@ const App = () => (
         meat going to those channels, some farmers may choose to forgo the farmers market.
       </p>
     </section>
-    <section className={cx(sectionMarginMedium, sectionMaxWidthSmall)}>
+    <section className={sectionMarginMedium}>
       <FarmersMarketsOverTime />
     </section>
     <section className={cx(sectionBodyHeading, sectionMaxWidthSmall)}>


### PR DESCRIPTION
Addresses #262 - which has already been addressed in the live package, but there was some additional CSS in the example package that was making the card width there look weird.