### PR TITLE
Update CivicStoryCard Footer

### DIFF
--- a/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
@@ -74,12 +74,16 @@ const CivicStoryCard = ({ slug, title, children, error, loading, source }) => {
       <div className={descriptionClass}>
         {content}
       </div>
-      <CivicStoryFooter slug={slug} source={source}/>
+      <CivicStoryFooter slug={slug} source={source} />
     </div>
   );
 };
 
 CivicStoryCard.displayName = 'CivicStoryCard';
+
+CivicStoryCard.defaultProps = {
+  source: 'https://service.civicpdx.org/',
+};
 
 CivicStoryCard.propTypes = {
   loading: PropTypes.bool,

--- a/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
@@ -51,7 +51,7 @@ const cardError = css`
   background: #FDD;
 `;
 
-const CivicStoryCard = ({ slug, title, children, error, loading }) => {
+const CivicStoryCard = ({ slug, title, children, error, loading, source }) => {
   let content = children;
 
   if (loading) {
@@ -74,7 +74,7 @@ const CivicStoryCard = ({ slug, title, children, error, loading }) => {
       <div className={descriptionClass}>
         {content}
       </div>
-      <CivicStoryFooter slug={slug} />
+      <CivicStoryFooter slug={slug} source={source}/>
     </div>
   );
 };
@@ -87,6 +87,7 @@ CivicStoryCard.propTypes = {
   title: PropTypes.string,
   slug: PropTypes.string,
   children: PropTypes.node,
+  source: PropTypes.string,
 };
 
 export default CivicStoryCard;

--- a/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
@@ -50,16 +50,26 @@ export default class StoryFooter extends Component {
     this.setState({ copied: true });
   }
 
+  routeOrUndefined = () => {
+    const { slug } = this.props;
+    return `${window.location.origin}/cards/${slug}` === window.location.href
+    ? ''
+    : `/cards/${slug}`;
+  }
+
   render() {
     const { slug } = this.props;
     const shareTxt = this.state.copied ? 'Link copied!' : 'Share card'; // if copied, show Link copied, otherwise, show Share card
     const shareIcon = this.state.copied ? ICONS.check : ICONS.link;
+    const routeOrUndefined = `${window.location.origin}/cards/${slug}` === window.location.href
+      ? undefined
+      : `/cards/${slug}`;
+
     return (
       <div className={actionsClass}>
         <CivicStoryLink route={`/cards/${slug}`} icon={ICONS.info}>Source</CivicStoryLink>
         <div className={alignRight}>
-          <CivicStoryLink additionalClassName={alignRight} route={`/cards/${slug}`} icon={ICONS.eye}>View card</CivicStoryLink>
-          <CivicStoryLink additionalClassName={alignRight} action={this.handleCopy} icon={shareIcon}>{shareTxt}</CivicStoryLink>
+          <CivicStoryLink additionalClassName={alignRight} route={routeOrUndefined} action={this.handleCopy} icon={shareIcon}>{shareTxt}</CivicStoryLink>
         </div>
       </div>
     );

--- a/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
@@ -29,6 +29,7 @@ export default class StoryFooter extends Component {
 
   static propTypes = {
     slug: PropTypes.string,
+    source: PropTypes.string,
   }
 
   constructor(props) {
@@ -43,7 +44,7 @@ export default class StoryFooter extends Component {
   switchState = ms => setTimeout(this.setToFalse, ms);
 
   handleCopy = () => {
-    const { slug } = this.props;
+    const slug = this.props.slug;
     // NOTE: we need to make sure this will work on all browsers
     copy(`${window.location.origin}/cards/${slug}`);
     this.switchState(MS_TO_SWITCH_TEXT);
@@ -51,14 +52,15 @@ export default class StoryFooter extends Component {
   }
 
   routeOrUndefined = () => {
-    const { slug } = this.props;
+    const slug = this.props.slug;
     return `${window.location.origin}/cards/${slug}` === window.location.href
     ? ''
     : `/cards/${slug}`;
   }
 
   render() {
-    const { slug } = this.props;
+    const slug = this.props.slug;
+    const source = this.props.source;
     const shareTxt = this.state.copied ? 'Link copied!' : 'Share card'; // if copied, show Link copied, otherwise, show Share card
     const shareIcon = this.state.copied ? ICONS.check : ICONS.link;
     const routeOrUndefined = `${window.location.origin}/cards/${slug}` === window.location.href
@@ -67,7 +69,7 @@ export default class StoryFooter extends Component {
 
     return (
       <div className={actionsClass}>
-        <CivicStoryLink route={`/cards/${slug}`} icon={ICONS.info}>Source</CivicStoryLink>
+        <CivicStoryLink link={source} route={source ? undefined : `/cards/${slug}`} icon={ICONS.info}>Source</CivicStoryLink>
         <div className={alignRight}>
           <CivicStoryLink additionalClassName={alignRight} route={routeOrUndefined} action={this.handleCopy} icon={shareIcon}>{shareTxt}</CivicStoryLink>
         </div>

--- a/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
@@ -51,13 +51,6 @@ export default class StoryFooter extends Component {
     this.setState({ copied: true });
   }
 
-  routeOrUndefined = () => {
-    const slug = this.props.slug;
-    return `${window.location.origin}/cards/${slug}` === window.location.href
-    ? ''
-    : `/cards/${slug}`;
-  }
-
   render() {
     const slug = this.props.slug;
     const source = this.props.source;

--- a/packages/component-library/src/CivicStoryCard/CivicStoryLink.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryLink.js
@@ -29,11 +29,13 @@ const storyLinkClass = css`
   }
 `;
 
-const StoryLink = ({ children, icon, route, action }) => (
+const StoryLink = ({ children, icon, route, action, link }) => (
   <div className={storyLinkClass}>
     {route
       ? <Link to={route}><i className={icon} /><span>{children}</span></Link>
-      : <a tabIndex="0" onClick={action}><i className={icon} /><span>{children}</span></a>
+      : link
+        ? <a href={link}><i className={icon} /><span>{children}</span></a>
+        : <a tabIndex="0" onClick={action}><i className={icon} /><span>{children}</span></a>
     }
   </div>
 );
@@ -45,6 +47,7 @@ StoryLink.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.string,
   route: PropTypes.string,
+  link: PropTypes.string,
 };
 
 export default StoryLink;

--- a/packages/component-library/stories/CivicStoryCard.story.js
+++ b/packages/component-library/stories/CivicStoryCard.story.js
@@ -114,6 +114,16 @@ export default () => storiesOf('CivicStoryCard', module)
       </Container>
     )
   )
+  .add(
+    'Custom source link',
+    () => (
+      <Container>
+        <CivicStoryCard title={'Campsite Reports & income levels of a community'} source={'http://www.hackoregon.org'}>
+          <p className="Description">{wallOfText}</p>
+        </CivicStoryCard>
+      </Container>
+    )
+  )
   .add('loading', loadingDemo)
   .add('with error', errorDemo)
   .add('with title & description', tdDemo)


### PR DESCRIPTION
This PR addresses #260 and part of #348.

It implements the simplified sharing functionality as described in #260 , with one additional improvement.
- If you click share card from anywhere other the standalone card page, it takes you to the standalone card page (old view card functionality)

**Improvement:**
- If you click share card from the standalone card page, it copies the link (old share card functionality)

It also adds a `source` prop as described in #348 and sets a default `source` prop on CivicStoryCard to link to https://service.civicpdx.org/ (see https://github.com/hackoregon/endpoint-service-catalog/pull/13)

**Before:**
<img width="371" alt="screen shot 2018-07-05 at 1 32 56 am" src="https://user-images.githubusercontent.com/7065695/42311914-cd91c226-7ff3-11e8-931b-c524be131896.png">

**After:**
<img width="365" alt="screen shot 2018-07-05 at 1 33 52 am" src="https://user-images.githubusercontent.com/7065695/42311923-d468b9c4-7ff3-11e8-81a6-59eef5e40992.png">

