### PR TITLE
Update/storybook button knobs

### DIFF
--- a/packages/component-library/src/Button/Button.js
+++ b/packages/component-library/src/Button/Button.js
@@ -4,7 +4,7 @@ import { css } from "emotion";
 
 const accentColor = "#DC4556";
 const bkgndColor = "#FFFFFF";
-const commonTransition = "all .2s ease-in-out";
+const transition = "all .2s ease-in-out";
 const buttonClass = props => css`
   display: ${props.display || "block"};
   margin: ${props.margin};
@@ -12,7 +12,7 @@ const buttonClass = props => css`
   flex-wrap: nowrap;
   align-items: center;
   justify-content: space-between;
-  transition: ${props.commonTransition || commonTransition};
+  transition: ${props.transition || transition};
   font-size: 1em;
   font-family: "Rubik", sans-serif;
   font-weight: 500;
@@ -27,7 +27,7 @@ const buttonClass = props => css`
 
   span {
     flex-wrap: nowrap;
-    transition: ${props.commonTransition || commonTransition};
+    transition: ${props.transition || transition};
   }
 
   &:hover {

--- a/packages/component-library/src/Button/Button.js
+++ b/packages/component-library/src/Button/Button.js
@@ -3,6 +3,7 @@ import React from "react";
 import { css } from "emotion";
 
 const accentColor = "#DC4556";
+const bkgndColor = "#FFFFFF";
 const commonTransition = "all .2s ease-in-out";
 const buttonClass = props => css`
   display: ${props.display || "block"};
@@ -11,14 +12,14 @@ const buttonClass = props => css`
   flex-wrap: nowrap;
   align-items: center;
   justify-content: space-between;
-  transition: ${commonTransition};
+  transition: ${props.commonTransition || commonTransition};
   font-size: 1em;
   font-family: "Rubik", sans-serif;
   font-weight: 500;
-  color: ${accentColor};
-  background: #fff;
+  color: ${props.accentColor || accentColor};
+  background: ${props.bkgndColor || bkgndColor};
   cursor: pointer;
-  border: 2px solid ${accentColor};
+  border: 2px solid ${props.accentColor || accentColor};
 
   i {
     margin-right: 12px;
@@ -26,12 +27,12 @@ const buttonClass = props => css`
 
   span {
     flex-wrap: nowrap;
-    transition: ${commonTransition};
+    transition: ${props.commonTransition || commonTransition};
   }
 
   &:hover {
-    background-color: ${accentColor};
-    color: #fff;
+    background-color: ${props.accentColor || accentColor};
+    color: ${props.bkgndColor || bkgndColor};
   }
 
   &:focus {

--- a/packages/component-library/stories/Button.story.js
+++ b/packages/component-library/stories/Button.story.js
@@ -8,6 +8,7 @@ import {
   text,
   color,
   boolean,
+  optionsKnob as options,
   select
 } from "@storybook/addon-knobs";
 import notes from "./button.markdown.md";
@@ -51,7 +52,16 @@ export default () =>
         "all .2s ease-in-out"
       );
       //const commonTransition = text("Transition", "all .2s ease-in-out");
-      const disabled = boolean("Disabled", false);
+      //const disabled = boolean("Disabled", false);
+      const valuesObj = {
+        Enabled: "",
+        Disabled: "disabled"
+      };
+      const optionsObj = {
+        display: "inline-radio"
+      };
+      const disabled = options("State", valuesObj, "", optionsObj);
+      //console.log(disabled);
       return (
         <Button
           onClick={action("clicked")}

--- a/packages/component-library/stories/Button.story.js
+++ b/packages/component-library/stories/Button.story.js
@@ -3,20 +3,23 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
-import { withKnobs, text } from "@storybook/addon-knobs";
+import {
+  withKnobs,
+  text,
+  color,
+  boolean,
+  select
+} from "@storybook/addon-knobs";
+import notes from "./button.markdown.md";
 import { Button } from "../src";
 import { storybookStyles } from "./storyStyles.js";
-
-const displayName = Button.displayName || "Button";
 
 const description = `
   This is some basic usage with the button with providing a label to show the text.
   Clicking should trigger an action.`;
 
-const simpleButtonLabel = "Hello button";
-
 export default () =>
-  storiesOf("Component Lib|Basic UI Components/Button", module)
+  storiesOf("Component Lib|Basic Inputs/Button", module)
     .addDecorator(withKnobs)
     .addDecorator(checkA11y)
     .addDecorator(story => (
@@ -24,13 +27,59 @@ export default () =>
         <div style={storybookStyles.storyGridItem}>{story()}</div>
       </div>
     ))
-    .add("Simple usage", () => (
-      <Button onClick={action("clicked")}>{simpleButtonLabel}</Button>
-    ))
-    .add("With some emoji", () => (
-      <Button onClick={action("clicked")}>
-        <span role="img" aria-label="So cool">
-          😀 😎 👍 💯
-        </span>
-      </Button>
-    ));
+    .add("Simple usage", () => {
+      return (
+        <Button
+          onClick={action("clicked")}
+          //disabled={boolean("Disabled", false)}
+        >
+          Hello CIVIC
+        </Button>
+      );
+    })
+    .add("Basic usage", () => {
+      const accentColor = color("Text & border color", "#DC4556");
+      const bkgndColor = color("Background color", "#FFFFFF");
+      const label = text("Label", "Hello CIVIC");
+      const transitionOptions = {
+        Common: "all .2s ease-in-out",
+        Slower: "all 2s ease-in-out"
+      };
+      const commonTransition = select(
+        "Transition",
+        transitionOptions,
+        "all .2s ease-in-out"
+      );
+      //const commonTransition = text("Transition", "all .2s ease-in-out");
+      const disabled = boolean("Disabled", false);
+      return (
+        <Button
+          onClick={action("clicked")}
+          accentColor={accentColor}
+          bkgndColor={bkgndColor}
+          commonTransition={commonTransition}
+          disabled={disabled}
+        >
+          {label}
+        </Button>
+      );
+    })
+    .add(
+      "With some emoji",
+      () => {
+        const accentColor = color("Border color", "#DC4556");
+        const bkgndColor = color("Background color", "#FFFFFF");
+        return (
+          <Button
+            onClick={action("clicked")}
+            accentColor={accentColor}
+            bkgndColor={bkgndColor}
+          >
+            <span role="img" aria-label="So cool">
+              😀 😎 👍 💯
+            </span>
+          </Button>
+        );
+      },
+      { notes }
+    );

--- a/packages/component-library/stories/Button.story.js
+++ b/packages/component-library/stories/Button.story.js
@@ -7,17 +7,12 @@ import {
   withKnobs,
   text,
   color,
-  boolean,
   optionsKnob as options,
   select
 } from "@storybook/addon-knobs";
 import notes from "./button.markdown.md";
 import { Button } from "../src";
 import { storybookStyles } from "./storyStyles.js";
-
-const description = `
-  This is some basic usage with the button with providing a label to show the text.
-  Clicking should trigger an action.`;
 
 export default () =>
   storiesOf("Component Lib|Basic Inputs/Button", module)
@@ -28,64 +23,79 @@ export default () =>
         <div style={storybookStyles.storyGridItem}>{story()}</div>
       </div>
     ))
-    .add("Simple usage", () => {
-      return (
-        <Button
-          onClick={action("clicked")}
-          //disabled={boolean("Disabled", false)}
-        >
-          Hello CIVIC
-        </Button>
-      );
-    })
-    .add("Basic usage", () => {
-      const accentColor = color("Text & border color", "#DC4556");
-      const bkgndColor = color("Background color", "#FFFFFF");
-      const label = text("Label", "Hello CIVIC");
-      const transitionOptions = {
-        Common: "all .2s ease-in-out",
-        Slower: "all 2s ease-in-out"
-      };
-      const commonTransition = select(
-        "Transition",
-        transitionOptions,
-        "all .2s ease-in-out"
-      );
-      //const commonTransition = text("Transition", "all .2s ease-in-out");
-      //const disabled = boolean("Disabled", false);
-      const valuesObj = {
-        Enabled: "",
-        Disabled: "disabled"
-      };
-      const optionsObj = {
-        display: "inline-radio"
-      };
-      const disabled = options("State", valuesObj, "", optionsObj);
-      //console.log(disabled);
-      return (
-        <Button
-          onClick={action("clicked")}
-          accentColor={accentColor}
-          bkgndColor={bkgndColor}
-          commonTransition={commonTransition}
-          disabled={disabled}
-        >
-          {label}
-        </Button>
-      );
-    })
     .add(
-      "With some emoji",
+      "Standard",
       () => {
-        const accentColor = color("Border color", "#DC4556");
+        const label = text("Label", "Hello CIVIC");
+        return <Button onClick={action("clicked")}>{label}</Button>;
+      },
+      { notes }
+    )
+    .add(
+      "Custom",
+      () => {
+        const accentColor = color("Text & border color", "#DC4556");
         const bkgndColor = color("Background color", "#FFFFFF");
+        const label = text("Label", "Hello CIVIC");
+        const transitionOptions = {
+          Standard: "all .2s ease-in-out",
+          Slow: "all .6s ease-in-out",
+          Fast: "all .1s ease-in-out"
+        };
+        const transition = select(
+          "Transition",
+          transitionOptions,
+          "all .2s ease-in-out"
+        );
+        //const disabled = boolean("Disabled", false);
+        const valuesObj = {
+          Enabled: "",
+          Disabled: "disabled"
+        };
+        const optionsObj = {
+          display: "inline-radio"
+        };
+        const disabled = options("State", valuesObj, "", optionsObj);
+        //console.log(disabled);
         return (
           <Button
             onClick={action("clicked")}
             accentColor={accentColor}
             bkgndColor={bkgndColor}
+            transition={transition}
+            disabled={disabled}
           >
-            <span role="img" aria-label="So cool">
+            {label}
+          </Button>
+        );
+      },
+      { notes }
+    )
+    .add(
+      "Custom non-text label",
+      () => {
+        const accentColor = color("Border color", "#DC4556");
+        const bkgndColor = color("Background color", "#FFFFFF");
+        const transitionOptions = {
+          Standard: "all .2s ease-in-out",
+          Slow: "all .6s ease-in-out",
+          Fast: "all .1s ease-in-out"
+        };
+        const transition = select(
+          "Transition",
+          transitionOptions,
+          "all .2s ease-in-out"
+        );
+        const ariaLabel = text("aria-label", "So cool");
+        return (
+          <Button
+            onClick={action("clicked")}
+            accentColor={accentColor}
+            bkgndColor={bkgndColor}
+            transition={transition}
+          >
+            {" "}
+            <span role="img" aria-label={ariaLabel}>
               😀 😎 👍 💯
             </span>
           </Button>

--- a/packages/component-library/stories/DropdownMenu.story.js
+++ b/packages/component-library/stories/DropdownMenu.story.js
@@ -1,38 +1,69 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { withInfo } from "@storybook/addon-info";
 import { checkA11y } from "@storybook/addon-a11y";
+import { withKnobs, text, color } from "@storybook/addon-knobs";
 import { Dropdown } from "../src";
 import { storybookStyles } from "./storyStyles.js";
 
-const displayName = Dropdown.displayName || "Dropdown";
-const title = "Simple usage";
 const description = `
   This is some basic usage with the button with providing a label to show the text.
   Clicking should trigger an action.`;
 
-const demoCode = () => (
-  <Dropdown
-    dispatch={dispatch => action => dispatch(action)}
-    reduxAction={payload => console.log({ type: "ACTION", payload })}
-    options={[
-      { value: "0", label: "David" },
-      { value: "1", label: "Daniel" },
-      { value: "2", label: "Last" },
-      { value: "3", label: "Name" }
-    ]}
-  />
-);
-
 // const propDocs = { inline: true, propTables: [Dropdown] };
 
 export default () =>
-  storiesOf("Component Lib|Basic UI Components/Dropdown List", module)
+  storiesOf("Component Lib|Basic Inputs/Dropdown List", module)
     .addDecorator(checkA11y)
     .addDecorator(story => (
       <div style={storybookStyles.storyGrid}>
         <div style={storybookStyles.storyGridItem}>{story()}</div>
       </div>
     ))
-    .add(title, demoCode);
+    .add("Simple usage", () => {
+      const options = [
+        { value: "0", label: "Murphy" },
+        { value: "1", label: "Carter" },
+        { value: "2", label: "Bebe" },
+        { value: "3", label: "Cissi" }
+      ];
+      return (
+        <Dropdown
+          dispatch={dispatch => action => dispatch(action)}
+          reduxAction={payload => console.log({ type: "ACTION", payload })}
+          options={options}
+        />
+      );
+    })
+    .add("Basic usage", () => {
+      const options = [
+        { value: "0", label: "Murphy" },
+        { value: "1", label: "Carter" },
+        { value: "2", label: "Bebe" },
+        { value: "3", label: "Cissi" }
+      ];
+      return (
+        <Dropdown
+          dispatch={dispatch => action => dispatch(action)}
+          reduxAction={payload => console.log({ type: "ACTION", payload })}
+          options={options}
+        />
+      );
+    })
+    .add("Multi-select", () => {
+      const options = [
+        { value: "0", label: "Murphy" },
+        { value: "1", label: "Carter" },
+        { value: "2", label: "Bebe" },
+        { value: "3", label: "Cissi" }
+      ];
+      const multi = true;
+      return (
+        <Dropdown
+          dispatch={dispatch => action => dispatch(action)}
+          reduxAction={payload => console.log({ type: "ACTION", payload })}
+          options={options}
+          multi={multi}
+        />
+      );
+    });

--- a/packages/component-library/stories/Slider.story.js
+++ b/packages/component-library/stories/Slider.story.js
@@ -47,7 +47,7 @@ const demoCode = () => {
 // const propDocs = { inline: true, propTables: [Slider] };
 
 export default () =>
-  storiesOf("Component Lib|Basic UI Components/Slider", module)
+  storiesOf("Component Lib|Basic Inputs/Slider", module)
     .addDecorator(checkA11y)
     .addDecorator(story => (
       <div style={storybookStyles.storyGrid}>

--- a/packages/component-library/stories/button.markdown.md
+++ b/packages/component-library/stories/button.markdown.md
@@ -1,0 +1,1 @@
+A very simple example of add on notes

--- a/packages/component-library/stories/button.markdown.md
+++ b/packages/component-library/stories/button.markdown.md
@@ -1,1 +1,36 @@
-A very simple example of add on notes
+# Button Component
+
+## Standard
+
+The Standard button story uses the standard styles for the CIVIC platform. Most buttons will use these props, and only customize the label. (See the buttom component for values of these props and additional standard button styles.)
+
+- Color theme
+- Font size, family, and weight
+- Margins and padding
+- User interaction
+- Transition
+
+The label prop can be edited to see the final design:
+
+- Text label
+
+## Custom
+
+The Custom button story allows the developer to edit these style props of the Standard button:
+
+- Color theme
+- Transition
+- Enabled / Disabled
+- Text label
+
+## Custom Non-text Label
+
+Use the Non-text Label button story if the label isn't readable by accesibile technologies. Use the aria-label attribute to give the button an accessible name. See https://www.w3.org/TR/WCAG20-TECHS/ARIA14.html for more information.
+
+This story allows the developer to edit these props of the Standard button and edit the aria-label prop:
+
+- Color theme
+- Transition
+- Enabled / Disabled
+- Image (including emojis)
+- aria-label

--- a/packages/component-library/stories/index.js
+++ b/packages/component-library/stories/index.js
@@ -104,7 +104,7 @@ storiesOf("Design|UX Style Guide", module)
   .add("Terminology", () => <TerminologyStyle />);
 
 // Basic UI components
-storiesOf("Component Lib|Basic UI Components", module)
+storiesOf("Component Lib|Basic Inputs", module)
   .addDecorator(checkA11y)
   .addParameters({ options: { showPanel: false } })
   .add("Basic Components Style Guide", () => <UIComponentsStyle />);

--- a/packages/component-library/stories/styleGuideStories/AccessibilityGuidelinesStyle.story.js
+++ b/packages/component-library/stories/styleGuideStories/AccessibilityGuidelinesStyle.story.js
@@ -15,7 +15,8 @@ const AccessibilityGuidelines = () => (
       The CIVIC platform will meet all criteria specified in{" "}
       <a href="https://www.w3.org/TR/WCAG21/" target="_blank">
         Web Content Accessibility Guidelines (WCAG) 2.1
-      </a>{" "}Level A and Level AA.
+      </a>{" "}
+      Level A and Level AA.
     </p>
     <h2>What types of disabilities do we need to account for?</h2>
     <h4>Visual</h4>
@@ -32,7 +33,6 @@ const AccessibilityGuidelines = () => (
       Learning disabilities, distractibility, and inability to remember or focus
       on large amounts of information.
     </p>
-<<<<<<< HEAD
 
     <h2>What are the principles of the guidelines?</h2>
     <p>
@@ -165,141 +165,4 @@ const AccessibilityGuidelines = () => (
   </div>
 );
 
-=======
-    <h2>What are the principles of the guidelines?</h2>
-    <p>
-      See{" "}
-      <a href="https://www.w3.org/WAI/WCAG21/quickref/" target="_blank">
-        How to Meet WCAG
-      </a>{" "}
-      for a quick reference on meeting the four principles of WCAG.
-    </p>{" "}
-    <p>
-      The CIVIC platform will meet all criteria specified in{" "}
-      <a href="https://www.w3.org/TR/WCAG21/" target="_blank">
-        Web Content Accessibility Guidelines (WCAG) 2.1
-      </a>{" "}
-      Level A and Level AA.
-    </p>
-    <h4>Perceivable</h4>
-    <p>
-      Information and user interface components must be presentable to users in
-      ways they can perceive.
-    </p>
-    <p>
-      It must be available to the senses, vision and hearing primarily, either
-      through the browser or through assistive technologies, e.g., screen
-      readers, screen enlargers, etc.
-    </p>
-    <h4>Operable</h4>
-    <p>User interface components and navigation must be operable.</p>
-    <p>
-      Users can interact with all controls and interactive elements using either
-      the mouse, keyboard, or an assistive device.
-    </p>
-    <h4>Understandable</h4>
-    <p>Content is clear and limits confusion and ambiguity.</p>
-    <p>
-      Information and the operation of user interface must be understandable.
-    </p>
-    <h4>Robust</h4>
-    <p>
-      Content must be robust enough that it can be interpreted reliably by a
-      wide variety of user agents, including assistive technologies.
-    </p>
-    <h2>Implementation Checklist</h2>
-    <p>
-      Implementation of the accessibility guidelines can be done using this
-      order of priority. Considerations when proposing this order are the most
-      common disabilities and the most common features in our user interfaces.
-    </p>
-    <h4>Color Theme</h4>
-    <p>
-      Meet contrast ratios between text and its background color and between
-      colors used to represent distinct information in data visualization.
-      WebAIM describes the guidelines and has many examples
-      <a href="https://webaim.org/articles/contrast/" target="_blank">
-        : WebAIM Contrast and Color Accessibility
-      </a>
-      .
-    </p>
-    <h4>Forms</h4>
-    <p>
-      See{" "}
-      <a href="https://www.w3.org/WAI/tutorials/forms/" target="_blank">
-        Web Accessibility Tutorials on Forms
-      </a>
-      . The following sections in the tutorials are especially relevant to the
-      CIVIC platform.
-    </p>
-    <ol type="a">
-      <li>Labels</li>
-      <li>Groups</li>
-      <li>Instructions</li>
-      <li>Validating input</li>
-      <li>User notifications</li>
-      <li>Custom controls</li>
-    </ol>
-    <p>
-      The Forms story has an example of a form that follows our styles and meets
-      accessibility requirements.
-    </p>
-    <h4>Resize Text</h4>
-    <p>Allow text to be increased in size and readable.</p>
-    <h4>Images</h4>
-    <p>Use alternative text with images.</p>
-    <h4>Data Visualization</h4>
-    <p>
-      A good reference for meeting accessibility requirements in data
-      visualizations:{" "}
-      <a
-        href="https://accessibility.digital.gov/visual-design/data-visualizations/"
-        target="_blank"
-      >
-        Data Visualizations
-      </a>
-      .
-    </p>
-    <h4>Reading and Navigation Order</h4>
-    <p>Logical and intuitive.</p>
-    <h4>Keyboard Accessible</h4>
-    <p>Navigation to all page elements is available using the keyboard.</p>
-    <p>Keyboard commands reference: (placeholder).</p>
-    <h2>What are the guidelines and who made them?</h2>
-    <p>
-      The{" "}
-      <a href="https://www.w3.org/Consortium/" target="_blank">
-        W3C (World Wide Web Consortium)
-      </a>{" "}
-      develops web standards; they are led by the Web inventor Tim Berners-Lee.
-      One of their initiatives is the{" "}
-      <a href="http://www.w3.org/WAI/" target="_blank">
-        WAI (Web Accessibility Initiative)
-      </a>
-      , to improve accessibility of the Web for people with disabilities.
-    </p>
-    <p>
-      The WAI is made up of several working groups and Special Interest groups.
-      The most important working group is the{" "}
-      <a href="http://www.w3.org/WAI/GL/" target="_blank">
-        WCAG WG (Web Content Accessibility Guidelines Working Group)
-      </a>
-      . This group published{" "}
-      <a href="https://www.w3.org/TR/WCAG21/" target="_blank">
-        WCAG 2.1
-      </a>
-      ; their web site has many useful resources and materials.
-    </p>
-    <p>
-      Another organization that does a good job of explaining accessibility and
-      the guidelines is{" "}
-      <a href="http://webaim.org" target="_blank">
-        WebAIM
-      </a>
-      .
-    </p>
-  </div>
-);
-
->>>>>>> Added vision statement to the Accessibility story.
 export default AccessibilityGuidelines;

--- a/packages/component-library/stories/styleGuideStories/CardsStyle.story.js
+++ b/packages/component-library/stories/styleGuideStories/CardsStyle.story.js
@@ -4,7 +4,7 @@ import { storybookStyles } from "../storyStyles";
 const CardsStyle = () => (
   <div style={storybookStyles.main}>
     <h1>Story Cards</h1>
-    <p>Placeholder for story Cards style guidelines.</p>
+    <p>Placeholder for Story Cards style guidelines.</p>
   </div>
 );
 


### PR DESCRIPTION
A work in progress...

Button Story:
* Renamed and created 3 button stories for different development goals.
* Added Notes - read notes to understand the differences in the 3 stories.
* Added knobs to each story based on how the developer will want to use the button in their design; knobs were added only for those props that can be edited within the design goals of the CIVIC platform.

Please review:
* Look at the presentation in these 3 browsers:  Chrome, Firefox, Edge
* Do the 3 stories and knobs for each support the way the CIVIC platform is meant to be used and stay within the design goals of the platform?
* Are the Notes complete enough?  Have too much information?  
* The Story code in the addon panel... the goal is to write the story so the developer will be able to see which props they use when they want to use that "version" of a component.  Do the button stories do this?

Still to do:
* Add a knob for changing the label on the non-text label button
* Get the knob for enable/disable button working 
* A story for a multi-select dropdown list

Issues:
* The order of stories isn't correct in Firefox.
* Additional knobs are sometimes shown (could this be a bug in Storybook?):  Data, Data key, Data values, Data key labels
* Notes are not using the correct font family; I will add an issue to update the Storybook theme.
* The red color (CIVIC color theme) used in the button fails accessibility test; I will add an issue to update the color theme to meet accessibility requirements.
