### PR TITLE
Issue #471 - Storybook Deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,10 @@ deploy-2018: setup-aws access-ecr
 	./bin/ecs-deploy.sh --cluster $$ECS_CLUSTER --service-name $$ECS_SERVICE_2018 --image $$REMOTE_IMAGE_URL/civic-2018:latest --timeout 10
 
 deploy-component-library:
+	@echo "Deploying the component library"
+	yarn run deploy-storybook -- --ci --existing-output-dir=packages/component-library/es
 	@echo "Setting npm credentials"
 	npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 	@echo "Publishing canary versions of packages to npm"
 	yarn run publish-canary
-	@echo "Deploying the component library"
-	yarn run deploy-storybook -- --ci
 


### PR DESCRIPTION
This should workaround issue #471 -- since we've already successfully built the component library as part of our test suite, we can just deploy that version rather than building it again.

I think the issue we were encountering was potentially a node out of memory error, similar to the issue this person encountered.
https://github.com/storybooks/storybook-deployer/issues/57