### PR TITLE
Updated props for ScatterPlotMap and Storybook

### DIFF
--- a/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
+++ b/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
@@ -9,15 +9,16 @@ const crosshair = css`
 
 const ScatterPlotMap = props => {
   const {
+    stroked,
+    getLineWidth,
+    getFillColor,
+    getLineColor,
     viewport,
     data,
     getPosition,
     opacity,
-    getColor,
     getRadius,
     radiusScale,
-    outline,
-    strokeWidth,
     autoHighlight,
     highlightColor,
     onLayerClick,
@@ -49,19 +50,19 @@ const ScatterPlotMap = props => {
           data={data}
           getPosition={getPosition}
           opacity={opacity}
-          getColor={getColor}
           getRadius={getRadius}
           radiusScale={radiusScale}
           radiusMinPixels={1}
-          outline={outline}
-          strokeWidth={strokeWidth}
           autoHighlight={autoHighlight}
           highlightColor={highlightColor}
           onClick={onLayerClick}
           parameters={{ depthTest: false }}
           visible={visible}
-          updateTriggers={{ instanceColors: getColor }}
           onHover={onHover}
+          stroked={stroked}
+          getLineColor={getLineColor}
+          getLineWidth={getLineWidth}
+          getFillColor={getFillColor}
         />
         {tooltipRender}
       </DeckGL>
@@ -74,11 +75,8 @@ ScatterPlotMap.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   getPosition: PropTypes.func,
   opacity: PropTypes.number,
-  getColor: PropTypes.func,
   getRadius: PropTypes.func,
   radiusScale: PropTypes.number,
-  outline: PropTypes.bool,
-  strokeWidth: PropTypes.number,
   autoHighlight: PropTypes.bool,
   highlightColor: PropTypes.arrayOf(PropTypes.number),
   onLayerClick: PropTypes.func,
@@ -87,19 +85,24 @@ ScatterPlotMap.propTypes = {
   x: PropTypes.number,
   y: PropTypes.number,
   onHover: PropTypes.func,
-  children: PropTypes.node
+  children: PropTypes.node,
+  stroked: PropTypes.bool,
+  getLineColor: PropTypes.func,
+  getLineWidth: PropTypes.func,
+  getFillColor: PropTypes.func
 };
 
 ScatterPlotMap.defaultProps = {
   getPosition: d => d.geometry.coordinates,
   opacity: 0.8,
-  getColor: () => [0, 0, 0],
   getRadius: () => 50,
   radiusScale: 1,
-  outline: false,
-  strokeWidth: 1,
   visible: true,
-  highlightColor: [0, 255, 0, 255]
+  highlightColor: [0, 255, 0, 255],
+  stroked: false,
+  getLineColor: () => [0, 0, 0],
+  getLineWidth: () => 1,
+  getFillColor: () => [0, 0, 0]
 };
 
 export default ScatterPlotMap;

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -16,8 +16,11 @@ const opacityOptions = {
 const getPosition = f =>
   f.geometry ? f.geometry.coordinates : [-124.664355, 45.615779];
 
-const getCircleColor = f =>
+const getFillColor = f =>
   f.properties.year_2017 > 1000 ? [255, 0, 0, 255] : [0, 0, 255, 255];
+
+const getLineColor = f =>
+  f.properties.year_2017 > 1000 ? [0, 0, 255, 255] : [255, 0, 0, 255];
 
 const getCircleRadius = f => Math.sqrt(f.properties.year_2017 / Math.PI) * 15;
 
@@ -28,7 +31,7 @@ const radiusScaleOptions = {
   step: 0.5
 };
 
-const strokeWidthOptions = {
+const lineWidthOptions = {
   range: true,
   min: 0,
   max: 20,
@@ -46,19 +49,20 @@ const demoMap = () => (
     {data => {
       const opacity = number("Opacity:", 0.1, opacityOptions);
       const radiusScale = number("Radius Scale:", 1, radiusScaleOptions);
-      const outline = boolean("Stroke Only:", false);
-      const strokeWidth = number("Stroke Width:", 1, strokeWidthOptions);
+      const stroked = boolean("Stroke Only:", false);
+      const getLineWidth = number("Line Width:", 1, lineWidthOptions);
       return (
         <BaseMap>
           <ScatterPlotMap
             data={data.slide_data.features}
             getPosition={getPosition}
             opacity={opacity}
-            getColor={getCircleColor}
+            getFillColor={getFillColor}
+            getLineColor={getLineColor}
             getRadius={getCircleRadius}
             radiusScale={radiusScale}
-            outline={outline}
-            strokeWidth={strokeWidth}
+            stroked={stroked}
+            getLineWidth={getLineWidth}
             autoHighlight
             highlightColor={highlightColor}
             onLayerClick={info =>
@@ -76,19 +80,20 @@ const tooltipMap = () => (
     {data => {
       const opacity = number("Opacity:", 0.1, opacityOptions);
       const radiusScale = number("Radius Scale:", 1, radiusScaleOptions);
-      const outline = boolean("Stroke Only:", false);
-      const strokeWidth = number("Stroke Width:", 1, strokeWidthOptions);
+      const stroked = boolean("Stroke Only:", false);
+      const getLineWidth = number("Line Width:", 1, lineWidthOptions);
       return (
         <BaseMap>
           <ScatterPlotMap
             data={data.slide_data.features}
             getPosition={getPosition}
             opacity={opacity}
-            getColor={getCircleColor}
+            getFillColor={getFillColor}
+            getLineColor={getLineColor}
             getRadius={getCircleRadius}
             radiusScale={radiusScale}
-            outline={outline}
-            strokeWidth={strokeWidth}
+            stroked={stroked}
+            getLineWidth={getLineWidth}
             autoHighlight
             highlightColor={highlightColor}
             onLayerClick={info =>


### PR DESCRIPTION
[Issue #505](https://github.com/hackoregon/civic/issues/505)

What needs to be done?

The Scatter Plot Map component has 3 props that need to be removed:

- [x]   outline
- [x]   strokeWidth
- [x]   getColor

These props need to be added:

- [x]   stroked
- [x]   getLineWidth
- [x]   getFillColor
- [x]   getLineColor

Additionally:

- [x]   Update the Scatter Plot Map simple usage story and knobs to use the new props
- [x]   Update the Scatter Plot Map with tooltip story and knobs to use the new props
- [ ]   Update the Explore Urban Campsite Sweeps story card in the 2018-neighborhood-development package to use the new props