### PR TITLE
Add useful suggestions when running yarn start and yarn storybook in wrong places

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "canary": "lerna publish --skip-git --skip-npm --canary",
     "clean": "lerna clean && rimraf node_modules",
     "watch": "node scripts/watch",
+    "start": "node scripts/start",
     "deploy-storybook": "BABEL_ENV=esm storybook-to-ghpages",
     "in": "lerna run --scope",
     "link:all": "lerna link",

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -11,7 +11,9 @@
     "configure": "yarn run build",
     "test": "BABEL_ENV=test mocha --opts ./mocha.options ./src/**/*.test.js",
     "test:watch": "yarn run test -- -w",
-    "lint": "eslint --fix src"
+    "lint": "eslint --fix src",
+    "storybook": "node scripts/storybook.js",
+    "start": "node scripts/start.js"        
   },
   "author": "David Daniel <davidedaniel@gmail.com> (http://davidedaniel.github.io)",
   "license": "MIT",

--- a/packages/component-library/scripts/start.js
+++ b/packages/component-library/scripts/start.js
@@ -1,0 +1,3 @@
+console.log(
+  "`yarn start` doesn't work here. Maybe you meant to run `yarn storybook` at project root?"
+);

--- a/packages/component-library/scripts/storybook.js
+++ b/packages/component-library/scripts/storybook.js
@@ -1,0 +1,3 @@
+console.log(
+  "`yarn start` doesn't work here. Maybe you meant to run `yarn storybook` at project root?"
+);

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,3 @@
+console.log(
+  "`yarn start` only works in project packages, not at project root. Did you mean `yarn storybook`?"
+);


### PR DESCRIPTION
I've seen a decent amount of people run `yarn start` and `yarn storybook` from the component library, and `yarn start` from the project root.

This improves that experience by logging a useful message about where you might want to run the command.

And when I say people, I also mean me. 🙃