### PR TITLE
Add improve button to CivicStoryCard

### DIFF
--- a/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
@@ -17,11 +17,17 @@ const actionsClass = css`
   @media (max-width: 640px) {
     margin: -3em -2em;
     margin-top: 2em;
+    padding: 0;
   }
 `;
 
 const alignRight = css`
   margin-left: 0;
+  display: flex;
+`;
+
+const alignLeft = css`
+  margin-right: 0;
   display: flex;
 `;
 
@@ -57,23 +63,33 @@ export default class StoryFooter extends Component {
   render() {
     const { slug, source } = this.props;
     const { copied } = this.state;
-    const shareTxt = copied ? "Link copied!" : "Share card"; // if copied, show Link copied, otherwise, show Share card
+    const shareTxt = copied ? "Copied!" : "Share"; // if copied, show Link copied, otherwise, show Share card
     const shareIcon = copied ? ICONS.check : ICONS.link;
     const routeOrUndefined =
       `${window.location.origin}/cards/${slug}` === window.location.href
         ? undefined
         : `/cards/${slug}`;
+    const issue = `https://github.com/hackoregon/civic/issues/new?labels=type%3Astory-card&template=story-card-improve.md&title=[FEEDBACK] ${slug}`;
 
     return (
       <div className={actionsClass}>
-        <CivicStoryLink
-          link={source}
-          route={source ? undefined : `/cards/${slug}`}
-          icon={ICONS.info}
-        >
-          Source
-        </CivicStoryLink>
+        <div className={alignLeft}>
+          <CivicStoryLink
+            link={source}
+            route={source ? undefined : `/cards/${slug}`}
+            icon={ICONS.info}
+          >
+            Source
+          </CivicStoryLink>
+        </div>
         <div className={alignRight}>
+          <CivicStoryLink
+            additionalClassName={alignRight}
+            link={issue}
+            icon={ICONS.improve}
+          >
+            Improve
+          </CivicStoryLink>
           <CivicStoryLink
             additionalClassName={alignRight}
             route={routeOrUndefined}

--- a/packages/component-library/src/styleConstants.js
+++ b/packages/component-library/src/styleConstants.js
@@ -6,7 +6,8 @@ export const ICONS = {
   hamburger: "fa fa-bars",
   info: "fa fa-info-circle",
   arrowDown: "fa fa-arrow-down",
-  arrowUp: "fa fa-arrow-up"
+  arrowUp: "fa fa-arrow-up",
+  improve: "fa fa-commenting-o"
 };
 
 export default {


### PR DESCRIPTION
Per #500 - added an improve button to CivicStoryCard, which links to [this issue template](https://github.com/hackoregon/civic/issues/new?labels=type%3Astory-card&template=story-card-improve.md&title=[FEEDBACK]%20some-card-id), auto-populated based on the card slug 

**Feedback requested:**

- Is this the right [icon](https://fontawesome.com/v4.7.0/icons/)?
- Is there anything that can be improved about the process or issue template?

**Notes:**
If you don't have a GitHub account, you're asked to create one without context. If you do create an account, then you'll be able to comment. There may be things that could make this experience better for someone who is not a GitHub user, but I think this is a good start.

**What's it look like?**
![image](https://user-images.githubusercontent.com/7065695/57008146-e60d0e00-6ba2-11e9-992b-0978dc36a68c.png)

![image](https://user-images.githubusercontent.com/7065695/57008225-73e8f900-6ba3-11e9-8728-0c8681c48d7b.png)

