### PR TITLE
Embeddable Story Cards

### DIFF
--- a/packages/2018/src/App.js
+++ b/packages/2018/src/App.js
@@ -60,6 +60,7 @@ import PortlandCollectionPage from "./components/PortlandCollectionPage";
 import CityNotFoundPage from "./components/CityNotFoundPage";
 import StateNotFoundPage from "./components/StateNotFoundPage";
 import CardDetailPage from "./components/CardDetailPage";
+import CardDetailPageEmbed from "./components/CardDetailPageEmbed";
 
 // Create a store by combining all project reducers and the routing reducer
 const configureStore = (initialState, history) => {
@@ -189,6 +190,10 @@ const routes = {
     {
       path: "cards/:slug",
       component: CardDetailPage
+    },
+    {
+      path: "cards/:slug/embed",
+      component: CardDetailPageEmbed
     },
     {
       path: "sandbox",

--- a/packages/2018/src/components/CardDetailPageEmbed.js
+++ b/packages/2018/src/components/CardDetailPageEmbed.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router";
-import { PageLayout } from "@hackoregon/component-library";
 import CardRegistry from "../card-registry";
 
 const CardDetailPageEmbed = ({ params }) => {
@@ -25,6 +24,6 @@ CardDetailPageEmbed.propTypes = {
   params: PropTypes.string
 };
 
-CardDetailPageEmbed.displayName = "CardDetailPage";
+CardDetailPageEmbed.displayName = "CardDetailPageEmbed";
 
 export default CardDetailPageEmbed;

--- a/packages/2018/src/components/CardDetailPageEmbed.js
+++ b/packages/2018/src/components/CardDetailPageEmbed.js
@@ -1,0 +1,30 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Link } from "react-router";
+import { PageLayout } from "@hackoregon/component-library";
+import CardRegistry from "../card-registry";
+
+const CardDetailPageEmbed = ({ params }) => {
+  const card = CardRegistry.find(params.slug);
+
+  if (card && card.component) {
+    const CardComponent = card.component;
+    return <CardComponent />;
+  }
+
+  return (
+    <div>
+      <h1>Card not found</h1>
+      <p>The card you are looking for doesn&apos;t exist.</p>
+      <Link to="/">Find more on CIVIC</Link>
+    </div>
+  );
+};
+
+CardDetailPageEmbed.propTypes = {
+  params: PropTypes.string
+};
+
+CardDetailPageEmbed.displayName = "CardDetailPage";
+
+export default CardDetailPageEmbed;


### PR DESCRIPTION
We talked about it, now it's real!

I was doing a little bit of research to try and provide context to write an issue about embeddable story cards, and found this great [Mozilla reference guide](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies), and decided to give it a go. Thanks to @DingoEatingFuzz's architecture, implementing it was very straightforward.

Here's some screenshots of a card embedded in the [Hack Oregon Weekly Updates Page](https://dazzling-newton-967394.netlify.com/), which happened to be the most convenient other website for me to test with locally.

|  Working (note: you can see the whole card) <img width="300" alt="image" src="https://user-images.githubusercontent.com/7065695/57767408-1e8e0b00-76be-11e9-8a69-c12ccc9f7d11.png"> | Not found <img width="300" alt="image" src="https://user-images.githubusercontent.com/7065695/57767372-07e7b400-76be-11e9-8422-a3a8cc2e0a3c.png">  |
|---|---|

This is what the embed code looks like:
```
        <iframe
          id="magnitude-of-sweeps"
          type="text/html"
          width="800"
          height="900"
          src="https://civicplatform.org/cards/magnitude-of-urban-campsite-sweeps/embed/"
          frameborder="0"
        />
```
Note that you need to set an explicit height, but this is just a limitation of iframes.

We may want to tweak things as we start to embed more story cards other places, but this gives us a really great start.

- Added route /cards/slug/embed
- Added CardDetailPageEmbed component, almost identical to CardDetailPage but stripping out PageLayout to show standalone card.