### PR TITLE
Fixed gradient scale to display primary and secondary lines.

### DIFF
--- a/packages/component-library/src/GradientScale/GradientBox.js
+++ b/packages/component-library/src/GradientScale/GradientBox.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import { Box } from "victory";
 
-const GradientLine = ({ scale, domain, fill }) => {
+const GradientBox = ({ scale, domain, fill }) => {
   const width = scale.x(domain.x[1]) - scale.x(domain.x[0]);
   const height = Math.abs(scale.y(domain.y[1]) - scale.y(domain.y[0]));
   return (
@@ -17,7 +17,7 @@ const GradientLine = ({ scale, domain, fill }) => {
   );
 };
 
-GradientLine.propTypes = {
+GradientBox.propTypes = {
   scale: PropTypes.shape({
     y: PropTypes.func,
     x: PropTypes.func
@@ -29,4 +29,4 @@ GradientLine.propTypes = {
   fill: PropTypes.string.isRequired
 };
 
-export default GradientLine;
+export default GradientBox;

--- a/packages/component-library/src/GradientScale/GradientScale.js
+++ b/packages/component-library/src/GradientScale/GradientScale.js
@@ -109,6 +109,8 @@ const GradientScale = ({
         width={width}
       >
         <GradientBox padding={0} fill="url(#myGradient)" />
+        {/* Necessary dummy component to make VictoryLine work within GradientBox work */}
+        <VictoryScatter data={data} dataComponent={<GradientLine />} />
         <VictoryScatter data={data} dataComponent={<GradientLine />} />
       </VictoryGroup>
     </div>


### PR DESCRIPTION
This addresses issue #499 

- updated GradientBox name to match file name
- added dummy VictoryScatter component as a work around for Victory bug
that was causing secondary line(s) not to display