### PR TITLE
Update z-index for Navigation dropdown

### DIFF
--- a/packages/component-library/src/Navigation/Nav.js
+++ b/packages/component-library/src/Navigation/Nav.js
@@ -95,7 +95,7 @@ const exClass = css`
     position: absolute;
     right: 1rem;
     width: auto;
-    z-index: 999;
+    z-index: 99999;
 
     @media (max-width: 640px) {
       display: block;


### PR DESCRIPTION
Fixes an issue in the sandbox where the navigation control doesn't display above the package selector.

The offending issue:
![image](https://user-images.githubusercontent.com/7065695/46267103-40989b80-c4e8-11e8-9924-2cd1b39c4b2c.png)
