### PR TITLE
Add prettier precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,13 @@
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check"
   },
   "husky": {
-    "hooks": {}
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   },
   "lint-staged": {
-    "*.{js,jsx}": [
+    "*.{js,jsx,json}": [
       "prettier --write",
-      "eslint --fix",
       "git add"
     ],
     "*.{css,md}": [


### PR DESCRIPTION
Implemented pre-commit hook for prettier. For now, it does not run eslint, but this will change when we have the project linted.