### PR TITLE
Added README section for component library/project workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ yarn test
 $ yarn test --watch
 ```
 
-## Working on the component library using storybook
+## Working on the component library using Storybook
 
 We are committed to a shared component library. This is achieved using the `component-library` package and React Storybook.
 Run Storybook with the following command or [view it here](https://hackoregon.github.io/civic/):
@@ -119,10 +119,12 @@ $ yarn storybook
 
 ## Working on the component library and a project package simultaneuously
 
-In separate terminals, run the commands in both sections above. Project packages rely on the built version of the component library, so if you have updated the component library, and want to see your changes in the project package you are working on, you'll need to rebuild the component library. Once the component library build has finished, your project package will reload with the update components.
+In separate terminals, run the commands in the **Working on a single package other than the component library** and **Working on the component library using Storybook** sections. Project packages rely on the built version of the component library, so if you have updated the component library, and want to see your changes in the project package you are working on, you'll need to rebuild the component library. Once the component library build has finished, your project package will reload with the update components.
 
 ```bash
 $ cd packages/component-library
+
+# rebuild the component library
 $ yarn build
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ Run Storybook with the following command or [view it here](https://hackoregon.gi
 $ yarn storybook
 ```
 
+## Working on the component library and a project package simultaneuously
+
+In separate terminals, run the commands in both sections above. Project packages rely on the built version of the component library, so if you have updated the component library, and want to see your changes in the project package you are working on, you'll need to rebuild the component library. Once the component library build has finished, your project package will reload with the update components.
+
+```bash
+$ cd packages/component-library
+$ yarn build
+```
+
 ## Project Layout
 
 There are three types of packages right now:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ $ yarn storybook
 
 ## Working on the component library and a project package simultaneuously
 
-In separate terminals, run the commands in the **Working on a single package other than the component library** and **Working on the component library using Storybook** sections. Project packages rely on the built version of the component library, so if you have updated the component library, and want to see your changes in the project package you are working on, you'll need to rebuild the component library. Once the component library build has finished, your project package will reload with the update components.
+In separate terminals, run the commands in the **Working on a single package other than the component library** and **Working on the component library using Storybook** sections above. Project packages rely on the built version of the component library, so if you have updated the component library, and want to see your changes in the project package you are working on, you'll need to rebuild the component library. Once the component library build has finished, your project package will reload with the update components.
 
 ```bash
 $ cd packages/component-library


### PR DESCRIPTION
Added a section to the README about working on the component library and a project package at the same time, following up on working with @kdv24 on #534