### PR TITLE
Implement eslint hook in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,12 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,json}": [
+    "*.{js,jsx}": [
       "prettier --write",
+      "eslint --fix",
       "git add"
     ],
-    "*.{css,md}": [
+    "*.{css,md,json}": [
       "prettier --write",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "start": "node scripts/start",
     "deploy-storybook": "BABEL_ENV=esm storybook-to-ghpages",
     "in": "lerna run --scope",
-    "lint": "lerna run lint",
+    "lint": "lerna run lint --no-bail",
     "lint:fix": "lerna run lint --no-bail -- --fix",
     "storybook": "BABEL_ENV=esm start-storybook -p 6006",
     "test": "lerna run test --no-bail",

--- a/packages/2017/package.json
+++ b/packages/2017/package.json
@@ -10,7 +10,7 @@
     "start:prod": "yarn run build && cross-env NODE_ENV=production node server",
     "build": "rimraf dist && cross-env NODE_ENV=production webpack --progress --config ./webpack.config.js",
     "test": "echo 'No tests!'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "repository": {
     "type": "git",

--- a/packages/2018-disaster-resilience/package.json
+++ b/packages/2018-disaster-resilience/package.json
@@ -29,7 +29,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@hackoregon/component-library": "^3.0.0",

--- a/packages/2018-example-farmers-markets/package.json
+++ b/packages/2018-example-farmers-markets/package.json
@@ -29,7 +29,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@hackoregon/component-library": "^3.0.0",

--- a/packages/2018-housing-affordability/package.json
+++ b/packages/2018-housing-affordability/package.json
@@ -29,7 +29,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@hackoregon/component-library": "^3.0.0",

--- a/packages/2018-local-elections/package.json
+++ b/packages/2018-local-elections/package.json
@@ -29,7 +29,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@hackoregon/component-library": "^3.0.0",

--- a/packages/2018-neighborhood-development/package.json
+++ b/packages/2018-neighborhood-development/package.json
@@ -29,7 +29,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@hackoregon/component-library": "^3.0.0",

--- a/packages/2018-transportation-systems/package.json
+++ b/packages/2018-transportation-systems/package.json
@@ -29,7 +29,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@hackoregon/component-library": "^3.0.0",

--- a/packages/2018/package.json
+++ b/packages/2018/package.json
@@ -10,7 +10,7 @@
     "start:prod": "yarn run build && cross-env NODE_ENV=production node server",
     "build": "rimraf dist && cross-env NODE_ENV=production webpack --progress --config ./webpack.config.js",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "repository": {
     "type": "git",

--- a/packages/budget/.eslintignore
+++ b/packages/budget/.eslintignore
@@ -1,1 +1,2 @@
 **/*.js
+!src/.eslint.js

--- a/packages/budget/package.json
+++ b/packages/budget/package.json
@@ -29,7 +29,7 @@
     "start:dev": "cross-env NODE_ENV=development node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/packages/budget/src/.eslint.js
+++ b/packages/budget/src/.eslint.js
@@ -1,0 +1,7 @@
+//  This file exists solely for ESLint to find when matching '*.{js,mjs}'.
+//  ESLint considers it an error to specify a pattern which matches no files
+//  (even if multiple patterns are provided and other patterns do match files).
+//
+//  This file can be removed if <https://github.com/eslint/eslint/issues/10587>
+//  is resolved or if this project is restructured to match the expectations of
+//  sanctuary-scripts.

--- a/packages/civic-babel-presets/package.json
+++ b/packages/civic-babel-presets/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",
-    "lint": "eslint --fix index.js"
+    "lint": "eslint index.js"
   },
   "author": "David Daniel <davidedaniel@gmail.com> (http://davidedaniel.github.io)",
   "license": "MIT",

--- a/packages/civic-sandbox/package.json
+++ b/packages/civic-sandbox/package.json
@@ -29,7 +29,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@hackoregon/component-library": "^3.0.0",

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -11,7 +11,7 @@
     "configure": "yarn run build",
     "test": "BABEL_ENV=test mocha --opts ./mocha.options ./src/**/*.test.js",
     "test:watch": "yarn run test -- -w",
-    "lint": "eslint --fix src stories",
+    "lint": "eslint src stories",
     "storybook": "node scripts/storybook.js",
     "start": "node scripts/start.js"        
   },

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/hackoregon/civic.git"
   },
   "scripts": {
-    "lint": "eslint --fix index.js"
+    "lint": "eslint index.js"
   },
   "private": false,
   "keywords": [

--- a/packages/emergency-response/package.json
+++ b/packages/emergency-response/package.json
@@ -29,7 +29,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod:": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@hackoregon/component-library": "^3.0.0",

--- a/packages/homelessness/package.json
+++ b/packages/homelessness/package.json
@@ -31,7 +31,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@hackoregon/component-library": "^3.0.0",

--- a/packages/housing/package.json
+++ b/packages/housing/package.json
@@ -35,7 +35,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@hackoregon/component-library": "^3.0.0",

--- a/packages/mock-wrapper/package.json
+++ b/packages/mock-wrapper/package.json
@@ -18,7 +18,7 @@
     "build:cjs": "babel src --out-dir dist --copy-files --no-comments",
     "build": "BABEL_ENV=esm yarn run build:esm && BABEL_ENV=cjs yarn run build:cjs",
     "configure": "yarn run build",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/transportation/package.json
+++ b/packages/transportation/package.json
@@ -29,7 +29,7 @@
     "start:dev": "cross-env NODE_ENV=development babel-node server",
     "start:prod": "cross-env NODE_ENV=production node server",
     "test": "cross-env BABEL_ENV=test mocha --opts ./mocha.opts 'src/**/*.test.js'",
-    "lint": "eslint --fix src"
+    "lint": "eslint src"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/packages/webpack-common/package.json
+++ b/packages/webpack-common/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/hackoregon/civic.git"
   },
   "scripts": {
-    "lint": "eslint --fix index.js"
+    "lint": "eslint index.js"
   },
   "keywords": [
     "civic",


### PR DESCRIPTION
This adds eslint to the lint-staged hook currently used to prettier files for #515. It will display linting errors in the console, and not allow you to commit unless you fix them (or manually skip the process).