### PR TITLE
Remove link to out of date platform info repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,7 @@
 
 Hello! Whether you have met with the Hack Oregon organization or not, you are welcome to contribute to the Civic Platform!
 Bear in mind that this repo only encompasses the front-end web assets. There are many backend repos as well where data
-is cleaned, analyzed, converted into databases, and made available through APIs. See the whole landscape in the
-[Civic Platform Info repository](https://github.com/hackoregon/Civic-platform-info).
+is cleaned, analyzed, converted into databases, and made available through APIs.
 
 We use React and Redux as the backbone of our front-end technologies, but there are also many smaller libraries that any
 contributor may want to learn more about. Here's a list of resources:


### PR DESCRIPTION
If someone was to go to this link, they would be very confused and misinformed about the architecture of the CIVIC Platform.

It's possible the linked repo should be deprecated. If not, it needs an overhaul.