### PR TITLE
Add source link to Sandbox footer

### DIFF
--- a/packages/civic-sandbox/src/components/App/index.js
+++ b/packages/civic-sandbox/src/components/App/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import Packages from '../Packages';
-import '@hackoregon/component-library/assets/global.styles.css';
 import { PageLayout } from '@hackoregon/component-library';
+import '@hackoregon/component-library/assets/global.styles.css';
+import Packages from '../Packages';
 
+const attribution = (<a href="https://service.civicpdx.org">Data Sources</a>);
 
 const App = () => (
-  <PageLayout>
+  <PageLayout attribution={attribution}>
     <Packages />
   </PageLayout>
 );

--- a/packages/component-library/src/Footer/Footer.js
+++ b/packages/component-library/src/Footer/Footer.js
@@ -73,10 +73,7 @@ const scrollToTopClass = css`
   }
 `;
 
-const defaultAttribution = (
-  <div>
-    &copy; Copyright {(new Date()).getFullYear()}
-  </div>);
+const defaultAttribution = `\u00A9 Copyright ${(new Date()).getFullYear()}`;
 
 const Footer = ({ attribution }) => (
   <div className={footerClass}>

--- a/packages/component-library/src/Footer/Footer.js
+++ b/packages/component-library/src/Footer/Footer.js
@@ -73,10 +73,7 @@ const scrollToTopClass = css`
   }
 `;
 
-const defaultAttribution = (
-  <div>
-    &copy; Copyright {(new Date()).getFullYear()}
-  </div>);
+const defaultAttribution = <div />;
 
 const Footer = ({ attribution }) => (
   <div className={footerClass}>

--- a/packages/component-library/src/Footer/Footer.js
+++ b/packages/component-library/src/Footer/Footer.js
@@ -73,7 +73,10 @@ const scrollToTopClass = css`
   }
 `;
 
-const defaultAttribution = <div />;
+const defaultAttribution = (
+  <div>
+    &copy; Copyright {(new Date()).getFullYear()}
+  </div>);
 
 const Footer = ({ attribution }) => (
   <div className={footerClass}>

--- a/packages/component-library/src/Footer/Footer.js
+++ b/packages/component-library/src/Footer/Footer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { css } from 'emotion';
 import LogoStandard from '../Logo/LogoStandard';
@@ -72,9 +73,14 @@ const scrollToTopClass = css`
   }
 `;
 
-const Footer = () => (
+const defaultAttribution = (
+  <div>
+    &copy; Copyright {(new Date()).getFullYear()}
+  </div>);
+
+const Footer = ({ attribution }) => (
   <div className={footerClass}>
-    <div className={copyrightClass}>&copy; Copyright {(new Date()).getFullYear()}</div>
+    <div className={copyrightClass}>{attribution}</div>
     <div className={logoClass}><Link to="/" className={logoLinkStyle}><LogoStandard /></Link></div>
     <div className={scrollToTopClass}><ScrollToTop iconStyle="fa fa-angle-up" /></div>
   </div>
@@ -82,5 +88,13 @@ const Footer = () => (
 );
 
 Footer.displayName = 'Footer';
+
+Footer.defaultProps = {
+  attribution: defaultAttribution,
+};
+
+Footer.propTypes = {
+  attribution: PropTypes.node,
+};
 
 export default Footer;

--- a/packages/component-library/src/PageLayout/PageLayout.js
+++ b/packages/component-library/src/PageLayout/PageLayout.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from 'emotion';
-import CivicStoryCard from '../CivicStoryCard/CivicStoryCard';
-import Header from '../Navigation/Header'
-import Footer from '../Footer/Footer'
-import CollectionHero from '../Hero/CollectionHero'
+import Header from '../Navigation/Header';
+import Footer from '../Footer/Footer';
+import CollectionHero from '../Hero/CollectionHero';
 
 const defaultStyles = css`
   padding: 0px 24px;
@@ -30,9 +29,9 @@ const defaultStyles = css`
   }
 `;
 
-const PageLayout = ({ cardId, collectionId, heroTitle, heroSubtitle, title, mainProjectColor, teamTitle, overlay, children }) => (
+const PageLayout = ({ heroTitle, heroSubtitle, mainProjectColor, teamTitle, overlay, children, attribution }) => (
   <div>
-    <Header title="Civic" mainProjectColor={mainProjectColor} overlay={overlay ? overlay : false} />
+    <Header title="Civic" mainProjectColor={mainProjectColor} overlay={overlay || false} />
     { heroTitle && <CollectionHero
       teamTitle={teamTitle}
       heroTitle={heroTitle}
@@ -42,7 +41,7 @@ const PageLayout = ({ cardId, collectionId, heroTitle, heroSubtitle, title, main
     <div className={defaultStyles}>
       {children}
     </div>
-    <Footer />
+    <Footer attribution={attribution} />
   </div>
 );
 
@@ -53,9 +52,9 @@ PageLayout.propTypes = {
   teamTitle: PropTypes.string,
   heroTitle: PropTypes.string,
   heroSubtitle: PropTypes.string,
-  title: PropTypes.string,
   mainProjectColor: PropTypes.string,
   children: PropTypes.node,
+  attribution: PropTypes.node,
 };
 
 export default PageLayout;


### PR DESCRIPTION
This will complete #371 by adding a data sources attribution link to the Sandbox footer.

I see this as a stop gap solution to at least cover our bases for the attribution that we need for the Eviction Labs data. Ideally, the data sources would be connected to each layer, but since we don't have that capability right now, I'm linking to our default data sources page.