### PR TITLE
Fix map tooltip position

### DIFF
--- a/packages/component-library/src/HexOverlay/HexOverlay.js
+++ b/packages/component-library/src/HexOverlay/HexOverlay.js
@@ -2,21 +2,8 @@
 /* eslint-disable */
 
 import React, { Component } from "react";
-import { render } from "react-dom";
 import PropTypes from "prop-types";
-import { css } from "emotion";
 import DeckGL, { HexagonLayer } from "deck.gl";
-
-const crosshair = css`
-  cursor: crosshair;
-`;
-
-const mapWrapper = css`
-  margin: auto;
-  max-width: 900px;
-`;
-
-const colorScale = r => [r * 255, 140, 200 * (1 - r)];
 
 const elevationScale = { min: 1, max: 50 };
 
@@ -103,7 +90,8 @@ class HexOverlay extends Component {
         y
       });
     });
-    const tooltipRender = tooltipInfo ? tooltip : null;
+
+    const tooltipRender = tooltipInfo && x && y ? tooltip : null;
 
     const layers = [
       new HexagonLayer({
@@ -127,14 +115,16 @@ class HexOverlay extends Component {
     ];
 
     return (
-      <div className={crosshair}>
-        <DeckGL {...viewport} layers={layers} className="HexOverlay">
-          {tooltipRender}
-        </DeckGL>
+      <div>
+        <DeckGL
+          {...viewport}
+          layers={layers}
+          className="HexOverlay"
+          getCursor={() => "crosshair"}
+        />
+        {tooltipRender}
       </div>
     );
   }
 }
 export default HexOverlay;
-
-// TODO: after implimenting tooltip the booleans knobs are no longer work.... filled, wireframe, extruded.... extruded has to be set as true currently in layers... fix it

--- a/packages/component-library/src/HexOverlay/HexOverlay.test.js
+++ b/packages/component-library/src/HexOverlay/HexOverlay.test.js
@@ -42,34 +42,38 @@ describe("HexOverlay", () => {
   });
 
   it("should render with extruded", () => {
-    expect(wrapper.props().children.props.layers[0].props.extruded).to.equal(
+    expect(wrapper.props().children[0].props.layers[0].props.extruded).to.equal(
       true
     );
   });
 
   it("should render with radius", () => {
-    expect(wrapper.props().children.props.layers[0].props.radius).to.equal(200);
+    expect(wrapper.props().children[0].props.layers[0].props.radius).to.equal(
+      200
+    );
   });
 
   it("should render with opacity of 0.8", () => {
-    expect(wrapper.props().children.props.layers[0].props.opacity).to.equal(
+    expect(wrapper.props().children[0].props.layers[0].props.opacity).to.equal(
       0.8
     );
   });
 
   it("should render with an extrusion", () => {
-    expect(wrapper.props().children.props.layers[0].props.extruded).to.equal(
+    expect(wrapper.props().children[0].props.layers[0].props.extruded).to.equal(
       true
     );
   });
 
   it("should render with data", () => {
-    expect(wrapper.props().children.props.layers[0].props.data).to.equal(data);
+    expect(wrapper.props().children[0].props.layers[0].props.data).to.equal(
+      data
+    );
   });
 
   it("should render with an type string", () => {
     expect(
-      wrapper.props().children.props.layers[0].props.data[0].type
+      wrapper.props().children[0].props.layers[0].props.data[0].type
     ).to.equal("Feature");
   });
 });

--- a/packages/component-library/src/IconMap/IconMap.js
+++ b/packages/component-library/src/IconMap/IconMap.js
@@ -1,11 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
 import DeckGL, { IconLayer } from "deck.gl";
-import { css } from "emotion";
-
-const crosshair = css`
-  cursor: crosshair;
-`;
 
 const IconMap = props => {
   const {
@@ -40,11 +35,11 @@ const IconMap = props => {
     });
   });
 
-  const tooltipRender = tooltipInfo ? tooltip : null;
+  const tooltipRender = tooltipInfo && x && y ? tooltip : null;
 
   return (
-    <div className={crosshair}>
-      <DeckGL className="DeckGL" {...viewport}>
+    <div>
+      <DeckGL className="DeckGL" {...viewport} getCursor={() => "crosshair"}>
         <IconLayer
           id="icon-layer"
           className="IconMap"
@@ -64,8 +59,8 @@ const IconMap = props => {
           visible={visible}
           updateTriggers={{ getSize }}
         />
-        {tooltipRender}
       </DeckGL>
+      {tooltipRender}
     </div>
   );
 };

--- a/packages/component-library/src/MapOverlay/MapOverlay.js
+++ b/packages/component-library/src/MapOverlay/MapOverlay.js
@@ -1,11 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import DeckGL, { GeoJsonLayer } from "deck.gl";
-import { css } from "emotion";
-
-const crosshair = css`
-  cursor: crosshair;
-`;
 
 const MapOverlay = props => {
   const {
@@ -42,7 +37,7 @@ const MapOverlay = props => {
     });
   });
 
-  const tooltipRender = tooltipInfo ? tooltip : null;
+  const tooltipRender = tooltipInfo && x && y ? tooltip : null;
 
   const LIGHT_SETTINGS = {
     lightsPosition: [-125, 50.5, 5000, -122.8, 48.5, 8000],
@@ -78,10 +73,14 @@ const MapOverlay = props => {
   });
 
   return (
-    <div className={crosshair}>
-      <DeckGL {...viewport} layers={[layer]} className="MapOverlay">
-        {tooltipRender}
-      </DeckGL>
+    <div>
+      <DeckGL
+        {...viewport}
+        layers={[layer]}
+        className="MapOverlay"
+        getCursor={() => "crosshair"}
+      />
+      {tooltipRender}
     </div>
   );
 };
@@ -101,7 +100,7 @@ MapOverlay.propTypes = {
   onLayerClick: PropTypes.func,
   opacity: PropTypes.number,
   strokeWidth: PropTypes.number,
-  tooltipInfo: PropTypes.bool,
+  tooltipInfo: PropTypes.shape({}),
   x: PropTypes.number,
   y: PropTypes.number,
   visible: PropTypes.bool,

--- a/packages/component-library/src/PathMap/PathMap.js
+++ b/packages/component-library/src/PathMap/PathMap.js
@@ -1,11 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
 import DeckGL, { PathLayer } from "deck.gl";
-import { css } from "emotion";
-
-const crosshair = css`
-  cursor: crosshair;
-`;
 
 const PathMap = props => {
   const {
@@ -36,11 +31,11 @@ const PathMap = props => {
     });
   });
 
-  const tooltipRender = tooltipInfo ? tooltip : null;
+  const tooltipRender = tooltipInfo && x && y ? tooltip : null;
 
   return (
-    <div className={crosshair}>
-      <DeckGL className="DeckGL" {...viewport}>
+    <div>
+      <DeckGL className="DeckGL" {...viewport} getCursor={() => "crosshair"}>
         <PathLayer
           id="path-layer"
           className="PathMap"
@@ -61,8 +56,8 @@ const PathMap = props => {
           updateTriggers={{ instanceColors: getColor }}
           visible={visible}
         />
-        {tooltipRender}
       </DeckGL>
+      {tooltipRender}
     </div>
   );
 };

--- a/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
+++ b/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
@@ -1,11 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import DeckGL, { ScatterplotLayer } from "deck.gl";
-import { css } from "emotion";
-
-const crosshair = css`
-  cursor: crosshair;
-`;
 
 const ScatterPlotMap = props => {
   const {
@@ -37,11 +32,11 @@ const ScatterPlotMap = props => {
     });
   });
 
-  const tooltipRender = tooltipInfo ? tooltip : null;
+  const tooltipRender = tooltipInfo && x && y ? tooltip : null;
 
   return (
-    <div className={crosshair}>
-      <DeckGL className="DeckGL" {...viewport}>
+    <div>
+      <DeckGL className="DeckGL" {...viewport} getCursor={() => "crosshair"}>
         <ScatterplotLayer
           className="ScatterPlotMap"
           id="scatterplot-layer"
@@ -63,8 +58,8 @@ const ScatterPlotMap = props => {
           updateTriggers={{ instanceColors: getColor }}
           onHover={onHover}
         />
-        {tooltipRender}
       </DeckGL>
+      {tooltipRender}
     </div>
   );
 };


### PR DESCRIPTION
This addresses #512 by fixing the position of the tooltip on all map components.

It also adds back the crosshair cursor instead of the hand icon.

![Screen Shot 2019-05-05 at 21 02 12](https://user-images.githubusercontent.com/9361258/57206320-b3379100-6f79-11e9-9387-a7fb731203fa.png)
