### PR TITLE
Revert "Issue #471 - Storybook Deployment"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,10 @@ deploy-2018: setup-aws access-ecr
 	./bin/ecs-deploy.sh --cluster $$ECS_CLUSTER --service-name $$ECS_SERVICE_2018 --image $$REMOTE_IMAGE_URL/civic-2018:latest --timeout 10
 
 deploy-component-library:
-	@echo "Deploying the component library"
-	yarn run deploy-storybook -- --ci --existing-output-dir=packages/component-library/es
 	@echo "Setting npm credentials"
 	npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 	@echo "Publishing canary versions of packages to npm"
 	yarn run publish-canary
+	@echo "Deploying the component library"
+	yarn run deploy-storybook -- --ci
 


### PR DESCRIPTION
Welp, this didn't do the right thing. Turns out you need to point the storybook-deployer to the built version of Storybook, not the built version of the component-library. 🤭

I believe #471 is still an issue. Running deploy-storybook locally works fine, but it fails when run on Travis. Still a little puzzled about why.