### PR TITLE
Updates/legend components

### DIFF
--- a/packages/component-library/src/LineChart/LineChart.js
+++ b/packages/component-library/src/LineChart/LineChart.js
@@ -34,6 +34,7 @@ const LineChart = ({
   yLabel,
   xNumberFormatter,
   yNumberFormatter,
+  legendComponent,
 }) => {
   const chartDomain = domain || getDefaultDomain(data, dataKey, dataValue);
 
@@ -76,6 +77,8 @@ const LineChart = ({
   return (
     <ChartContainer title={title} subtitle={subtitle}>
       {legendData && (
+        legendComponent ?
+        legendComponent(legendData) :
         <SimpleLegend className="legend" legendData={legendData} />
       )}
 
@@ -172,6 +175,7 @@ LineChart.propTypes = {
   yLabel: PropTypes.string,
   xNumberFormatter: PropTypes.func,
   yNumberFormatter: PropTypes.func,
+  legendComponent: PropTypes.func,
 };
 
 LineChart.defaultProps = {
@@ -191,6 +195,7 @@ LineChart.defaultProps = {
   yLabel: "Y",
   xNumberFormatter: numeric,
   yNumberFormatter: numeric,
+  legendComponent: null,
 };
 
 export default LineChart;

--- a/packages/component-library/src/Scatterplot/Scatterplot.js
+++ b/packages/component-library/src/Scatterplot/Scatterplot.js
@@ -51,6 +51,7 @@ const Scatterplot = ({
   yNumberFormatter,
   invertX,
   invertY,
+  legendComponent,
 }) => {
   const chartDomain = domain || getDefaultDomain(data, dataKey, dataValue);
 
@@ -73,6 +74,8 @@ const Scatterplot = ({
   return (
     <ChartContainer title={title} subtitle={subtitle}>
       {legendData && (
+        legendComponent ?
+        legendComponent(legendData) :
         <SimpleLegend className="legend" legendData={legendData} />
       )}
 
@@ -175,6 +178,7 @@ Scatterplot.propTypes = {
   yNumberFormatter: PropTypes.func,
   invertX: PropTypes.bool,
   invertY: PropTypes.bool,
+  legendComponent: PropTypes.func,
 };
 
 Scatterplot.defaultProps = {
@@ -196,6 +200,7 @@ Scatterplot.defaultProps = {
   yNumberFormatter: numeric,
   invertX: false,
   invertY: false,
+  legendComponent: null,
 };
 
 export default Scatterplot;

--- a/packages/component-library/src/StackedAreaChart/StackedAreaChart.js
+++ b/packages/component-library/src/StackedAreaChart/StackedAreaChart.js
@@ -35,6 +35,7 @@ const StackedAreaChart = ({
   yLabel,
   xNumberFormatter,
   yNumberFormatter,
+  legendComponent,
 }) => {
 
   const chartDomain = domain || getDefaultStackedDomain(data, dataKey, dataValue);
@@ -110,6 +111,8 @@ const StackedAreaChart = ({
   return (
     <ChartContainer title={title} subtitle={subtitle}>
       {legendData && (
+        legendComponent ?
+        legendComponent(legendData) :
         <SimpleLegend className="legend" legendData={legendData} />
       )}
 
@@ -184,6 +187,7 @@ StackedAreaChart.propTypes = {
   yLabel: PropTypes.string,
   xNumberFormatter: PropTypes.func,
   yNumberFormatter: PropTypes.func,
+  legendComponent: PropTypes.func,
 };
 
 StackedAreaChart.defaultProps = {
@@ -203,6 +207,7 @@ StackedAreaChart.defaultProps = {
   yLabel: "Y",
   xNumberFormatter: numeric,
   yNumberFormatter: numeric,
+  legendComponent: null,
 };
 
 export default StackedAreaChart;

--- a/packages/component-library/src/index.js
+++ b/packages/component-library/src/index.js
@@ -52,4 +52,5 @@ export { default as Collapsable } from './Collapsable/Collapsable';
 export { default as Sandbox } from './Sandbox/Sandbox';
 export { default as StackedAreaChart } from './StackedAreaChart/StackedAreaChart';
 export { default as PDF } from './PDF/PDF';
+export { default as SimpleLegend } from './SimpleLegend/SimpleLegend';
 

--- a/packages/component-library/stories/LineChart.story.js
+++ b/packages/component-library/stories/LineChart.story.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import { css } from 'emotion';
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from '@storybook/react';
 import { object, text, withKnobs } from '@storybook/addon-knobs';
-import { LineChart } from '../src';
+import { LineChart, SimpleLegend } from '../src';
 
 const displayName = LineChart.displayName || 'LineChart';
 
@@ -57,6 +58,70 @@ const sampleUnstructuredYKey = 'age';
 const sampleUnstructuredDataSeries = 'type';
 const sampleUnstructuredXLabel = 'Size (ft)';
 const sampleUnstructuredYLabel = 'Age (yrs)';
+
+const customLegend = (legendData) => {
+  const legendStyle = css`
+    font-family: 'Roboto Condensed', 'Helvetica Neue', Helvetica, sans-serif;
+    font-size: 14px;
+    font-weight: bold;
+    text-align: center;
+    margin: 10px 0 0 0;
+  `;
+
+  const legendContainer = css`
+    display: flex;
+    width: 100%;
+    justify-content: center;
+  `;
+
+  return (
+    <div className={legendContainer}>
+      <SimpleLegend legendData={legendData} />
+      <legend className={legendStyle}>
+        <span
+          className={css`
+            margin-left: 5px;
+          `}
+        >
+          <svg viewBox="0 0 50 10" width="50px">
+            <circle
+              cx="5"
+              cy="5"
+              r="1"
+            />
+            <circle
+              cx="15"
+              cy="5"
+              r="2"
+            />
+            <circle
+              cx="25"
+              cy="5"
+              r="3"
+            />
+            <circle
+              cx="35"
+              cy="5"
+              r="4"
+            />
+            <circle
+              cx="45"
+              cy="5"
+              r="5"
+            />
+          </svg>
+          <span
+            className={css`
+              margin-left: 5px;
+            `}
+          >
+            Population
+          </span>
+        </span>
+      </legend>
+    </div>
+  );
+};
 
 export default () =>
   storiesOf(displayName, module)
@@ -138,6 +203,7 @@ export default () =>
           title={title}
           xLabel={xLabel}
           yLabel={yLabel}
+          legendComponent={customLegend}
         />
       );
     });

--- a/packages/component-library/stories/Scatterplot.story.js
+++ b/packages/component-library/stories/Scatterplot.story.js
@@ -4,7 +4,6 @@ import { css } from 'emotion';
 import { storiesOf } from '@storybook/react';
 import { object, text, boolean, withKnobs } from '@storybook/addon-knobs';
 import { Scatterplot, SimpleLegend } from '../src';
-import CivicVictoryTheme from '../src/VictoryTheme/VictoryThemeIndex';
 
 const displayName = Scatterplot.displayName || 'Scatterplot';
 const sampleData = [

--- a/packages/component-library/stories/Scatterplot.story.js
+++ b/packages/component-library/stories/Scatterplot.story.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import { css } from 'emotion';
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from '@storybook/react';
 import { object, text, boolean, withKnobs } from '@storybook/addon-knobs';
-import { Scatterplot } from '../src';
+import { Scatterplot, SimpleLegend } from '../src';
+import CivicVictoryTheme from '../src/VictoryTheme/VictoryThemeIndex';
 
 const displayName = Scatterplot.displayName || 'Scatterplot';
 const sampleData = [
@@ -43,6 +45,70 @@ const sampleUnstructuredYKey = 'age';
 const sampleUnstructuredDataSeries = 'type';
 const sampleUnstructuredXLabel = 'Size (ft)';
 const sampleUnstructuredYLabel = 'Age (yrs)';
+
+const customLegend = (legendData) => {
+  const legendStyle = css`
+    font-family: 'Roboto Condensed', 'Helvetica Neue', Helvetica, sans-serif;
+    font-size: 14px;
+    font-weight: bold;
+    text-align: center;
+    margin: 10px 0 0 0;
+  `;
+
+  const legendContainer = css`
+    display: flex;
+    width: 100%;
+    justify-content: center;
+  `;
+
+  return (
+    <div className={legendContainer}>
+      <SimpleLegend legendData={legendData} />
+      <legend className={legendStyle}>
+        <span
+          className={css`
+            margin-left: 5px;
+          `}
+        >
+          <svg viewBox="0 0 50 10" width="50px">
+            <circle
+              cx="5"
+              cy="5"
+              r="1"
+            />
+            <circle
+              cx="15"
+              cy="5"
+              r="2"
+            />
+            <circle
+              cx="25"
+              cy="5"
+              r="3"
+            />
+            <circle
+              cx="35"
+              cy="5"
+              r="4"
+            />
+            <circle
+              cx="45"
+              cy="5"
+              r="5"
+            />
+          </svg>
+          <span
+            className={css`
+              margin-left: 5px;
+            `}
+          >
+            Population
+          </span>
+        </span>
+      </legend>
+    </div>
+  );
+};
 
 export default () =>
   storiesOf(displayName, module)
@@ -123,6 +189,7 @@ export default () =>
           yLabel={yLabel}
           invertX={invertX}
           invertY={invertY}
+          legendComponent={customLegend}
         />
       );
     });

--- a/packages/component-library/stories/StackedAreaChart.story.js
+++ b/packages/component-library/stories/StackedAreaChart.story.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import { css } from 'emotion';
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from '@storybook/react';
 import { object, text, withKnobs } from '@storybook/addon-knobs';
-import { StackedAreaChart } from '../src';
+import { StackedAreaChart, SimpleLegend } from '../src';
 
 const displayName = StackedAreaChart.displayName || 'Stacked Area Chart';
 
@@ -57,6 +58,71 @@ const sampleUnstructuredYKey = 'age';
 const sampleUnstructuredDataSeries = 'type';
 const sampleUnstructuredXLabel = 'Size (ft)';
 const sampleUnstructuredYLabel = 'Age (yrs)';
+
+const customLegend = (legendData) => {
+  const legendStyle = css`
+    font-family: 'Roboto Condensed', 'Helvetica Neue', Helvetica, sans-serif;
+    font-size: 14px;
+    font-weight: bold;
+    text-align: center;
+    margin: 10px 0 0 0;
+  `;
+
+  const legendContainer = css`
+    display: flex;
+    width: 100%;
+    justify-content: center;
+  `;
+
+  return (
+    <div className={legendContainer}>
+      <SimpleLegend legendData={legendData} />
+      <legend className={legendStyle}>
+        <span
+          className={css`
+            margin-left: 5px;
+          `}
+        >
+          <svg viewBox="0 0 50 10" width="50px">
+            <circle
+              cx="5"
+              cy="5"
+              r="1"
+            />
+            <circle
+              cx="15"
+              cy="5"
+              r="2"
+            />
+            <circle
+              cx="25"
+              cy="5"
+              r="3"
+            />
+            <circle
+              cx="35"
+              cy="5"
+              r="4"
+            />
+            <circle
+              cx="45"
+              cy="5"
+              r="5"
+            />
+          </svg>
+          <span
+            className={css`
+              margin-left: 5px;
+            `}
+          >
+            Population
+          </span>
+        </span>
+      </legend>
+    </div>
+  );
+};
+
 
 export default () =>
   storiesOf(displayName, module)
@@ -138,6 +204,7 @@ export default () =>
           title={title}
           xLabel={xLabel}
           yLabel={yLabel}
+          legendComponent={customLegend}
         />
       );
     });


### PR DESCRIPTION
Adds a legendComponent prop to be able to pass in a custom legend to each of the charts that already used SimpleLegend, add added to each of the stories.

This is going to be useful for #201 as well as a nice improvement for #274.

This sample shows an addition to SimpleLegend, but you could pass in any component that takes legendData.

![image](https://user-images.githubusercontent.com/7065695/42613240-b4d25e42-8554-11e8-8391-0a9a58a3b535.png)

The charts:
- Scatterplot
- Line Chart
- Stacked Area Chart


