### PR TITLE
Improve loading and error states for CivicStoryCard

### DIFF
--- a/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryCard.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { css } from "emotion";
 import CivicStoryFooter from "./CivicStoryFooter";
+import Logo from "../Logo/Logo";
 
 const cardClass = css`
   text-align: center;
@@ -52,13 +53,12 @@ const titleClass = css`
 const cardLoading = css`
   padding: 50px;
   text-align: center;
-  background: #eee;
 `;
 
 const cardError = css`
   padding: 50px;
   text-align: center;
-  background: #fdd;
+  color: #ee495c;
 `;
 
 const desktopOnly = css`
@@ -86,9 +86,17 @@ const CivicStoryCard = ({
 }) => {
   let content = children;
   if (loading) {
-    content = <div className={cardLoading}>Loading...</div>;
+    content = (
+      <div className={cardLoading}>
+        <Logo type="squareLogoAnimated" alt="Loading..." />
+      </div>
+    );
   } else if (error) {
-    content = <div className={cardError}>{error}</div>;
+    content = (
+      <div className={cardError}>
+        <h2>{error}</h2>
+      </div>
+    );
   }
 
   return (

--- a/packages/component-library/src/CivicStoryCard/CivicStoryCard.test.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryCard.test.js
@@ -31,8 +31,8 @@ describe("CivicStoryCard", () => {
       </CivicStoryCard>
     );
 
-    it("should render loading message", () => {
-      expect(wrapper.text().indexOf("Loading...")).to.eql(0);
+    it("should render loading image", () => {
+      expect(wrapper.find("Logo").length).to.eql(1);
     });
 
     it("should not render children", () => {

--- a/packages/component-library/src/Logo/CivicLogoCAnimated.js
+++ b/packages/component-library/src/Logo/CivicLogoCAnimated.js
@@ -1,0 +1,24 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { css } from "emotion";
+import isClient from "../utils/isClient";
+import logoC from "../../assets/civic-logo-c.svg";
+
+const stylesClass = css`
+  height: 100px;
+  width: auto;
+  animation-duration: 3s, 1s;
+  animation-name: rotate, fadeInOut;
+  animation-iteration-count: infinite, 1;
+  opacity: 0.4;
+`;
+
+const CivicLogoCAnimated = ({ alt }) =>
+  isClient && <img className={stylesClass} src={logoC} alt={alt} />;
+
+CivicLogoCAnimated.displayName = "Logo";
+CivicLogoCAnimated.propTypes = {
+  alt: PropTypes.string
+};
+
+export default CivicLogoCAnimated;

--- a/packages/component-library/src/Logo/Logo.js
+++ b/packages/component-library/src/Logo/Logo.js
@@ -5,6 +5,7 @@ import CivicLogoInverted from "./CivicLogoInverted";
 import CivicLogoAnimated from "./CivicLogoAnimated";
 import CivicLogoAnimatedInverted from "./CivicLogoAnimatedInverted";
 import CivicLogoC from "./CivicLogoC";
+import CivicLogoCAnimated from "./CivicLogoCAnimated";
 import CivicLogoCInverted from "./CivicLogoCInverted";
 
 function Logo({ type, alt }) {
@@ -19,6 +20,8 @@ function Logo({ type, alt }) {
       return <CivicLogoAnimatedInverted alt={alt} />;
     case "squareLogo":
       return <CivicLogoC alt={alt} />;
+    case "squareLogoAnimated":
+      return <CivicLogoCAnimated alt={alt} />;
     case "squareLogoInverted":
       return <CivicLogoCInverted alt={alt} />;
     default:


### PR DESCRIPTION
I'd love for someone to take this further, but I couldn't take looking at the grey box any more.

# Loading

Before:
![image](https://user-images.githubusercontent.com/7065695/56847058-62de7600-688b-11e9-91b9-b2cb947faf49.png)

After:
![loadingAnimation](https://user-images.githubusercontent.com/7065695/56847068-6e31a180-688b-11e9-9ce4-a4908e94da2a.gif)

# Error

Before:
![image](https://user-images.githubusercontent.com/7065695/56847121-04fe5e00-688c-11e9-8945-a47251f2a4a2.png)

After: 
![image](https://user-images.githubusercontent.com/7065695/56847140-442caf00-688c-11e9-85e5-6a7616f1fdf2.png)

