### PR TITLE
Update Transportation API Endpoint For Plateau In Ridership

### DIFF
--- a/packages/2018-transportation-systems/src/state/decline-in-ridership/actions.js
+++ b/packages/2018-transportation-systems/src/state/decline-in-ridership/actions.js
@@ -10,7 +10,7 @@ export const ridershipOverTimeSuccess = actionEmitter(API_SUCCESS);
 export const ridershipOverTimeError = actionEmitter(API_ERROR);
 
 const DECLINE_IN_RIDERSHIP_API =
-  'http://service.civicpdx.org/transportation-systems/passenger-census/system/annual/total/?format=json';
+  'http://service.civicpdx.org/transportation-systems/passenger-census/system/annual/averages/?format=json';
 
 export const fetchRidershipOverTime = apiAdapter(DECLINE_IN_RIDERSHIP_API, {
   start: ridershipOverTimeStart,


### PR DESCRIPTION
Per our [Swagger docs for the Transportation API](http://service.civicpdx.org/transportation-systems/):
This viewset is deprecated. Returns same values as `/system/annual/averages`. Please update to use other endpoint

Links to both endpoints included for review convenience
http://service.civicpdx.org/transportation-systems/passenger-census/system/annual/total/?format=json
http://service.civicpdx.org/transportation-systems/passenger-census/system/annual/averages/?format=json