### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto
+
+yarn.lock -diff
+packages/component-library/es/** -diff


### PR DESCRIPTION
This adds a .gitattributes file that does two things:
1. Ensures that line ending uniformity across platforms. Here's [more than you ever wanted to know about git and line endings](https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/). I recall this was an issue for a few developers last season, and I encountered it while helping @bradfordjanice get set up.

2. Tells git to not try to merge the yarn.lock file and all files in the packages/component-library/es/ directory. We'll still be able to see whether those files changed, but the diffs will be hidden from our PRs!
_Note: the reason that we just can't just .gitignore the whole packages/component-library/es/ directory is so that it's available while npm installing the component library in other contexts (#398)_

[This article](https://medium.com/@pablorsk/be-a-git-ninja-the-gitattributes-file-e58c07c9e915) has more info on .gitattributes files.