### PR TITLE
Update Civic Sandbox Dashboard

### DIFF
--- a/packages/civic-sandbox/src/components/Packages/index.js
+++ b/packages/civic-sandbox/src/components/Packages/index.js
@@ -112,7 +112,20 @@ export class Packages extends React.Component {
             <a onClick={this.closeMap}>&lt; Back to Packages</a>
           </p>
           <SandboxComponent />
-          {selectedFoundationDatum && <div>
+          {selectedFoundationDatum && <div
+            className={css(`
+              position: absolute;
+              top: 21%;
+              left: 4%;
+              width: 96%;
+              height: 0;
+              @media(max-width: 900px) {
+                position: relative;
+                left: 0;
+                height: auto;
+              }
+            `)}
+          >
             <CivicSandboxDashboard data={selectedFoundationDatum}>
               {/*<div className={css(`display: inline-block; width: 90%; margin: 1% 2% 2% 7.5%;`)}>
                 <h2>How has ridership changed throughout Tri-Met's service area over time?</h2>

--- a/packages/civic-sandbox/src/components/Packages/index.js
+++ b/packages/civic-sandbox/src/components/Packages/index.js
@@ -114,6 +114,14 @@ export class Packages extends React.Component {
           <SandboxComponent />
           {selectedFoundationDatum && <div>
             <CivicSandboxDashboard data={selectedFoundationDatum}>
+              {/*<div className={css(`display: inline-block; width: 90%; margin: 1% 2% 2% 7.5%;`)}>
+                <h2>How has ridership changed throughout Tri-Met's service area over time?</h2>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <p><b>Source:</b> Census.gov ACS</p>
+              </div>*/}
             </CivicSandboxDashboard>
           </div>}
         </section>)}

--- a/packages/civic-sandbox/src/components/Packages/index.js
+++ b/packages/civic-sandbox/src/components/Packages/index.js
@@ -126,16 +126,7 @@ export class Packages extends React.Component {
               }
             `)}
           >
-            <CivicSandboxDashboard data={selectedFoundationDatum}>
-              {/*<div className={css(`display: inline-block; width: 90%; margin: 1% 2% 2% 7.5%;`)}>
-                <h2>How has ridership changed throughout Tri-Met's service area over time?</h2>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                <p><b>Source:</b> Census.gov ACS</p>
-              </div>*/}
-            </CivicSandboxDashboard>
+            <CivicSandboxDashboard data={selectedFoundationDatum}/>
           </div>}
         </section>)}
       </div>

--- a/packages/civic-sandbox/src/components/Packages/index.js
+++ b/packages/civic-sandbox/src/components/Packages/index.js
@@ -112,14 +112,9 @@ export class Packages extends React.Component {
             <a onClick={this.closeMap}>&lt; Back to Packages</a>
           </p>
           <SandboxComponent />
-          {selectedFoundationDatum && <div
-            style={{
-              top: '175px',
-              position: 'absolute',
-              width: '100%',
-            }}
-          >
-            <CivicSandboxDashboard data={selectedFoundationDatum} />
+          {selectedFoundationDatum && <div>
+            <CivicSandboxDashboard data={selectedFoundationDatum}>
+            </CivicSandboxDashboard>
           </div>}
         </section>)}
       </div>

--- a/packages/civic-sandbox/src/state/layerStyles.js
+++ b/packages/civic-sandbox/src/state/layerStyles.js
@@ -18,7 +18,7 @@ const foundation007GetColor = (f) => {
     value >= 12000 ? earth[3] :
     value >= 8000 ? earth[2] :
     value >= 4000 ? earth[1] :
-    value >= 0 ? earth[0] :
+    value >= 0 && value !== null ? earth[0] :
     [0, 0, 0, 100];
 };
 
@@ -33,7 +33,7 @@ const foundation018GetColor = (f) => {
     value >= 75000 ? space[3] :
     value >= 50000 ? space[2] :
     value >= 25000 ? space[1] :
-    value >= 0 ? space[0] :
+    value >= 0 && value !== null ? space[0] :
     [0, 0, 0, 100];
 };
 
@@ -85,7 +85,8 @@ const foundation021GetColor = (f) => {
 // FOUNDATION 022 - Rent Burden
 const foundation022GetColor = (f) => {
   const value = f.properties.rent_burden;
-  return value <= 20 ? thermal[0] :
+  return value === null ? [0, 0, 0, 100] :
+    value <= 20 ? thermal[0] :
     value <= 30 ? thermal[1] :
     value <= 40 ? thermal[2] :
     value <= 50 ? thermal[3] :
@@ -100,7 +101,8 @@ const foundation022GetColor = (f) => {
 // FOUNDATION 024 - Households with Children
 const foundation024GetColor = (f) => {
   const value = f.properties.pc_household_with_children_under_18;
-  return value <= 0.2 ? space[0] :
+  return value === null ? [0, 0, 0, 100] :
+    value <= 0.2 ? space[0] :
     value <= 0.3 ? space[1] :
     value <= 0.4 ? space[2] :
     value <= 0.5 ? space[3] :
@@ -115,7 +117,8 @@ const foundation024GetColor = (f) => {
 // FOUNDATION 025 - Households with Seniors
 const foundation025GetColor = (f) => {
   const value = f.properties.pc_household_with_individuals_65_ovr;
-  return value <= 0.2 ? ocean[0] :
+  return value === null ? [0, 0, 0, 100] :
+    value <= 0.2 ? ocean[0] :
     value <= 0.3 ? ocean[1] :
     value <= 0.4 ? ocean[2] :
     value <= 0.5 ? ocean[3] :
@@ -344,7 +347,7 @@ const foundation045GetColor = (f) => {
     value >= 75 ? ocean[3] :
     value >= 50 ? ocean[2] :
     value >= 25 ? ocean[1] :
-    value >= 0 ? ocean[0] :
+    value >= 0 && value !== null ? ocean[0] :
     [0, 0, 0, 100];
 };
 

--- a/packages/civic-sandbox/src/state/sandbox/selectors.js
+++ b/packages/civic-sandbox/src/state/sandbox/selectors.js
@@ -110,7 +110,6 @@ const makeVisFor = (spec, data) => {
     };
   }
   if (type === 'Text') {
-    // console.log('TYPE', spec.name, spec.field, data.properties[spec.field]);
     return {
       visualizationType: 'Text',
       title: spec.name,

--- a/packages/civic-sandbox/src/state/sandbox/selectors.js
+++ b/packages/civic-sandbox/src/state/sandbox/selectors.js
@@ -211,6 +211,22 @@ export const getSelectedFoundationDatum = createSelector(
     const attrs = foundation.slide_meta.attributes;
     const visualizations = [];
 
+    const selectedFoundationDatumProps = selectedFoundationDatum.object.properties;
+    const priamryFieldMatch = selectedFoundationDatumProps.hasOwnProperty(attrs.primary.field);
+    const secondaryFieldMatch = selectedFoundationDatumProps.hasOwnProperty(attrs.secondary.field);
+
+    if(!priamryFieldMatch && !secondaryFieldMatch) return;
+
+    if (attrs.primary && attrs.primary.field && attrs.primary.visualization) {
+      visualizations.push(
+        makeVisFor(attrs.primary, selectedFoundationDatum),
+      );
+    }
+    if (attrs.secondary && attrs.secondary.field && attrs.primary.visualization) {
+      visualizations.push(
+        makeVisFor(attrs.secondary, selectedFoundationDatum),
+      );
+    }
     if (attrs.primary && attrs.primary.field) {
       const legendType = {
         field: attrs.primary.field,
@@ -221,15 +237,6 @@ export const getSelectedFoundationDatum = createSelector(
 
       visualizations.push(
         makeVisFor(legendType, selectedFoundationDatum),
-      );
-
-      visualizations.push(
-        makeVisFor(attrs.primary, selectedFoundationDatum),
-      );
-    }
-    if (attrs.secondary && attrs.secondary.field) {
-      visualizations.push(
-        makeVisFor(attrs.secondary, selectedFoundationDatum),
       );
     }
 

--- a/packages/civic-sandbox/src/state/sandbox/selectors.js
+++ b/packages/civic-sandbox/src/state/sandbox/selectors.js
@@ -99,7 +99,7 @@ export const getLayerFoundation = createSelector(
 const makeVisFor = (spec, data) => {
   const type = spec.visualization.type;
   if (type === 'PercentDonut') {
-    const val = data.properties[spec.field];
+    const val = data.object.properties[spec.field];
     return {
       visualizationType: 'PercentDonut',
       title: spec.name,
@@ -110,13 +110,96 @@ const makeVisFor = (spec, data) => {
     };
   }
   if (type === 'Text') {
-    console.log('TYPE', spec.name, spec.field, data.properties[spec.field]);
+    // console.log('TYPE', spec.name, spec.field, data.properties[spec.field]);
     return {
       visualizationType: 'Text',
       title: spec.name,
-      data: data.properties[spec.field],
+      data: data.object.properties[spec.field] !== null && data.object.properties[spec.field] !== undefined ? data.object.properties[spec.field] : 'Data Not Available',
     };
   }
+  if (type === 'ComparisonBar') {
+    const val = data.object.properties[spec.field];
+    return {
+      visualizationType: 'ComparisonBar',
+      title: spec.name,
+      data: [
+        {
+          name: '',
+          value: val ? parseInt(data.object.properties[spec.field], 10) : 0,
+          sortOrder: 2,
+        },
+        {
+          name: spec.visualization.comparison_name,
+          value: spec.visualization.comparison_value === '10000000' ? 50000 : parseInt(spec.visualization.comparison_value, 10),
+          sortOrder: 1,
+        },
+      ],
+      dataLabel: 'name',
+      dataValue: 'value',
+      sortOrder: 'sortOrder',
+      minimalist: true,
+    };
+  }
+  if (type === 'Legend') {
+    const field = spec.field;
+    const colorScale = data.layer.props.getFillColor;
+
+    if (field === 'pgv_site_mean_mmi_txt') {
+      return {
+        visualizationType: 'Legend',
+        title: 'Map Legend',
+        min: 'Very strong (VII)',
+        max: 'Severe (VIII)',
+        colors: ['Very strong (VII)', 'Severe (VIII)']
+          .map(d => colorScale({properties: {[field]: d}}))
+          .map(d => `rgba(${d.slice(0,3).toString()},1.0)`),
+      };
+    }
+
+    if (field === 'pgd_total_wet_mean_di') {
+      return {
+        visualizationType: 'Legend',
+        title: 'Map Legend',
+        min: 'Low',
+        max: 'Very High',
+        colors: ['Low', 'Moderate', 'High', 'Very High']
+          .map(d => colorScale({properties: {[field]: d}}))
+          .map(d => `rgba(${d.slice(0,3).toString()},1.0)`),
+      };
+    }
+
+    if (field === 'pgd_landslide_dry_mean_di') {
+      return {
+        visualizationType: 'Legend',
+        title: 'Map Legend',
+        min: 'None',
+        max: 'Low',
+        colors: ['None', 'Low']
+          .map(d => colorScale({properties: {[field]: d}}))
+          .map(d => `rgba(${d.slice(0,3).toString()},1.0)`),
+      };
+    }
+
+    const minMax = [...data.layer.props.data]
+      .filter(d => d.properties[field] !== null && d.properties[field] !== undefined)
+      .sort((a,b) => a.properties[field] - b.properties[field]);
+
+    const uniqColors = [...minMax]
+      .map(d => colorScale(d))
+      .filter((d,i,arr) => arr.indexOf(d) === i);
+
+    const stringColors = uniqColors
+      .map(d => `rgba(${d.slice(0,3).toString()},1.0)`);
+
+    return {
+      visualizationType: 'Legend',
+      title: 'Map Legend',
+      min: minMax[0].properties[field],
+      max: minMax[minMax.length-1].properties[field],
+      colors: stringColors,
+    };
+  }
+
 };
 
 export const getSelectedFoundationDatum = createSelector(
@@ -129,13 +212,24 @@ export const getSelectedFoundationDatum = createSelector(
     const visualizations = [];
 
     if (attrs.primary && attrs.primary.field) {
+      const legendType = {
+        field: attrs.primary.field,
+        visualization: {
+          type: 'Legend',
+        },
+      };
+
       visualizations.push(
-        makeVisFor(attrs.primary, selectedFoundationDatum.object),
+        makeVisFor(legendType, selectedFoundationDatum),
+      );
+
+      visualizations.push(
+        makeVisFor(attrs.primary, selectedFoundationDatum),
       );
     }
     if (attrs.secondary && attrs.secondary.field) {
       visualizations.push(
-        makeVisFor(attrs.secondary, selectedFoundationDatum.object),
+        makeVisFor(attrs.secondary, selectedFoundationDatum),
       );
     }
 

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -32,7 +32,7 @@ class BaseMap extends Component {
         maxZoom: 16,
         pitch: props.initialPitch || 0,
         bearing: 0,
-        scrollZoom: false,
+        scrollZoom: true,
       },
       tooltipInfo: null,
       x: null,

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -11,7 +11,7 @@ const mapWrapper = css`
   margin: 0 auto;
   padding: 0;
   width: 100%;
-  height: 500px;
+  height: 100%;
 `;
 
 const navControl = css`
@@ -32,6 +32,7 @@ class BaseMap extends Component {
         maxZoom: 16,
         pitch: props.initialPitch || 0,
         bearing: 0,
+        scrollZoom: false,
       },
       tooltipInfo: null,
       x: null,
@@ -63,14 +64,15 @@ class BaseMap extends Component {
       y,
     } = this.state;
 
-    viewport.width = this.props.containerWidth ? this.props.containerWidth : 500;
-    viewport.height = 500;
-
     const {
+      height,
       mapboxStyle,
       mapboxToken,
       children,
     } = this.props;
+
+    viewport.width = this.props.containerWidth ? this.props.containerWidth : 500;
+    viewport.height = height ? height : 500;
 
     const childrenLayers = React.Children.map(children, child => {
       return React.cloneElement(child, {

--- a/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
+++ b/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
@@ -71,10 +71,10 @@ const iconActive = css`
 const donutChart = css`
   width: 90%;
   margin: 1% 2% 2% 7.5%;
-  height: 55%;
+  height: 75%;
+  overflow-y: hidden;
   @media(max-width: 900px) {
     max-height: 400px;
-    overflow-y: hidden;
   }
 `;
 

--- a/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
+++ b/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
@@ -3,21 +3,25 @@ import PropTypes from 'prop-types';
 import PieChart from '../PieChart/PieChart';
 import HorizontalBarChart from '../HorizontalBarChart/HorizontalBarChart';
 import { numeric, percentage } from '../utils/formatters';
-
 import { css } from 'emotion';
 
 const dashboard = css`
   background: rgba(255, 255, 255, 1.0);
   color: #000;
-  width: 25%;
-  min-height: 275px;
-  max-height: 590px;
+  width: 28%;
+  min-height: 300px;
+  max-height: 525px;
   position: absolute;
-  top: 20%;
-  left: 2.5%;
-  z-index: 4;
+  top: 21%;
+  left: 4%;
   display: flex;
   flex-direction: column;
+  @media (max-width: 900px) {
+    width: 100%;
+    position: relative;
+    left: 0;
+    display: inline-block;
+  }
 `;
 
 const contentContainer = css`
@@ -36,17 +40,15 @@ const watermarkContainer = css`
 `;
 
 const viz = css`
-  margin: 0 1% 1% 5%;
+  width: 90%;
+  margin: 1% 2% 2% 7.5%;
 `;
 
 const buttonContainer = css`
+  position: relative;
   display: flex;
   flex-direction: row;
-  margin-top: auto;
-  height: 28px;
   width: 100%;
-  position: sticky;
-  bottom: 0;
 `;
 
 const icon = css`
@@ -57,6 +59,7 @@ const icon = css`
   font-size: 20px;
   height: 98%;
   width: 50%;
+  margin: 0 auto;
 `;
 
 const iconActive = css`
@@ -67,6 +70,7 @@ const iconActive = css`
   font-size: 20px;
   height: 98%;
   width: 50%;
+  margin: 0 auto;
 `;
 
 class CivicDashboard extends React.Component {
@@ -106,14 +110,20 @@ class CivicDashboard extends React.Component {
             <p>{ object.data.toLocaleString() }</p>
           </div>
         ) : object.visualizationType === "PercentDonut" ? (
-          <div className={viz} key={index}>
+          <div className={viz} key={index}
+            style={{"maxHeight": "500px", "overflowY": "hidden", "overflowX": "visible"}}>
             <h2>{ object.title }</h2>
+            <h2 style={{"textAlign": "center", "margin": "auto", "width": "50%"}}>
+              { object.data[0].y < 1 ? percentage(object.data[0].y) :
+                object.data[0].y.toFixed(1) + "%"
+              }
+            </h2>
             <PieChart
               data={object.data}
-              colors={['#19b7aa','#a9a9a9']}
-              width={450}
-              height={350}
-              innerRadius={70}
+              colors={["#19b7aa","#a9a9a9"]}
+              width={475}
+              height={375}
+              innerRadius={90}
               halfDoughnut={true}
             />
           </div>
@@ -136,26 +146,26 @@ class CivicDashboard extends React.Component {
         ) : object.visualizationType === "Legend" ? (
           <div className={viz} key={index}>
             <h2>{ object.title }</h2>
-            <div style={{display: 'flex', flexDirection: 'row'}}>
+            <div style={{"display": "flex", "flexDirection": "row"}}>
               {
                 object.colors.map((d,i,arr) => {
                   return (
-                    <div style={{background: d, height: '40px', width: `${100/arr.length}%`}} key={'legend' + i}>
+                    <div style={{"background": d, "height": "40px", "width": `${100/arr.length}%`}} key={"legend" + i}>
                     </div>
                   );
                 })
               }
             </div>
             <div>
-              <h4 style={{float: 'left'}}>
+              <h4 style={{"float": "left"}}>
                 {
                   object.min === 0 ? 0 :
-                  object.min < 1 && object.min > 0 ? percentage(object.min) :
+                  object.min > 0 && object.min < 1 ? percentage(object.min) :
                   object.min > 1 ? numeric(object.min) :
                   object.min
                 }
               </h4>
-              <h4 style={{float: 'right'}}>
+              <h4 style={{"float": "right"}}>
                 {
                   object.max < 1 && object.max > 0 ? percentage(object.max) :
                   object.max > 1 ? numeric(object.max) :
@@ -171,10 +181,10 @@ class CivicDashboard extends React.Component {
     const buttons = (
       <div className={buttonContainer}>
         <div className={this.state.show === "info" ? iconActive : icon} onClick={this.showInfo}>
-          <span className={"fa fa-info-circle"}></span>
+          <div className={"fa fa-info-circle"}></div>
         </div>
         <div className={this.state.show === "viz" ? iconActive : icon} onClick={this.showViz}>
-          <span className={"fa fa-eye"}></span>
+          <div className={"fa fa-eye"}></div>
         </div>
       </div>
     );

--- a/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
+++ b/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
@@ -2,56 +2,70 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import PieChart from '../PieChart/PieChart';
 import HorizontalBarChart from '../HorizontalBarChart/HorizontalBarChart';
+import { numeric, percentage } from '../utils/formatters';
 
 import { css } from 'emotion';
 
 const dashboard = css`
   background: rgba(255, 255, 255, 1.0);
   color: #000;
-  width: 22.5%;
-  max-width: 350px;
-  max-height: 475px;
+  width: 25%;
+  min-height: 275px;
+  max-height: 590px;
   position: absolute;
-  right: 4%;
-  top: 1%;
-  overflow-y: auto;
-  pointer-events: auto;
+  top: 20%;
+  left: 2.5%;
   z-index: 4;
+  display: flex;
+  flex-direction: column;
 `;
 
-const dashboardViz = css`
-  margin: 0 0 0 7.5%;
+const contentContainer = css`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
 `;
 
 const watermarkContainer = css`
-  position:absolute;
+  position: absolute;
   left: 0;
   top: 0;
 `;
 
+const viz = css`
+  margin: 0 1% 1% 5%;
+`;
+
 const buttonContainer = css`
-  background-color: #f0f0f0;
   display: flex;
+  flex-direction: row;
+  margin-top: auto;
+  height: 28px;
   width: 100%;
+  position: sticky;
+  bottom: 0;
 `;
 
 const icon = css`
   text-align: center;
   border: 1px solid lightGray;
-  bottom: 0;
+  background-color: #f0f0f0;
   color: dimGray;
   font-size: 20px;
-  height: 15%;
+  height: 98%;
   width: 50%;
 `;
 
 const iconActive = css`
   text-align: center;
   border: 1px solid lightGray;
+  background-color: #f0f0f0;
   color: #dc4556;
-  bottom: 0;
   font-size: 20px;
-  height: 15%;
+  height: 98%;
   width: 50%;
 `;
 
@@ -87,67 +101,98 @@ class CivicDashboard extends React.Component {
     const visualizations = data.map((object, index) => {
       return (
         object.visualizationType === "Text" ? (
-          <div className={dashboardViz} key={index}>
+          <div className={viz} key={index}>
             <h2>{ object.title }</h2>
             <p>{ object.data.toLocaleString() }</p>
           </div>
-        ) : ["PieChart", "PercentDonut"].includes(object.visualizationType) ? (
-          <div className={dashboardViz} key={index}>
+        ) : object.visualizationType === "PercentDonut" ? (
+          <div className={viz} key={index}>
             <h2>{ object.title }</h2>
-            <div style={{ display: 'flex', justifyContent: 'space-around'}} >
-              <PieChart
-                data={object.data}
-                colors={['#19b7aa','#a9a9a9']}
-                width={450}
-                height={350}
-                innerRadius={90}
-                halfDoughnut={true}
-              />
-            </div>
+            <PieChart
+              data={object.data}
+              colors={['#19b7aa','#a9a9a9']}
+              width={450}
+              height={350}
+              innerRadius={70}
+              halfDoughnut={true}
+            />
           </div>
-        ) : object.visualizationType === "BarChart" ? (
-          <div className={dashboardViz} key={index}>
+        ) : object.visualizationType === "ComparisonBar" ? (
+          <div className={viz} key={index}>
             <h2>{ object.title }</h2>
-              <HorizontalBarChart
-                data={object.data}
-                dataKey={"sortOrder"}
-                dataValue={"value"}
-                dataKeyLabel={""}
-                title={""}
-                subtitle={""}
-                xLabel={""}
-                yLabel={""}
-              />
+            <HorizontalBarChart
+              minimalist={object.minimalist}
+              data={object.data}
+              sortOrder={object.sortOrder}
+              dataValue={object.dataValue}
+              dataLabel={object.dataLabel}
+              dataKeyLabel={""}
+              title={""}
+              subtitle={""}
+              xLabel={""}
+              yLabel={""}
+            />
+          </div>
+        ) : object.visualizationType === "Legend" ? (
+          <div className={viz} key={index}>
+            <h2>{ object.title }</h2>
+            <div style={{display: 'flex', flexDirection: 'row'}}>
+              {
+                object.colors.map((d,i,arr) => {
+                  return (
+                    <div style={{background: d, height: '40px', width: `${100/arr.length}%`}} key={'legend' + i}>
+                    </div>
+                  );
+                })
+              }
+            </div>
+            <div>
+              <h4 style={{float: 'left'}}>
+                {
+                  object.min === 0 ? 0 :
+                  object.min < 1 && object.min > 0 ? percentage(object.min) :
+                  object.min > 1 ? numeric(object.min) :
+                  object.min
+                }
+              </h4>
+              <h4 style={{float: 'right'}}>
+                {
+                  object.max < 1 && object.max > 0 ? percentage(object.max) :
+                  object.max > 1 ? numeric(object.max) :
+                  object.max
+                }
+              </h4>
+            </div>
           </div>
         ) : null
       );
     });
 
-    const content = this.state.show === "info" ? children : visualizations;
+    const buttons = (
+      <div className={buttonContainer}>
+        <div className={this.state.show === "info" ? iconActive : icon} onClick={this.showInfo}>
+          <span className={"fa fa-info-circle"}></span>
+        </div>
+        <div className={this.state.show === "viz" ? iconActive : icon} onClick={this.showViz}>
+          <span className={"fa fa-eye"}></span>
+        </div>
+      </div>
+    );
 
     return (
       <div className={dashboard}>
-        <div>
-          <div className={watermarkContainer}>
-            <svg width="134" height="135" xmlns="http://www.w3.org/2000/svg">
-              <g fill="none" fillRule="evenodd">
-                <path d="M0 134.658V0l11.566 11.597v123.061H0z" fill="#191119" />
-                <path d="M133.864 0v11.597H11.566v.008L0 .008V0h133.864z" fill="#DC4556" />
-              </g>
-            </svg>
-          </div>
+        <div className={contentContainer}>
+          { this.state.show === "info" ? children : visualizations }
         </div>
-        <div>
-          { content }
+        <div className={watermarkContainer}>
+          <svg width="134" height="135" xmlns="http://www.w3.org/2000/svg">
+            <g fill="none" fillRule="evenodd">
+              <path d="M0 134.658V0l11.566 11.597v123.061H0z" fill="#191119" />
+              <path d="M133.864 0v11.597H11.566v.008L0 .008V0h133.864z" fill="#DC4556" />
+            </g>
+          </svg>
         </div>
-        <div className={buttonContainer}>
-          <div className={this.state.show === "info" ? iconActive : icon} onClick={this.showInfo}>
-            <span className={"fa fa-info-circle"}></span>
-          </div>
-          <div className={this.state.show === "viz" ? iconActive : icon} onClick={this.showViz}>
-            <span className={"fa fa-eye"}></span>
-          </div>
-        </div>
+        { children ? buttons : null }
       </div>
     );
   }

--- a/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
+++ b/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
@@ -8,19 +8,14 @@ import { css } from 'emotion';
 const dashboard = css`
   background: rgba(255, 255, 255, 1.0);
   color: #000;
-  width: 28%;
+  width: 34%;
   min-height: 300px;
   max-height: 525px;
-  position: absolute;
-  top: 21%;
-  left: 4%;
   display: flex;
   flex-direction: column;
   @media (max-width: 900px) {
     width: 100%;
-    position: relative;
-    left: 0;
-    display: inline-block;
+    max-height: none;
   }
 `;
 
@@ -73,6 +68,16 @@ const iconActive = css`
   margin: 0 auto;
 `;
 
+const donutChart = css`
+  width: 90%;
+  margin: 1% 2% 2% 7.5%;
+  height: 55%;
+  @media(max-width: 900px) {
+    max-height: 400px;
+    overflow-y: hidden;
+  }
+`;
+
 class CivicDashboard extends React.Component {
   constructor(props) {
     super(props);
@@ -110,8 +115,7 @@ class CivicDashboard extends React.Component {
             <p>{ object.data.toLocaleString() }</p>
           </div>
         ) : object.visualizationType === "PercentDonut" ? (
-          <div className={viz} key={index}
-            style={{"maxHeight": "500px", "overflowY": "hidden", "overflowX": "visible"}}>
+          <div className={donutChart} key={index}>
             <h2>{ object.title }</h2>
             <h2 style={{"textAlign": "center", "margin": "auto", "width": "50%"}}>
               { object.data[0].y < 1 ? percentage(object.data[0].y) :

--- a/packages/component-library/src/CivicSandboxMap/CivicSandboxMap.js
+++ b/packages/component-library/src/CivicSandboxMap/CivicSandboxMap.js
@@ -16,30 +16,26 @@ const CivicSandboxMap = (props) => {
     onHoverSlide,
   } = props;
 
-  // Call multiple functions with supplied arguments
-  const mapClick = (...fns) => (...args) => {
-    fns.forEach(fn => fn(...args));
-  };
-
   const renderMaps = mapLayers.map((layer, index) => {
-    return layer.data.mapType === 'PathMap' ? (
-      <PathLayer
-        key={index}
-        id={layer.data.id}
-        pickable={layer.data.pickable}
-        data={layer.data.data}
-        getColor={layer.data.getColor}
-        opacity={layer.data.opacity}
-        getPath={layer.data.getPath}
-        getWidth={layer.data.getWidth}
-        widthScale={layer.data.widthScale}
-        widthMinPixels={1}
-        rounded={layer.data.rounded}
-        autoHighlight={layer.data.autoHighlight}
-        highlightColor={layer.data.highlightColor}
-        onHover={onHoverSlide}
-        parameters={{ depthTest: false }}
-      />
+    return (
+      layer.data.mapType === 'PathMap' ? (
+        <PathLayer
+          key={index}
+          id={layer.data.id}
+          pickable={layer.data.pickable}
+          data={layer.data.data}
+          getColor={layer.data.getColor}
+          opacity={layer.data.opacity}
+          getPath={layer.data.getPath}
+          getWidth={layer.data.getWidth}
+          widthScale={layer.data.widthScale}
+          widthMinPixels={1}
+          rounded={layer.data.rounded}
+          autoHighlight={layer.data.autoHighlight}
+          highlightColor={layer.data.highlightColor}
+          onHover={onHoverSlide}
+          parameters={{ depthTest: false }}
+        />
       ) : layer.data.mapType === 'ScatterPlotMap' ? (
         <ScatterplotLayer
           key={index}
@@ -91,24 +87,24 @@ const CivicSandboxMap = (props) => {
         />
       ) : layer.data.mapType === 'PolygonPlotMap' ||
           layer.data.mapType === 'SmallPolygonMap' ? (
-            <PolygonLayer
-              key={index}
-              id={layer.data.id}
-              pickable={layer.data.pickable}
-              data={layer.data.data}
-              opacity={layer.data.opacity}
-              getPolygon={layer.data.getPolygon}
-              getLineColor={layer.data.getLineColor}
-              getLineWidth={layer.data.getLineWidth}
-              lineWidthMinPixels={1}
-              stroked={layer.data.stroked}
-              getFillColor={layer.data.getFillColor}
-              filled={layer.data.filled}
-              onHover={onHoverSlide}
-              autoHighlight={layer.data.autoHighlight}
-              highlightColor={layer.data.highlightColor}
-              parameters={{ depthTest: false }}
-            />
+        <PolygonLayer
+          key={index}
+          id={layer.data.id}
+          pickable={layer.data.pickable}
+          data={layer.data.data}
+          opacity={layer.data.opacity}
+          getPolygon={layer.data.getPolygon}
+          getLineColor={layer.data.getLineColor}
+          getLineWidth={layer.data.getLineWidth}
+          lineWidthMinPixels={1}
+          stroked={layer.data.stroked}
+          getFillColor={layer.data.getFillColor}
+          filled={layer.data.filled}
+          onHover={onHoverSlide}
+          autoHighlight={layer.data.autoHighlight}
+          highlightColor={layer.data.highlightColor}
+          parameters={{ depthTest: false }}
+        />
       ) : layer.data.mapType === 'ChoroplethMap' ? (
         <PolygonLayer
           key={index}
@@ -123,13 +119,14 @@ const CivicSandboxMap = (props) => {
           stroked={layer.data.stroked}
           getFillColor={layer.data.getFillColor}
           filled={layer.data.filled}
-          onClick={mapClick(onClick, layer.data.onClick)}
+          onClick={onClick}
           autoHighlight={layer.data.autoHighlight}
           highlightColor={layer.data.highlightColor}
           parameters={{ depthTest: false }}
           updateTriggers={layer.data.updateTriggers || {}}
         />
-      ) : null;
+      ) : null
+    );
   });
 
   return (

--- a/packages/component-library/src/Sandbox/Sandbox.js
+++ b/packages/component-library/src/Sandbox/Sandbox.js
@@ -109,6 +109,8 @@ const Sandbox = ({
           mapboxToken={mapboxToken}
           mapboxStyle={mapboxStyle}
           initialZoom={10.5}
+          initialLatitude={45.5431}
+          height={650}
         >
           <CivicSandboxMap
             mapLayers={layerData}

--- a/packages/component-library/src/Sandbox/Sandbox.js
+++ b/packages/component-library/src/Sandbox/Sandbox.js
@@ -110,6 +110,7 @@ const Sandbox = ({
           mapboxStyle={mapboxStyle}
           initialZoom={10.5}
           initialLatitude={45.5431}
+          initialLongitude={-122.7465}
           height={575}
         >
           <CivicSandboxMap

--- a/packages/component-library/src/Sandbox/Sandbox.js
+++ b/packages/component-library/src/Sandbox/Sandbox.js
@@ -110,7 +110,7 @@ const Sandbox = ({
           mapboxStyle={mapboxStyle}
           initialZoom={10.5}
           initialLatitude={45.5431}
-          height={650}
+          height={575}
         >
           <CivicSandboxMap
             mapLayers={layerData}

--- a/packages/component-library/stories/CivicSandboxDashboard.story.js
+++ b/packages/component-library/stories/CivicSandboxDashboard.story.js
@@ -2,18 +2,16 @@
 import React from 'react';
 import * as d3 from 'd3';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, selectV2, number, boolean } from '@storybook/addon-knobs';
-import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 import { checkA11y } from '@storybook/addon-a11y';
 import { BaseMap } from '../src';
 import { CivicSandboxMap } from '../src';
-import CivicSandboxTooltip from '../src/CivicSandboxMap/CivicSandboxTooltip';
 import { CivicSandboxDashboard } from '../src';
 import { css } from 'emotion';
 import { wallOfText } from './shared';
 
-const dashboardInfo = css`
-  padding: 0 1% 0 7.5%;
+const dashboardDescription = css`
+  padding: 0 1% 0 5%;
 `;
 
 const displayName = CivicSandboxDashboard.displayName || 'CivicSandboxDashboard';
@@ -24,7 +22,6 @@ class LoadData extends React.Component {
     this.state = {
       foundation1: null,
       slide1: null,
-      slide2: null,
       error: null,
     };
   }
@@ -34,219 +31,253 @@ class LoadData extends React.Component {
     d3.queue()
       .defer(d3.json, this.props.urls[0])
       .defer(d3.json, this.props.urls[1])
-      .defer(d3.json, this.props.urls[2])
-      .await((error, foundation1, slide1, slide2) => {
-        if (error) { return this.setState({error: error}) }
-        cmp.setState({foundation1, slide1, slide2});
+      .await((error, foundation1, slide1) => {
+        if (error) { cmp.setState({error: error}) }
+        cmp.setState({foundation1, slide1});
       });
   }
 
   render() {
-    if (this.state.data1 === null) { return null }
-    const { foundation1, slide1, slide2 } = this.state;
-    return this.props.children(foundation1, slide1, slide2);
+    if (this.state.foundation1 === null) { return null }
+    const { foundation1, slide1 } = this.state;
+    return this.props.children(foundation1, slide1);
   }
 }
 
 const dataURLs = [
   'https://gist.githubusercontent.com/mendozaline/f78b076ce13a9fd484f6b8a004065a95/raw/ff8bd893ba1890a6f6c20265f720587f9595a9c4/pop.json',
-  'https://gist.githubusercontent.com/mendozaline/b3a75b40c9a60781b6adc77cebb9b400/raw/fa0aa13c75bfcc2fd92ccf1f3cc612af83d5d704/002-bike-lanes.json',
   'https://gist.githubusercontent.com/mendozaline/b3a75b40c9a60781b6adc77cebb9b400/raw/fa0aa13c75bfcc2fd92ccf1f3cc612af83d5d704/010-grocery.json',
 ];
+
+const dashboardComponent = (foundationData1, slideData1) => {
+  if (foundationData1 === null) { return null }
+
+  const mapboxToken = 'pk.eyJ1IjoidGhlbWVuZG96YWxpbmUiLCJhIjoiY2o1aXdoem1vMWtpNDJ3bnpqaGF1bnlhNSJ9.sjTrNKLW9daDBIGvP3_W0w';
+  const mapboxStyle = 'mapbox://styles/hackoregon/cjiazbo185eib2srytwzleplg';
+  const planetColorScheme = [[247,244,249,255],[231,225,239,255],[212,185,218,255],[201,148,199,255],[223,101,176,255],[231,41,138,255],[206,18,86,255],[152,0,67,255],[103,0,31,255]];
+
+  const populationGetColor = f => {
+    const population = parseFloat(f.properties.total_population);
+    return population < 3000 ? planetColorScheme[0] :
+      population < 8000 ? planetColorScheme[1] :
+      population < 12000 ? planetColorScheme[2] :
+      population < 16000 ? planetColorScheme[3] :
+      population < 20000 ? planetColorScheme[4] :
+      population < 24000 ? planetColorScheme[5] :
+      population < 28000 ? planetColorScheme[6] :
+      population < 32000 ? planetColorScheme[7] :
+      planetColorScheme[8];
+  };
+
+  const foundation = {
+    mapType: 'ChoroplethMap',
+    id: 'choropleth-layer-foundation-population',
+    pickable: true,
+    data: foundationData1.slide_data.features,
+    opacity: 0.5,
+    getPolygon: f => f.geometry.coordinates,
+    getLineColor: f => [0, 0, 0, 255],
+    getLineWidth: f => 0.5,
+    stroked: true,
+    getFillColor: populationGetColor,
+    filled: true,
+    autoHighlight: true,
+    highlightColor: [200, 200, 200, 150],
+    updateTriggers: { getFillColor: populationGetColor },
+  };
+
+  const groceryBoundary = {
+    mapType: 'PolygonPlotMap',
+    id: 'boundary-layer-grocery',
+    data: slideData1.slide_meta.boundary,
+    opacity: 1,
+    filled: false,
+    getPolygon: f => f.coordinates,
+    getLineColor: f => [138, 43, 226, 255],
+    getLineWidth: f => 45,
+    lineWidthScale: 1,
+    lineJointRounded: false,
+  };
+  const groceryMap = {
+    mapType: 'ScatterPlotMap',
+    id: 'scatterplot-layer-grocery',
+    pickable: true,
+    data: slideData1.slide_data.features,
+    getPosition: f => f.geometry.coordinates,
+    opacity: 0.9,
+    getColor: f => [138,43,226,255],
+    getRadius: f => 75,
+    radiusScale: 1,
+    radiusMinPixels: 1,
+    autoHighlight: true,
+    parameters: { depthTest: false },
+    highlightColor: [200, 200, 200, 255],
+  };
+
+  const mapLayers = [
+    {
+      data: foundation,
+      visible: true,
+    },
+    {
+      data: groceryBoundary,
+      visible: true,
+    },
+    {
+      data: groceryMap,
+      visible: true,
+    },
+  ];
+
+  // Dashboard Data
+  const legendData = {
+    "visualizationType": "Legend",
+    "title": "Map Legend",
+    "min": 2500,
+    "max": 32000,
+    "colors": [
+      "rgba(247,244,249,1.0)",
+      "rgba(231,225,239,1.0)",
+      "rgba(212,185,218,1.0)",
+      "rgba(201,148,199,1.0)",
+      "rgba(223,101,176,1.0)",
+      "rgba(231,41,138,1.0)",
+      "rgba(206,18,86,1.0)",
+      "rgba(152,0,67,1.0)",
+      "rgba(103,0,31,1.0)",
+    ],
+  };
+
+  const textData = {
+    visualizationType: 'Text',
+    title: 'Population',
+    data: 245450,
+  };
+
+  const comarpisonBarData = {
+    "visualizationType": "ComparisonBar",
+    "title": "Total Population",
+    "data": [
+      {
+        "name": "Downtown",
+        "value": 30639,
+        "sortOrder": 2,
+      },
+      {
+        "name": "Average Total Population",
+        "value": 55000,
+        "sortOrder": 1,
+      },
+    ],
+    "dataLabel": "name",
+    "dataValue": "value",
+    "sortOrder": "sortOrder",
+    "minimalist": true,
+  };
+
+  const donutData = {
+    "visualizationType": "PercentDonut",
+    "title": "Households with Children",
+    "data": [
+      {
+        "x": "Households with Children",
+        "y": 0.75,
+      },
+      {
+        "x": null,
+        "y": 0.25,
+      },
+    ],
+  };
+
+  const legnendVisible = boolean('Legend:', true);
+  const textVisible = boolean('Text:', true);
+  const comarpisonBarsVisible = boolean('Comparison Bars:', true);
+  const donutVisible = boolean('Percent Donut:', true);
+
+  const dashboardArray = [
+    {
+      "data": legendData,
+      "visible": legnendVisible,
+    },
+    {
+      "data": textData,
+      "visible": textVisible,
+    },
+    {
+      "data": comarpisonBarData,
+      "visible": comarpisonBarsVisible,
+    },
+    {
+      "data": donutData,
+      "visible": donutVisible,
+    },
+  ];
+
+  const dashboardData = dashboardArray
+    .filter(d => d.visible)
+    .map(d => d.data);
+
+  //Dashboard Description
+  const dashboardInformation = (
+    <div className={dashboardDescription}>
+      <h2>How has ridership changed throughout Tri-Met's service area over time?</h2>
+      <p>{ wallOfText }</p>
+      <p>{ wallOfText }</p>
+      <p>{ wallOfText }</p>
+      <p>{ wallOfText }</p>
+      <p>{ wallOfText }</p>
+      <p>{ wallOfText }</p>
+      <p>{ wallOfText }</p>
+      <p>{ wallOfText }</p>
+      <h4>Source: census.gov ACS</h4>
+    </div>
+  );
+  const dashboardDescriptionVisible = boolean('Include Description:', true);
+
+  return (
+    <div>
+      <div style={{ margin: '0 4%'}}>
+        <BaseMap
+          mapboxToken={mapboxToken}
+          mapboxStyle={mapboxStyle}
+          initialZoom={10.5}
+          initialLatitude={45.5445}
+          initialLongitude={-122.7250}
+          height={650}
+        >
+            <CivicSandboxMap mapLayers={mapLayers}>
+            </CivicSandboxMap>
+        </BaseMap>
+      </div>
+      <div
+        className={css(`
+          position: absolute;
+          top: 2%;
+          left: 7.5%;
+          width: 92.5%;
+          height: 0;
+          @media(max-width: 900px) {
+            position: relative;
+            left: 0;
+            height: 100%;
+          };
+        `)}
+      >
+        <CivicSandboxDashboard data={dashboardData}>
+          { dashboardDescriptionVisible ? dashboardInformation : null }
+        </CivicSandboxDashboard>
+      </div>
+    </div>
+  );
+};
+
 
 export default () => storiesOf(displayName, module)
   .addDecorator(withKnobs)
   .addDecorator(checkA11y)
   .add('Simple usage', () => (
     <LoadData urls={dataURLs}>
-      {
-        (foundation1, slide1, slide2) => {
-          if (foundation1 === null) { return null }
-
-          const mapboxToken = 'pk.eyJ1IjoidGhlbWVuZG96YWxpbmUiLCJhIjoiY2o1aXdoem1vMWtpNDJ3bnpqaGF1bnlhNSJ9.sjTrNKLW9daDBIGvP3_W0w';
-          const mapStyleOptions = {
-            'Hack Oregon Light': 'mapbox://styles/hackoregon/cjiazbo185eib2srytwzleplg',
-            'Hack Oregon Dark': 'mapbox://styles/hackoregon/cjie02elo1vyw2rohd24kbtbd',
-            'Scenic': 'mapbox://styles/themendozaline/cj8rrlv4tbtgs2rqnyhckuqva',
-            'Navigation Guidance Night': 'mapbox://styles/themendozaline/cj6y6f5m006ar2sobpimm7ay7',
-            'Lè Shine': 'mapbox://styles/themendozaline/cjg6296ub04ot2sqv9izku3qq',
-            'North Star': 'mapbox://styles/themendozaline/cj5oyewyy0fg22spetiv0hap0',
-            'Odyssey': 'mapbox://styles/themendozaline/cjgq6rklb000d2so1b8myaait',
-          };
-          const mapboxStyle = selectV2('Mapbox Style', mapStyleOptions, mapStyleOptions['Hack Oregon Light']);
-
-          const opacityOptions = {
-            range: true,
-            min: 0,
-            max: 1,
-            step: 0.05,
-          };
-          const opacity = number('Opacity:', 0.75, opacityOptions);
-
-          const colorOptions = {
-            'Thermal': '[[255,255,204,255],[255,237,160,255],[254,217,118,255],[254,178,76,255],[253,141,60,255],[252,78,42,255],[227,26,28,255],[189,0,38,255],[128,0,38,255]]',
-            'Planet': '[[247,244,249,255],[231,225,239,255],[212,185,218,255],[201,148,199,255],[223,101,176,255],[231,41,138,255],[206,18,86,255],[152,0,67,255],[103,0,31,255]]',
-            'Space': '[[247,252,253,255],[224,236,244,255],[191,211,230,255],[158,188,218,255],[140,150,198,255],[140,107,177,255],[136,65,157,255],[129,15,124,255],[77,0,75,255]]',
-            'Earth': '[[255,247,251,255],[236,226,240,255],[208,209,230,255],[166,189,219,255],[103,169,207,255],[54,144,192,255],[2,129,138,255],[1,108,89,255],[1,70,54,255]]',
-            'Ocean': '[[255,255,217,255],[237,248,177,255],[199,233,180,255],[127,205,187,255],[65,182,196,255],[29,145,192,255],[34,94,168,255],[37,52,148,255],[8,29,88,255]]',
-          };
-          const colorScheme = selectV2('Color Schemes:', colorOptions, colorOptions['Ocean']);
-          const colorSchemeArray = JSON.parse(colorScheme);
-
-          const populationGetColor = f => {
-            const population = parseFloat(f.properties.total_population); 
-            return population < 3000 ? colorSchemeArray[0] :
-              population < 8000 ? colorSchemeArray[1] :
-              population < 12000 ? colorSchemeArray[2] :
-              population < 16000 ? colorSchemeArray[3] :
-              population < 20000 ? colorSchemeArray[4] :
-              population < 24000 ? colorSchemeArray[5] :
-              population < 28000 ? colorSchemeArray[6] :
-              population < 32000 ? colorSchemeArray[7] :
-              colorSchemeArray[8];
-          };
-
-          const foundation = {
-            mapType: 'ChoroplethMap',
-            id: 'choropleth-layer-foundation-population',
-            pickable: true,
-            data: foundation1.slide_data.features,
-            opacity: opacity,
-            getPolygon: f => f.geometry.coordinates,
-            getLineColor: f => [0,0,0,255],
-            getLineWidth: f => 50,
-            stroked: true,
-            getFillColor: populationGetColor,
-            filled: true,
-            onClick: info => action('Layer clicked:', { depth: 2 })(info, info.object),
-            autoHighlight: true,
-            highlightColor: [200,200,200,150],
-            updateTriggers: {getFillColor: populationGetColor},
-          };
-
-          //SLIDES
-          //002 Bike Lanes
-          const bikeLanesBoundary = {
-            mapType: 'PolygonPlotMap',
-            id: 'boundary-layer-bike-lanes',
-            data: slide1.slide_meta.boundary,
-            opacity: 1,
-            filled: false,
-            getPolygon: f => f.coordinates,
-            getLineColor: f => [220,69,86,255],
-            getLineWidth: f => 55,
-            lineWidthScale: 1,
-            lineJointRounded: false,
-          };
-          const bikeLanesMap = {
-            mapType: 'PathMap',
-            id: 'path-layer-bike-lanes',
-            pickable: true,
-            data: slide1.slide_data.features,
-            opacity: 1,
-            getColor: f => [220,69,86,255],
-            getPath: f => f.geometry.coordinates,
-            getWidth: f => 40,
-            rounded: false,
-            autoHighlight: true,
-            highlightColor: [200,200,200,100],
-          };
-
-          //010 Grocery Stores
-          const groceryBoundary = {
-            mapType: 'PolygonPlotMap',
-            id: 'boundary-layer-grocery',
-            data: slide2.slide_meta.boundary,
-            opacity: 1,
-            filled: false,
-            getPolygon: f => f.coordinates,
-            getLineColor: f => [138,43,226,255],
-            getLineWidth: f => 45,
-            lineWidthScale: 1,
-            lineJointRounded: false,
-          };
-          const groceryMap = {
-            mapType: 'ScatterPlotMap',
-            id: 'scatterplot-layer-grocery',
-            pickable: true,
-            data: slide2.slide_data.features,
-            getPosition: f => f.geometry.coordinates,
-            opacity: 0.9,
-            getColor: f => [138,43,226,255],
-            getRadius: f => 75,
-            radiusScale: 1,
-            radiusMinPixels: 1,
-            autoHighlight: true,
-            parameters: { depthTest: false },
-            highlightColor: [200,200,200,255],
-          };
-
-          const bikeLanesSlideVisible = boolean('Bike Lanes:', true);
-          const grocerySlideVisible = boolean('Grocery Stores:', true);
-
-          const allMapLayers = [
-            {
-              "data": foundation,
-              "visible": true,
-            },
-            {
-              "data": bikeLanesBoundary,
-              "visible": bikeLanesSlideVisible,
-            },
-            {
-              "data": bikeLanesMap,
-              "visible": bikeLanesSlideVisible,
-            },
-            {
-              "data": groceryBoundary,
-              "visible": grocerySlideVisible,
-            },
-            {
-              "data": groceryMap,
-              "visible": grocerySlideVisible,
-            },
-          ];
-
-          const mapLayersArray = allMapLayers.filter(d => {
-            if (d.visible === true) { return d.data }
-          });
-
-          //dashboard data
-          const mockData = [
-            {
-              visualizationType: 'Text',
-              title: 'Population',
-              data: 245450,
-            },
-            {
-              visualizationType: 'PieChart',
-              title: 'Percentage White/Non-White',
-              data: [{'x': 1, 'y': 40}, {'x': 2, 'y': 60}],
-            },
-          ];
-
-          return (
-            <div style={{position:"relative"}}>
-              <BaseMap
-                mapboxToken={mapboxToken}
-                mapboxStyle={mapboxStyle}
-                initialZoom={10.1}
-                initialLatitude={45.5445}
-                initialLongitude={-122.5599}
-              >
-                <CivicSandboxMap mapLayers={mapLayersArray}>
-                  <CivicSandboxTooltip/>
-                </CivicSandboxMap>
-              </BaseMap>
-              <CivicSandboxDashboard data={mockData}>
-                <div className={dashboardInfo}>
-                  <h2>How has ridership changed throughout Tri-Met's service area over time?</h2>
-                  <p>{wallOfText}</p>
-                  <h4>Source: census.gov ACS</h4>
-                </div>
-              </CivicSandboxDashboard>
-            </div>
-          );
-      }}
+      { (foundation1, slide1, slide2) => dashboardComponent(foundation1, slide1, slide2) }
     </LoadData>
   ));


### PR DESCRIPTION
This is a follow up on [#269](https://github.com/hackoregon/civic/issues/269). 

The dashboard now includes the comparison bar and legend options. However, most of the comparison bars have placeholder values. So we can now update those foundation layers with real data. I planned on using the Gradient Scale component for the map legend, but I ran into issues with that. Instead I had to create something new. This meant only showing colors visible on the map and not all 9 colors in the scale. And only displaying the minimum and maximum numbers on the ends. I'm still trying to think of how to show the intermediate values. Also for the disaster response foundations, I had to account for the categorical data.

Other changes:
- [x] Increased the height of the map
- [x] Dashboard buttons only render if a description is provided
- [x] Moved the dashboard to the left to avoid overlap with the slide selector
- [x] Disable zoom on scroll

To do:
- [x] Make the dashboard responsive for small screens
