### PR TITLE
Fix storybook configuration 

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -3,17 +3,23 @@
 
 import { addParameters, configure } from "@storybook/react";
 import "../packages/component-library/assets/global.styles.css";
+import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 
 addParameters({
   options: {
     showPanel: true,
     theme: undefined
+  },
+  viewport: {
+    defaultViewport: "responsive",
+    viewports: {
+      ...INITIAL_VIEWPORTS
+    }
   }
 });
 
 function loadStories() {
   require("../packages/component-library/stories");
-  addParameters({ viewport: options });
 }
 
 configure(loadStories, module);


### PR DESCRIPTION
This addresses #514.

It fixes the viewport addon configuration by setting some defaults. This change solves the problem with stories not showing up when the page is reloaded.