### PR TITLE
Install and use yarn in dockerfile instead of npm for 2017/2018 deploy

### DIFF
--- a/packages/2017/Dockerfile
+++ b/packages/2017/Dockerfile
@@ -3,9 +3,15 @@ FROM node:10.15.3-stretch
 # Create app directory
 WORKDIR /usr/src/app
 
+# Install yarn
+RUN apt-get update && apt-get install -y apt-transport-https
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install yarn
+
 # Install app dependencies
 COPY package*.json ./
-RUN npm install --only=production
+RUN yarn install --production=true
 
 # Bundle app source
 COPY server server

--- a/packages/2017/Dockerfile
+++ b/packages/2017/Dockerfile
@@ -7,10 +7,15 @@ WORKDIR /usr/src/app
 RUN apt-get update && apt-get install -y apt-transport-https
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install yarn
+RUN apt-get update && apt-get install -y yarn
 
-# Install app dependencies
+# Copy and clean the package.json file to remove invalid
+# packages since this won't be associated to the workspace
 COPY package*.json ./
+COPY clean-packages.js clean-packages.js
+RUN node clean-packages.js
+
+# Instal dependencies
 RUN yarn install --production=true
 
 # Bundle app source

--- a/packages/2017/clean-packages.js
+++ b/packages/2017/clean-packages.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-console */
+/* eslint-disable no-var */
+
+var fs = require("fs");
+
+var file = JSON.parse(fs.readFileSync("package.json"));
+
+// Remove all of the hackoregon packages, since they aren't
+// in the public package registry
+Object.keys(file.dependencies).forEach(pkg => {
+  if (pkg.startsWith("@hackoregon")) {
+    console.log(`Removing ${pkg}`);
+    delete file.dependencies[pkg];
+  }
+});
+
+console.log("New package.json");
+console.log(JSON.stringify(file, null, 2));
+
+fs.writeFileSync("package.json", JSON.stringify(file, null, 2));

--- a/packages/2018/Dockerfile
+++ b/packages/2018/Dockerfile
@@ -3,9 +3,15 @@ FROM node:10.15.3-stretch
 # Create app directory
 WORKDIR /usr/src/app
 
+# Install yarn
+RUN apt-get update && apt-get install -y apt-transport-https
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install yarn
+
 # Install app dependencies
 COPY package*.json ./
-RUN npm install --only=production
+RUN yarn install --production=true
 
 # Bundle app source
 COPY server server

--- a/packages/2018/Dockerfile
+++ b/packages/2018/Dockerfile
@@ -7,10 +7,15 @@ WORKDIR /usr/src/app
 RUN apt-get update && apt-get install -y apt-transport-https
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install yarn
+RUN apt-get update && apt-get install -y yarn
 
-# Install app dependencies
+# Copy and clean the package.json file to remove invalid
+# packages since this won't be associated to the workspace
 COPY package*.json ./
+COPY clean-packages.js clean-packages.js
+RUN node clean-packages.js
+
+# Instal dependencies
 RUN yarn install --production=true
 
 # Bundle app source

--- a/packages/2018/clean-packages.js
+++ b/packages/2018/clean-packages.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-console */
+/* eslint-disable no-var */
+
+var fs = require("fs");
+
+var file = JSON.parse(fs.readFileSync("package.json"));
+
+// Remove all of the hackoregon packages, since they aren't
+// in the public package registry
+Object.keys(file.dependencies).forEach(pkg => {
+  if (pkg.startsWith("@hackoregon")) {
+    console.log(`Removing ${pkg}`);
+    delete file.dependencies[pkg];
+  }
+});
+
+console.log("New package.json");
+console.log(JSON.stringify(file, null, 2));
+
+fs.writeFileSync("package.json", JSON.stringify(file, null, 2));


### PR DESCRIPTION
Hopefully, addresses #536.

I copied the code for installing yarn in the docker image from [this article](https://medium.com/arthur-design-engineering/efficient-docker-with-the-new-yarn-package-manager-native-packages-like-bcrypt-for-node-js-apps-5b36c9930e2d)