### PR TITLE
Fix Story Card watermark Firefox

### DIFF
--- a/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
@@ -29,6 +29,7 @@ const watermarkContainer = css`
   left: 0;
   top: 0;
   z-index: 0;
+  text-align: left;
 `;
 
 const titleClass = css`


### PR DESCRIPTION
#375 made cards ugly in Firefox - Firefox used text-align to inform the SVG positioning, while the other browsers disregard it. This fixes that.

**🙀 ugliness below 🙀**
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/7065695/44227227-f3828500-a146-11e8-93a2-d639514331f0.png">
