### PR TITLE
Fix chart tooltip in Firefox browser

### DIFF
--- a/packages/component-library/src/VictoryTheme/CivicVictoryTheme.js
+++ b/packages/component-library/src/VictoryTheme/CivicVictoryTheme.js
@@ -7,8 +7,8 @@ import { assign } from "lodash";
 const civicPrimary = "#1f1123";
 const civicSecondary = "#eb4d5f";
 const civicTertiary = "#716470";
-const civicSecondaryLighter = "aaa4ab";
-const civicSecondaryLightest = "f3f2f3";
+const civicSecondaryLighter = "#aaa4ab";
+const civicSecondaryLightest = "#f3f2f3";
 
 const civicCategoricalColor1 = "#DC4556";
 const civicCategoricalColor2 = "#19B7AA";


### PR DESCRIPTION
This fixes issue [#151](https://github.com/hackoregon/civic/issues/251) with the chart tooltip in Firefox browsers. 

It was as simple as adding in a couple of missing hash symbols.