### PR TITLE
Icon Map touchscreen demo

### DIFF
--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -36,7 +36,7 @@ class BaseMap extends Component {
         latitude: props.initialLatitude || 45.5231,
         zoom: props.initialZoom || 9.5,
         minZoom: 6,
-        maxZoom: 16,
+        maxZoom: 20,
         pitch: props.initialPitch || 0,
         bearing: 0,
         scrollZoom: true
@@ -113,7 +113,8 @@ class BaseMap extends Component {
       geocoderOnChange,
       mapGLOptions,
       children,
-      useContainerHeight
+      useContainerHeight,
+      onBaseMapClick
     } = this.props;
 
     viewport.width = this.props.containerWidth
@@ -145,6 +146,7 @@ class BaseMap extends Component {
           onViewportChange={viewport => this.onViewportChange(viewport)}
           ref={this.mapRef}
           {...mapGLOptions}
+          onClick={onBaseMapClick}
         >
           <div className={navControl}>
             {navigation && (

--- a/packages/component-library/stories/IconMap.story.js
+++ b/packages/component-library/stories/IconMap.story.js
@@ -201,14 +201,10 @@ class TouchScreenDemo extends React.Component {
   render() {
     const { pointsData } = this.state;
 
-    // const touchZoomOption = boolean( "Touch Zoom:", true);
-    // const touchRotateOption = boolean("Touch Rotate:", true);
     const touchZoomRotateOption = boolean("Touch Zoom/Rotate:", true);
     const doubleClickZoomOption = boolean("Double Click Zoom:", true);
     const dragPanOption = boolean("Drag Pan:", true);
     const dragRotateOption = boolean("Drag Rotate:", true);
-    // const scrollZoomOption = boolean("Scroll Zoom:", true);
-    // const keyboardOption = boolean("Keyboard:", true);
 
     const getIconColor = f =>
       f.properties.type === "BEECN" ? [238, 73, 92] : [25, 183, 170];

--- a/packages/component-library/stories/IconMap.story.js
+++ b/packages/component-library/stories/IconMap.story.js
@@ -2,7 +2,7 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { withKnobs, number } from "@storybook/addon-knobs";
+import { withKnobs, number, boolean } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
 import { BaseMap, IconMap, MapTooltip, DemoJSONLoader } from "../src";
@@ -164,9 +164,98 @@ const tooltipMap = () => (
   </DemoJSONLoader>
 );
 
+class TouchScreenDemo extends React.Component {
+  state = {
+    pointsData: [
+      {
+        geometry: {
+          coordinates: [-122.6658475, 45.5084872]
+        },
+        properties: {
+          type: "BEECN"
+        }
+      }
+    ]
+  };
+
+  onClick = ({ lngLat }) => {
+    this.setState({
+      pointsData: [
+        ...this.state.pointsData,
+        {
+          geometry: {
+            coordinates: lngLat
+          },
+          properties: {
+            type: "Pin"
+          }
+        }
+      ]
+    });
+  };
+
+  clearPoints = () => {
+    this.setState({ pointsData: [] });
+  };
+
+  render() {
+    const { pointsData } = this.state;
+
+    // const touchZoomOption = boolean( "Touch Zoom:", true);
+    // const touchRotateOption = boolean("Touch Rotate:", true);
+    const touchZoomRotateOption = boolean("Touch Zoom/Rotate:", true);
+    const doubleClickZoomOption = boolean("Double Click Zoom:", true);
+    const dragPanOption = boolean("Drag Pan:", true);
+    const dragRotateOption = boolean("Drag Rotate:", true);
+    // const scrollZoomOption = boolean("Scroll Zoom:", true);
+    // const keyboardOption = boolean("Keyboard:", true);
+
+    const getIconColor = f =>
+      f.properties.type === "BEECN" ? [238, 73, 92] : [25, 183, 170];
+
+    return (
+      <div style={{ height: "95vh", minHeight: "500px" }}>
+        <BaseMap
+          initialZoom={15}
+          initialLatitude={45.5084872}
+          initialLongitude={-122.6658475}
+          mapGLOptions={{
+            touchZoomRotate: touchZoomRotateOption,
+            doubleClickZoom: doubleClickZoomOption,
+            dragPan: dragPanOption,
+            dragRotate: dragRotateOption,
+            scrollZoom: touchZoomRotateOption
+          }}
+          onBaseMapClick={this.onClick}
+          updateViewport={false}
+          useContainerHeight
+        >
+          <IconMap
+            data={pointsData}
+            opacity={1.0}
+            iconAtlas="https://i.imgur.com/xgTAROe.png"
+            iconMapping={poiIconMapping}
+            iconSizeScale={poiIconZoomScale}
+            getPosition={getPosition}
+            getIcon={getIcon}
+            getSize={() => 7}
+            getColor={getIconColor}
+          />
+        </BaseMap>
+        <input
+          type="button"
+          onClick={this.clearPoints}
+          value={"Clear all points"}
+        />
+      </div>
+    );
+  }
+}
+
 export default () =>
   storiesOf("Component Lib|Maps/Icon Map", module)
     .addDecorator(withKnobs)
     .addDecorator(checkA11y)
     .add("Simple usage", demoMap)
-    .add("With tooltip", tooltipMap);
+    .add("With tooltip", tooltipMap)
+    .add("TouchScreen Demo", () => <TouchScreenDemo />);


### PR DESCRIPTION
This addresses #501.

It adds a TouchScreenDemo story to the Icon Map in the Hack Oregon Storybook.

It includes the ability to add icons to the map by clicking/touching the screen and options to turn off/on touch zoom, touch rotate, double click zoom, drag pan, and drag rotate options.