### PR TITLE
Rimraf es and dist before building component-library

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "modules": "es/index.js",
   "scripts": {
-    "build:esm": "babel src --out-dir es --copy-files --no-comments",
-    "build:cjs": "babel src --out-dir dist --copy-files --no-comments",
+    "build:esm": "rimraf es && babel src --out-dir es --copy-files --no-comments",
+    "build:cjs": "rimraf dist && babel src --out-dir dist --copy-files --no-comments",
     "build": "BABEL_ENV=esm yarn run build:esm && BABEL_ENV=cjs yarn run build:cjs",
     "configure": "yarn run build",
     "test": "BABEL_ENV=test mocha --opts ./mocha.options ./src/**/*.test.js",
@@ -56,6 +56,7 @@
     "ignore-styles": "^5.0.1",
     "mocha": "^6.0.2",
     "mocha-clean": "^1.0.0",
+    "rimraf": "^2.6.2",
     "sinon": "^7.2.7",
     "sinon-chai": "^3.3.0",
     "source-map-support": "^0.4.11",


### PR DESCRIPTION
Fixes #471.

A few layers deep, found that storybook-to-ghpages was hitting this error when running build-storybook:
```ERR! Module not found: Error: Can't resolve 'recharts' in '/Users/jaronheard/Documents/programming/web/clones/temp/civic/packages/component-library/dist/AreaChart'```

AreaChart and recharts were removed as part of #423 -- but since `babel src --out-dir dist`  [doesn't overwrite any other files or directories](https://babeljs.io/docs/en/babel-cli) in dist, there were still files from a prior build of the removed AreaChart component. 

No change to the yarn.lock file as `rimraf` is already a dev dependency at the workspace root.