### PR TITLE
Update 2017 housing pie chart to useLegend

### DIFF
--- a/packages/component-library/src/PieChart/PieChart.js
+++ b/packages/component-library/src/PieChart/PieChart.js
@@ -29,7 +29,7 @@ const PieChart = props => {
   const y = getOrElse(dataValue, "y");
   const startAngle = halfDoughnut ? -90 : 0;
   const endAngle = halfDoughnut ? 90 : 360;
-  const legendLabels = data.map(value => ({ name: value.x }));
+  const legendLabels = data.map(value => ({ name: value[x] }));
   const legendProps = {};
 
   if (useLegend) {

--- a/packages/housing/src/components/DemographicDetailView/index.js
+++ b/packages/housing/src/components/DemographicDetailView/index.js
@@ -65,10 +65,11 @@ const DemographicDetailView = ({ demographics }) => {
           <div style={contentBlockStyle}>
             <h3 style={textAlignCenter}>Race/Ethnicity</h3>
             <PieChart
-              data={protectLabels(demographics.populations)}
+              data={demographics.populations}
               dataLabel="name"
               dataValue="value"
               colors={colors}
+              useLegend
               {...chartProportions}
             />
           </div>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7065695/56846192-04ac9580-6881-11e9-979d-f807cbaf2027.png)

After:
![image](https://user-images.githubusercontent.com/7065695/56846201-34f43400-6881-11e9-9f68-df216d6090b9.png)

Additionally, was able to unprotect labels, and fixed a bug in useLegend implementation.