### PR TITLE
Wrap window references for SSR

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -13,7 +13,7 @@
     "test:watch": "yarn run test -- -w",
     "lint": "eslint --fix src stories",
     "storybook": "node scripts/storybook.js",
-    "start": "node scripts/start.js"        
+    "start": "node scripts/start.js"
   },
   "author": "David Daniel <davidedaniel@gmail.com> (http://davidedaniel.github.io)",
   "license": "MIT",
@@ -85,6 +85,7 @@
     "d3-time-format": "^2.1.3",
     "deck.gl": "^6.4.7",
     "emotion": "^10.0.6",
+    "global": "^4.3.2",
     "lodash": "^4.17.11",
     "mapbox-gl": "^0.53.1",
     "prop-types": "^15.7.2",

--- a/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
+++ b/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { string, number, arrayOf, oneOfType, shape } from "prop-types";
 import { css } from "emotion";
+import window from "global/window";
 
 const tooltip = css`
   font-family: Helvetica, Arial, sans-serif;

--- a/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
+++ b/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
@@ -22,7 +22,9 @@ const MapTooltip = props => {
   const { y } = tooltipData;
 
   const xPosition =
-    x < window.innerWidth * 0.66 ? x : x - window.innerWidth * 0.1;
+    x < get(window, "innerWidth", 1000) * 0.66
+      ? x
+      : x - get(window, "innerWidth", 1000) * 0.1;
   const yPostition = y < 375 ? y : y - 50;
 
   const tooltipContent = tooltipData.content.map(obj => {

--- a/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
+++ b/packages/component-library/src/CivicSandboxMap/CivicSandboxTooltip.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { string, number, arrayOf, oneOfType, shape } from "prop-types";
 import { css } from "emotion";
+import { get } from "lodash";
 import window from "global/window";
 
 const tooltip = css`
@@ -31,7 +32,7 @@ const MapTooltip = props => {
     const value = obj.value ? obj.value : "No Data Available";
     return (
       <div key={`${obj.name}-${value}`}>
-        {obj.name + ": " + value.toLocaleString()}
+        {`${obj.name}: ${value.toLocaleString()}`}
       </div>
     );
   });

--- a/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import copy from "copy-to-clipboard";
 import { css } from "emotion";
+import window from "global/window";
 import CivicStoryLink from "./CivicStoryLink";
 import { ICONS } from "../styleConstants";
 

--- a/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
+++ b/packages/component-library/src/CivicStoryCard/CivicStoryFooter.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import copy from "copy-to-clipboard";
 import { css } from "emotion";
+import { get } from "lodash";
 import window from "global/window";
 import CivicStoryLink from "./CivicStoryLink";
 import { ICONS } from "../styleConstants";
@@ -48,7 +49,7 @@ export default class StoryFooter extends Component {
   handleCopy = () => {
     const { slug } = this.props;
     // NOTE: we need to make sure this will work on all browsers
-    copy(`${window.location.origin}/cards/${slug}`);
+    copy(`${get(window, "location.origin", "")}/cards/${slug}`);
     this.switchState(MS_TO_SWITCH_TEXT);
     this.setState({ copied: true });
   };
@@ -61,7 +62,8 @@ export default class StoryFooter extends Component {
     const shareTxt = copied ? "Link copied!" : "Share card"; // if copied, show Link copied, otherwise, show Share card
     const shareIcon = copied ? ICONS.check : ICONS.link;
     const routeOrUndefined =
-      `${window.location.origin}/cards/${slug}` === window.location.href
+      `${get(window, "location.origin", "")}/cards/${slug}` ===
+      get(window, "location.href", "")
         ? undefined
         : `/cards/${slug}`;
 

--- a/packages/component-library/src/HexOverlay/HexOverlay.js
+++ b/packages/component-library/src/HexOverlay/HexOverlay.js
@@ -5,6 +5,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import DeckGL, { HexagonLayer } from "deck.gl";
 import window from "global/window";
+import { has } from "lodash";
 
 const elevationScale = { min: 1, max: 50 };
 
@@ -39,7 +40,8 @@ class HexOverlay extends Component {
     this._stopAnimate();
 
     // wait 1.5 secs to start animation so that all data are loaded
-    this.startAnimationTimer = window.setTimeout(this._startAnimate, 1500);
+    this.startAnimationTimer =
+      has(window, "setTimeout") && window.setTimeout(this._startAnimate, 1500);
   }
 
   _animateHeight() {
@@ -51,12 +53,14 @@ class HexOverlay extends Component {
   }
 
   _startAnimate() {
-    this.intervalTimer = window.setInterval(this._animateHeight, 20);
+    this.intervalTimer =
+      has(window, "setInterval") && window.setInterval(this._animateHeight, 20);
   }
 
   _stopAnimate() {
-    window.clearTimeout(this.startAnimationTimer);
-    window.clearTimeout(this.intervalTimer);
+    has(window, "clearTimeout") &&
+      window.clearTimeout(this.startAnimationTimer);
+    has(window, "clearTimeout") && window.clearTimeout(this.intervalTimer);
   }
 
   render() {

--- a/packages/component-library/src/HexOverlay/HexOverlay.js
+++ b/packages/component-library/src/HexOverlay/HexOverlay.js
@@ -4,6 +4,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import DeckGL, { HexagonLayer } from "deck.gl";
+import window from "global/window";
 
 const elevationScale = { min: 1, max: 50 };
 

--- a/packages/component-library/src/LandingPage/CanvasParticles.js
+++ b/packages/component-library/src/LandingPage/CanvasParticles.js
@@ -3,6 +3,7 @@
 
 import React from "react";
 import { css } from "emotion";
+import window from "global/window";
 
 const canvasStyles = css`
   position: fixed;

--- a/packages/component-library/src/LandingPage/CanvasParticles.js
+++ b/packages/component-library/src/LandingPage/CanvasParticles.js
@@ -1,9 +1,9 @@
 /* Not currently used, updated and moved to 2018 package */
-/* eslint-disable */
 
 import React from "react";
 import { css } from "emotion";
 import window from "global/window";
+import { get, has } from "lodash";
 
 const canvasStyles = css`
   position: fixed;
@@ -13,21 +13,21 @@ class CanvasParticles extends React.Component {
   componentDidMount() {
     window.requestAnimFrame = (function() {
       return (
-        window.requestAnimationFrame ||
-        window.webkitRequestAnimationFrame ||
-        window.mozRequestAnimationFrame ||
-        window.oRequestAnimationFrame ||
-        window.msRequestAnimationFrame ||
+        get(window, "requestAnimationFrame") ||
+        get(window, "webkitRequestAnimationFrame") ||
+        get(window, "mozRequestAnimationFrame") ||
+        get(window, "oRequestAnimationFrame") ||
+        get(window, "msRequestAnimationFrame") ||
         function(callback) {
-          window.setTimeout(callback, 1000 / 60);
+          has(window, "setTimeout") && window.setTimeout(callback, 1000 / 60);
         }
       );
     })();
     const { canvas } = this.refs;
     const ctx = canvas.getContext("2d");
     const img = this.refs.image;
-    const W = window.innerWidth;
-    const H = window.innerHeight;
+    const W = get(window, "innerWidth", 1000);
+    const H = get(window, "innerHeight", 1000);
     canvas.width = W * 1.2;
     canvas.height = H * 1.2;
     const particleCount = 40;

--- a/packages/component-library/src/LandingPage/LandingPage.js
+++ b/packages/component-library/src/LandingPage/LandingPage.js
@@ -3,6 +3,7 @@
 
 import React from "react";
 import { cx, css } from "emotion";
+import window from "global/window";
 
 import { Header, Footer } from "@hackoregon/component-library";
 import CanvasParticles from "./CanvasParticles";

--- a/packages/component-library/src/MapTooltip/MapTooltip.js
+++ b/packages/component-library/src/MapTooltip/MapTooltip.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { css } from "emotion";
+import { get } from "lodash";
 import window from "global/window";
 
 const tooltip = css`
@@ -29,7 +30,9 @@ const MapTooltip = props => {
   } = props;
 
   const xPosition =
-    x < window.innerWidth * 0.66 ? x : x - window.innerWidth * 0.1;
+    x < get(window, "innerWidth", 1000) * 0.66
+      ? x
+      : x - get(window, "innerWidth", 1000) * 0.1;
   const yPostition = y < 375 ? y : y - 50;
 
   return (

--- a/packages/component-library/src/MapTooltip/MapTooltip.js
+++ b/packages/component-library/src/MapTooltip/MapTooltip.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { css } from "emotion";
+import window from "global/window";
 
 const tooltip = css`
   font-family: Helvetica, Arial, sans-serif;

--- a/packages/component-library/src/PullQuote/PullQuote.js
+++ b/packages/component-library/src/PullQuote/PullQuote.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { css } from "emotion";
 import { TwitterShareButton, TwitterIcon } from "react-share";
+import window from "global/window";
 
 const quoteClass = css`
   font-family: "Merriweather", serif;

--- a/packages/component-library/src/PullQuote/PullQuote.js
+++ b/packages/component-library/src/PullQuote/PullQuote.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { css } from "emotion";
 import { TwitterShareButton, TwitterIcon } from "react-share";
+import { get } from "lodash";
 import window from "global/window";
 
 const quoteClass = css`
@@ -31,7 +32,10 @@ const wrapperClass = css`
 
 const PullQuote = ({ quoteText, quoteAttribution, url }) => (
   <div className={wrapperClass}>
-    <TwitterShareButton url={url || window.location.href} title={quoteText}>
+    <TwitterShareButton
+      url={url || get(window, "location.href", "")}
+      title={quoteText}
+    >
       <blockquote className={quoteClass}>
         &#8220;
         {quoteText}

--- a/packages/component-library/src/Share/ShareCollection.js
+++ b/packages/component-library/src/Share/ShareCollection.js
@@ -4,6 +4,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import copy from "copy-to-clipboard";
+import window from "global/window";
+
 import StoryLink from "../StoryCard/StoryLink";
 import { ICONS } from "../styleConstants";
 

--- a/packages/component-library/src/Share/ShareCollection.js
+++ b/packages/component-library/src/Share/ShareCollection.js
@@ -31,7 +31,7 @@ export default class ShareCollection extends Component {
 
   handleCopy = () => {
     // NOTE: we need to make sure this will work on all browsers
-    copy(`${window.location.href}`);
+    copy(`${get(window, "location.href", "")}`);
     this.switchState(MS_TO_SWITCH_TEXT);
     this.setState({ copied: true });
   };

--- a/packages/component-library/src/Share/ShareCollection.js
+++ b/packages/component-library/src/Share/ShareCollection.js
@@ -4,6 +4,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import copy from "copy-to-clipboard";
+import { get } from "lodash";
 import window from "global/window";
 
 import StoryLink from "../StoryCard/StoryLink";

--- a/packages/component-library/src/StoryCard/StoryFooter.js
+++ b/packages/component-library/src/StoryCard/StoryFooter.js
@@ -5,6 +5,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import copy from "copy-to-clipboard";
 import { css } from "emotion";
+import { get } from "lodash";
 import window from "global/window";
 
 import StoryLink from "./StoryLink";
@@ -45,7 +46,7 @@ export default class StoryFooter extends Component {
   handleCopy = () => {
     const { collectionId, cardId } = this.props;
     // NOTE: we need to make sure this will work on all browsers
-    copy(`${window.location.origin}/${collectionId}/${cardId}`);
+    copy(`${get(window, "location.href", "")}/${collectionId}/${cardId}`);
     this.switchState(MS_TO_SWITCH_TEXT);
     this.setState({ copied: true });
   };

--- a/packages/component-library/src/StoryCard/StoryFooter.js
+++ b/packages/component-library/src/StoryCard/StoryFooter.js
@@ -5,6 +5,8 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import copy from "copy-to-clipboard";
 import { css } from "emotion";
+import window from "global/window";
+
 import StoryLink from "./StoryLink";
 import { ICONS } from "../styleConstants";
 


### PR DESCRIPTION
Addresses #503 

Still requires the Webpack configuration tweak to work with Gatsby, as described in [their documentation on this issue](https://www.gatsbyjs.org/docs/debugging-html-builds/). I feel like there is a workaround for the two offending modules, but I'm not sure what it is.

I added the [global](https://www.npmjs.com/package/global) module as a dependency for this purpose.

```
exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
  if (stage === "build-html") {
    actions.setWebpackConfig({
      module: {
        rules: [
          {
            test: /react-map-gl-geocoder/,
            use: loaders.null()
          },
          {
            test: /mapbox-gl/,
            use: loaders.null()
          }
        ]
      }
    });
  }
};
```

