### PR TITLE
Fix Sandbox Map Tooltip

### DIFF
--- a/packages/civic-sandbox/src/components/Sandbox/index.js
+++ b/packages/civic-sandbox/src/components/Sandbox/index.js
@@ -16,6 +16,7 @@ import {
   setPackage,
   fetchSlideByDate,
   setSelectedFoundationDatum,
+  setSelectedSlideDatum,
 } from '../../state/sandbox/actions';
 import {
   isAllSandboxLoading,
@@ -33,6 +34,7 @@ import {
   getSelectedFoundation,
   getSelectedSlides,
   getLayerSlides,
+  getSelectedSlideDatum,
 } from '../../state/sandbox/selectors';
 
 class SandboxComponent extends React.Component {
@@ -97,6 +99,8 @@ class SandboxComponent extends React.Component {
       foundationData={this.props.selectedFoundationData}
       defaultFoundation={this.props.foundationData}
       onFoundationClick={this.props.foundationClick}
+      onSlideHover={this.props.slideHover}
+      tooltipInfo={this.props.selectedSlideDatum}
     />;
   }
 }
@@ -119,6 +123,7 @@ export default connect(
     layerFoundation: getLayerFoundation(state),
     selectedSlide: getSelectedSlides(state),
     layerSlides: getLayerSlides(state),
+    selectedSlideDatum: getSelectedSlideDatum(state),
   }),
   dispatch => ({
     fetchFoundation(endpoint = '') {
@@ -141,6 +146,9 @@ export default connect(
     },
     foundationClick(feature) {
       dispatch(setSelectedFoundationDatum(feature));
+    },
+    slideHover(feature) {
+      dispatch(setSelectedSlideDatum(feature));
     },
   })
 )(SandboxComponent);

--- a/packages/civic-sandbox/src/state/layerStyles.js
+++ b/packages/civic-sandbox/src/state/layerStyles.js
@@ -1250,7 +1250,7 @@ export const slides = data => ({
       opacity: 1,
       filled: false,
       getPolygon: f => f.coordinates,
-      getLineColor: f => [114, 29, 124, 255],
+      getLineColor: f => [220, 69, 86, 255],
       getLineWidth: f => 45,
       lineWidthScale: 1,
       lineJointRounded: false,

--- a/packages/civic-sandbox/src/state/sandbox/actions.js
+++ b/packages/civic-sandbox/src/state/sandbox/actions.js
@@ -18,6 +18,7 @@ export const SLIDE_SUCCESS = 'SANDBOX/SLIDE_SUCCESS';
 export const SLIDE_FAILURE = 'SANDBOX/SLIDE_FAILURE';
 export const SET_SLIDES = 'SANDBOX/SET_SLIDES';
 export const SET_FOUNDATION_DATUM = 'SANDBOX/SET_FOUNDATION_DATUM';
+export const SET_SLIDE_DATUM = 'SANDBOX/SET_SLIDE_DATUM';
 
 // Simple actions
 export const SandboxStart = actionEmitter(SANDBOX_START);
@@ -89,5 +90,10 @@ export const fetchSlideByDate = (slide, date, type) => fetchByDateAdapter(slide,
 
 export const setSelectedFoundationDatum = (feature = {}) => ({
   type: SET_FOUNDATION_DATUM,
+  feature,
+});
+
+export const setSelectedSlideDatum = (feature = {}) => ({
+  type: SET_SLIDE_DATUM,
   feature,
 });

--- a/packages/civic-sandbox/src/state/sandbox/index.js
+++ b/packages/civic-sandbox/src/state/sandbox/index.js
@@ -13,6 +13,7 @@ import {
   SLIDES_SUCCESS,
   SET_FOUNDATION,
   SET_FOUNDATION_DATUM,
+  SET_SLIDE_DATUM,
   SET_SLIDES,
   SLIDE_START,
   SLIDE_FAILURE,
@@ -45,6 +46,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         sandboxError: null,
         sandbox: {},
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SANDBOX_SUCCESS:
       return {
@@ -53,6 +55,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         sandboxError: null,
         sandbox: action.payload.body,
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SANDBOX_FAILURE:
       return {
@@ -61,6 +64,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         sandboxError: action.payload,
         sandbox: {},
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case FOUNDATION_START:
       return {
@@ -68,6 +72,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         foundationPending: true,
         foundationError: null,
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case FOUNDATION_SUCCESS:
       return {
@@ -76,6 +81,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         foundationError: null,
         foundationData: action.payload,
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case FOUNDATION_FAILURE:
       return {
@@ -84,6 +90,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         foundationError: action.payload,
         foundationData: null,
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SLIDES_START:
       return {
@@ -91,6 +98,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         slidesPending: true,
         slidesError: null,
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SLIDES_SUCCESS:
       return {
@@ -100,6 +108,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         slidesSuccess: true,
         slidesData: action.payload,
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SLIDES_FAILURE:
       return {
@@ -108,6 +117,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         slidesError: action.payload,
         slidesData: null,
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SET_PACKAGE:
       return {
@@ -118,6 +128,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         selectedFoundation: state.sandbox.packages[action.selectedPackage].default_foundation,
         selectedSlide: isArray(state.sandbox.packages[action.selectedPackage].default_slide) ? state.sandbox.packages[action.selectedPackage].default_slide : [state.sandbox.packages[action.selectedPackage].default_slide],
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SET_FOUNDATION:
       return {
@@ -125,6 +136,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         selectedFoundation: action.selectedFoundation,
         foundationData: {},
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SET_SLIDES:
       return {
@@ -132,6 +144,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         selectedSlide: action.selectedSlides,
         slidesData: [],
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SLIDE_START:
       return {
@@ -139,6 +152,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         slidesPending: true,
         slidesError: null,
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SLIDE_SUCCESS:
       let foundationData = state.foundationData;
@@ -158,6 +172,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         slidesError: null,
         slidesSuccess: true,
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
         slidesData,
         foundationData,
       };
@@ -168,11 +183,17 @@ const reducer = (state = INITIAL_STATE, action) => {
         slidesError: action.payload,
         slidesData: null,
         selectedFoundationDatum: null,
+        selectedSlideDatum: null,
       };
     case SET_FOUNDATION_DATUM:
       return {
         ...state,
         selectedFoundationDatum: action.feature,
+      };
+    case SET_SLIDE_DATUM:
+      return {
+        ...state,
+        selectedSlideDatum: action.feature,
       };
     default:
       return state;

--- a/packages/civic-sandbox/src/state/sandbox/selectors.js
+++ b/packages/civic-sandbox/src/state/sandbox/selectors.js
@@ -180,7 +180,7 @@ export const getSelectedSlideDatum = createSelector(
     const tooltipObj = {};
     tooltipObj['x'] = selectedSlideDatum.x;
     tooltipObj['y'] = selectedSlideDatum.y;
-    tooltipObj['content'] = {};
+    tooltipObj['content'] = [];
 
     const tooltipSlideName = Object.keys(slide[slideIndex]);
 
@@ -191,10 +191,16 @@ export const getSelectedSlideDatum = createSelector(
     const datumProps = selectedSlideDatum.object.properties;
 
     if (tooltipPrimary && tooltipPrimary.field) {
-      tooltipObj.content[tooltipPrimary.name] = datumProps[tooltipPrimary.field];
+      tooltipObj.content.push({
+        name: tooltipPrimary.name,
+        value: datumProps[tooltipPrimary.field],
+      });
     }
     if (tooltipSecondary && tooltipSecondary.field) {
-      tooltipObj.content[tooltipSecondary.name] = datumProps[tooltipSecondary.field];
+      tooltipObj.content.push({
+        name: tooltipSecondary.name,
+        value: datumProps[tooltipSecondary.field],
+      });
     }
 
     return tooltipObj;

--- a/packages/civic-sandbox/src/state/sandbox/selectors.js
+++ b/packages/civic-sandbox/src/state/sandbox/selectors.js
@@ -142,3 +142,70 @@ export const getSelectedFoundationDatum = createSelector(
     return visualizations;
   }
 );
+
+export const getSelectedSlideDatum = createSelector(
+  getSandbox,
+  getSelectedSlidesData,
+  ({ selectedSlideDatum }, slide) => {
+    /*global console*/
+    console.log('\nhover datum:', selectedSlideDatum, '\nslide data:\n', slide, '\n');
+
+    if (!slide || !selectedSlideDatum || !selectedSlideDatum.object) return;
+
+    const datumFieldNames = Object.keys(selectedSlideDatum.object.properties);
+    console.log('\nDatum Field Names:\n', datumFieldNames);
+    if(datumFieldNames.length < 1) return;
+
+    const slideAttributes = slide.map((slideObject, index) => {
+      const slideName = Object.keys(slideObject);
+      const attrs = slideObject[slideName[0]].slide_meta.attributes;
+      const slideAttrObj = {};
+      slideAttrObj['index'] = index;
+      if (attrs.primary.field) { slideAttrObj['primary'] = attrs.primary; }
+      if (attrs.secondary.field) { slideAttrObj['secondary'] =  attrs.secondary }
+      return slideAttrObj;
+    });
+    console.log('\nSlide Attributes:\n', slideAttributes, '\n');
+
+    const findSlideIndex = slideAttributes.filter(d => {
+      const primary = d.primary;
+      const secondary = d.secondary;
+      if (primary && secondary) {
+        return datumFieldNames.includes(d.primary.field && d.secondary.field);
+      } else if (primary) {
+        return datumFieldNames.includes(d.primary.field);
+      } else {
+        return false;
+      }
+    });
+    console.log('\nFind Slide Index:\n', findSlideIndex);
+
+    if (findSlideIndex.length < 1) return;
+    const slideIndex = findSlideIndex[0].index;
+
+    const tooltipObj = {};
+    tooltipObj['x'] = selectedSlideDatum.x;
+    tooltipObj['y'] = selectedSlideDatum.y;
+    tooltipObj['content'] = {};
+
+    const tooltipSlideName = Object.keys(slide[slideIndex]);
+    console.log('\nTooltip Slide Name:\n', tooltipSlideName);
+
+    const tooltipSlideAttrs = slide[slideIndex][tooltipSlideName[0]].slide_meta.attributes;
+    console.log('\nTooltip Attributes:\n', tooltipSlideAttrs);
+    const tooltipPrimary = tooltipSlideAttrs.primary;
+    const tooltipSecondary = tooltipSlideAttrs.secondary;
+
+    const datumProps = selectedSlideDatum.object.properties;
+
+    if (tooltipPrimary && tooltipPrimary.field) {
+      tooltipObj.content[tooltipPrimary.name] = datumProps[tooltipPrimary.field];
+    }
+    if (tooltipSecondary && tooltipSecondary.field) {
+      tooltipObj.content[tooltipSecondary.name] = datumProps[tooltipSecondary.field];
+    }
+
+    console.log('\nTooltip Object:\n', tooltipObj, '\n');
+    return tooltipObj;
+  }
+);

--- a/packages/civic-sandbox/src/state/sandbox/selectors.js
+++ b/packages/civic-sandbox/src/state/sandbox/selectors.js
@@ -147,13 +147,9 @@ export const getSelectedSlideDatum = createSelector(
   getSandbox,
   getSelectedSlidesData,
   ({ selectedSlideDatum }, slide) => {
-    /*global console*/
-    console.log('\nhover datum:', selectedSlideDatum, '\nslide data:\n', slide, '\n');
-
     if (!slide || !selectedSlideDatum || !selectedSlideDatum.object) return;
 
     const datumFieldNames = Object.keys(selectedSlideDatum.object.properties);
-    console.log('\nDatum Field Names:\n', datumFieldNames);
     if(datumFieldNames.length < 1) return;
 
     const slideAttributes = slide.map((slideObject, index) => {
@@ -165,7 +161,6 @@ export const getSelectedSlideDatum = createSelector(
       if (attrs.secondary.field) { slideAttrObj['secondary'] =  attrs.secondary }
       return slideAttrObj;
     });
-    console.log('\nSlide Attributes:\n', slideAttributes, '\n');
 
     const findSlideIndex = slideAttributes.filter(d => {
       const primary = d.primary;
@@ -178,7 +173,6 @@ export const getSelectedSlideDatum = createSelector(
         return false;
       }
     });
-    console.log('\nFind Slide Index:\n', findSlideIndex);
 
     if (findSlideIndex.length < 1) return;
     const slideIndex = findSlideIndex[0].index;
@@ -189,10 +183,8 @@ export const getSelectedSlideDatum = createSelector(
     tooltipObj['content'] = {};
 
     const tooltipSlideName = Object.keys(slide[slideIndex]);
-    console.log('\nTooltip Slide Name:\n', tooltipSlideName);
 
     const tooltipSlideAttrs = slide[slideIndex][tooltipSlideName[0]].slide_meta.attributes;
-    console.log('\nTooltip Attributes:\n', tooltipSlideAttrs);
     const tooltipPrimary = tooltipSlideAttrs.primary;
     const tooltipSecondary = tooltipSlideAttrs.secondary;
 
@@ -205,7 +197,6 @@ export const getSelectedSlideDatum = createSelector(
       tooltipObj.content[tooltipSecondary.name] = datumProps[tooltipSecondary.field];
     }
 
-    console.log('\nTooltip Object:\n', tooltipObj, '\n');
     return tooltipObj;
   }
 );

--- a/packages/component-library/es/index.js
+++ b/packages/component-library/es/index.js
@@ -52,3 +52,4 @@ export { default as Collapsable } from './Collapsable/Collapsable';
 export { default as Sandbox } from './Sandbox/Sandbox';
 export { default as StackedAreaChart } from './StackedAreaChart/StackedAreaChart';
 export { default as PDF } from './PDF/PDF';
+export { default as SimpleLegend } from './SimpleLegend/SimpleLegend';

--- a/packages/component-library/src/CivicSandboxMap/CivicSandboxMap.js
+++ b/packages/component-library/src/CivicSandboxMap/CivicSandboxMap.js
@@ -11,12 +11,9 @@ const CivicSandboxMap = (props) => {
   const {
     viewport,
     mapLayers,
-    tooltipInfo,
-    x,
-    y,
-    onHover,
     children,
     onClick,
+    onHoverSlide,
   } = props;
 
   // Call multiple functions with supplied arguments
@@ -40,7 +37,7 @@ const CivicSandboxMap = (props) => {
         rounded={layer.data.rounded}
         autoHighlight={layer.data.autoHighlight}
         highlightColor={layer.data.highlightColor}
-        onHover={onHover}
+        onHover={onHoverSlide}
         parameters={{ depthTest: false }}
       />
       ) : layer.data.mapType === 'ScatterPlotMap' ? (
@@ -56,7 +53,7 @@ const CivicSandboxMap = (props) => {
           radiusScale={layer.data.radiusScale}
           autoHighlight={layer.data.autoHighlight}
           highlightColor={layer.data.highlightColor}
-          onHover={onHover}
+          onHover={onHoverSlide}
           parameters={{ depthTest: false }}
         />
       ) : layer.data.mapType === 'IconMap' ? (
@@ -75,7 +72,7 @@ const CivicSandboxMap = (props) => {
           getColor={layer.data.getColor}
           autoHighlight={layer.data.autoHighlight}
           highlightColor={layer.data.highlightColor}
-          onHover={onHover}
+          onHover={onHoverSlide}
           parameters={{ depthTest: false }}
         />
       ) : layer.data.mapType === 'ScreenGridMap' ? (
@@ -107,7 +104,7 @@ const CivicSandboxMap = (props) => {
               stroked={layer.data.stroked}
               getFillColor={layer.data.getFillColor}
               filled={layer.data.filled}
-              onHover={onHover}
+              onHover={onHoverSlide}
               autoHighlight={layer.data.autoHighlight}
               highlightColor={layer.data.highlightColor}
               parameters={{ depthTest: false }}
@@ -127,7 +124,6 @@ const CivicSandboxMap = (props) => {
           getFillColor={layer.data.getFillColor}
           filled={layer.data.filled}
           onClick={mapClick(onClick, layer.data.onClick)}
-          onHover={onHover}
           autoHighlight={layer.data.autoHighlight}
           highlightColor={layer.data.highlightColor}
           parameters={{ depthTest: false }}
@@ -136,16 +132,6 @@ const CivicSandboxMap = (props) => {
       ) : null;
   });
 
-  const tooltip = React.Children.map(children, (child) => {
-    return React.cloneElement(child, {
-      tooltipInfo,
-      x,
-      y,
-    });
-  });
-
-  const renderTooltip = tooltipInfo ? tooltip : null;
-
   return (
     <div className={crosshair}>
       <DeckGL
@@ -153,7 +139,7 @@ const CivicSandboxMap = (props) => {
         {...viewport}
       >
         { renderMaps }
-        { renderTooltip }
+        { children }
       </DeckGL>
     </div>
   );
@@ -162,10 +148,7 @@ const CivicSandboxMap = (props) => {
 CivicSandboxMap.propTypes = {
   viewport: PropTypes.object,
   mapLayers: PropTypes.array.isRequired,
-  tooltipInfo: PropTypes.object,
-  x: PropTypes.number,
-  y: PropTypes.number,
-  onHover: PropTypes.func,
+  onHoverSlide: PropTypes.func,
   onClick: PropTypes.func,
   children: PropTypes.node,
 };

--- a/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
+++ b/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { string, number, arrayOf, objectOf, oneOfType, shape} from 'prop-types';
 import { css } from 'emotion';
 
 const tooltip = css`
@@ -19,19 +19,16 @@ const MapTooltip = (props) => {
   const {
     tooltipData,
   } = props;
-
   const x = tooltipData.x;
   const y = tooltipData.y;
 
   const xPosition = x < window.innerWidth * 0.66 ? x : x - (window.innerWidth * 0.1);
-  const yPostition = y < 375  ? y : y - 50;
+  const yPostition = y < 375 ? y : y - 50;
 
-  const keyValuePairs = Object.entries(tooltipData.content);
-
-  const tooltipContent = keyValuePairs.map((d, index) => {
+  const tooltipContent = tooltipData.content.map((obj, index) => {
     return (
       <div key={index}>
-        {d[0] + ': ' + d[1].toLocaleString()}
+        {`${obj.name}: ${obj.value.toLocaleString()}`}
       </div>
     );
   });
@@ -50,7 +47,18 @@ const MapTooltip = (props) => {
 };
 
 MapTooltip.propTypes = {
-  tooltipData: PropTypes.object,
+  tooltipData: objectOf(
+    shape({
+      x: number,
+      y: number,
+      content: arrayOf(
+        shape({
+          name: string,
+          value: oneOfType([number, string]),
+        })
+      ),
+    })
+  ),
 };
 
 export default MapTooltip;

--- a/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
+++ b/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
@@ -17,31 +17,28 @@ const tooltip = css`
 
 const MapTooltip = (props) => {
   const {
-    tooltipInfo,
-    x,
-    y,
+    tooltipData,
   } = props;
+
+  console.log('\nCivicSandbox Tooltip:\n', props);
+
+  const x = tooltipData.x;
+  const y = tooltipData.y;
 
   const xPosition = x < window.innerWidth * 0.66 ? x : x - (window.innerWidth * 0.1);
   const yPostition = y < 375  ? y : y - 50;
 
-  const keyValuePairs = Object.entries(tooltipInfo.properties);
+  const keyValuePairs = Object.entries(tooltipData.content);
 
-  const tooltipContent = keyValuePairs.map((d, i) => {
-    const nameSplit = d[0].split("_");
-    const name = nameSplit.reduce((acc, cur, i) => {
-      const capitalize = cur.charAt(0).toUpperCase() + cur.slice(1);
-      return acc + " " + capitalize;
-    }, "");
-
+  const tooltipContent = keyValuePairs.map((d, index) => {
     return (
-      <div key={i}>
-        {name + ': ' + d[1].toLocaleString()}
+      <div key={index}>
+        {d[0] + ': ' + d[1].toLocaleString()}
       </div>
     );
   });
 
-  const tooltipWrapper = (
+  return (
     <div
       className={tooltip}
       style={{
@@ -52,20 +49,10 @@ const MapTooltip = (props) => {
       { tooltipContent }
     </div>
   );
-
-  const tooltipRender = keyValuePairs.length > 0 ? tooltipWrapper : null;
-
-  return (
-    <div>
-      { tooltipRender }
-    </div>
-  );
 };
 
 MapTooltip.propTypes = {
-  tooltipInfo: PropTypes.object,
-  x: PropTypes.number,
-  y: PropTypes.number,
+  tooltipData: PropTypes.object,
 };
 
 export default MapTooltip;

--- a/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
+++ b/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
@@ -20,8 +20,6 @@ const MapTooltip = (props) => {
     tooltipData,
   } = props;
 
-  console.log('\nCivicSandbox Tooltip:\n', props);
-
   const x = tooltipData.x;
   const y = tooltipData.y;
 

--- a/packages/component-library/src/Sandbox/Sandbox.js
+++ b/packages/component-library/src/Sandbox/Sandbox.js
@@ -36,7 +36,6 @@ const Sandbox = ({
   onSlideHover,
   tooltipInfo,
 }) => {
-  console.log('\nTooltip Info:\n', tooltipInfo);
   return (
     <div
       className={styles}

--- a/packages/component-library/src/Sandbox/Sandbox.js
+++ b/packages/component-library/src/Sandbox/Sandbox.js
@@ -33,7 +33,10 @@ const Sandbox = ({
   updateSlide,
   defaultFoundation,
   onFoundationClick,
+  onSlideHover,
+  tooltipInfo,
 }) => {
+  console.log('\nTooltip Info:\n', tooltipInfo);
   return (
     <div
       className={styles}
@@ -111,8 +114,12 @@ const Sandbox = ({
           <CivicSandboxMap
             mapLayers={layerData}
             onClick={onFoundationClick}
+            onHoverSlide={onSlideHover}
           >
-            <CivicSandboxTooltip />
+            { tooltipInfo && (
+              <CivicSandboxTooltip tooltipData={tooltipInfo}/>
+              )
+            }
           </CivicSandboxMap>
         </BaseMap>
       </div>


### PR DESCRIPTION
Currently the tooltip for the sandbox uses the field names from the property object for its text. So some of the descriptions are not very useful.

I finally got around to fixing that so the text is properly formatted and uses the field names provided in `slide_meta.attributes` for each slide.

One issue that I encountered was that some of the `slide_meta.attributes` fields don't match the names of the fields in the actual data. For example, in [slide 016 - points of interest](http://service.civicpdx.org/neighborhood-development/sandbox/slides/retailgrocers/?format=json), the value for `slide_meta.attributes.secondary.field` is `description_txt` but the field name in `slide_data.features.properties` is `description2_txt`. So that mismatch prevents the tooltip from showing up since they don't match. The same problem happens with [slide 015 - change in ridership by route](http://service.civicpdx.org/transportation-systems/sandbox/slides/routechange/?format=json).

Another issue is that some slides have information in `slide_data.features.properties`, but there are no `primary` or `secondary` fields provided in `slide_meta`. [Slide 011 - demolitions](http://service.civicpdx.org/neighborhood-development/sandbox/slides/demolitions/) and [slide 032 - crashes](http://service.civicpdx.org/transportation-systems/sandbox/slides/crashes/) share that issue.







