### PR TITLE
Remove Global Knobs from Storybooks

### DIFF
--- a/packages/component-library/stories/CivicStoryCard.story.js
+++ b/packages/component-library/stories/CivicStoryCard.story.js
@@ -3,20 +3,19 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { text, array } from "@storybook/addon-knobs";
 import { CivicStoryCard, HorizontalBarChart, Collapsable } from "../src";
 import { wallOfRichText, wallOfText } from "./shared";
 
-const data = array("Data", [
+const data = [
   { sortOrder: 1, population: 2000, label: "Labrador Retriever" },
   { sortOrder: 2, population: 8000, label: "Standard Poodle" },
   { sortOrder: 3, population: 6000, label: "French Bulldog" },
   { sortOrder: 4, population: 3000, label: "Afghan Hound" },
   { sortOrder: 5, population: 1000, label: "Jack Russell Terrier" }
-]);
-const dataKey = text("Data key", "sortOrder");
-const dataValue = text("Data values", "population");
-const dataKeyLabel = text("Data key labels", "label");
+];
+const dataKey = "sortOrder";
+const dataValue = "population";
+const dataKeyLabel = "label";
 
 const Container = ({ children }) => (
   <div style={{ padding: "30px" }}>{children}</div>
@@ -35,9 +34,9 @@ const tdvDemo = () => (
       <div style={{ display: "flex", justifyContent: "space-around" }}>
         <HorizontalBarChart
           data={data}
-          dataKey={dataKey}
+          sortOrder={dataKey}
           dataValue={dataValue}
-          dataKeyLabel={dataKeyLabel}
+          dataLabel={dataKeyLabel}
         />
       </div>
       <p className="Description">{wallOfRichText}</p>
@@ -52,9 +51,9 @@ const collapsableDemo = () => (
           <div style={{ display: "flex", justifyContent: "space-around" }}>
             <HorizontalBarChart
               data={data}
-              dataKey={dataKey}
+              sortOrder={dataKey}
               dataValue={dataValue}
-              dataKeyLabel={dataKeyLabel}
+              dataLabel={dataKeyLabel}
             />
           </div>
         </Collapsable.Section>

--- a/packages/component-library/stories/PackageSelectorBox.story.js
+++ b/packages/component-library/stories/PackageSelectorBox.story.js
@@ -3,67 +3,68 @@ import React from "react";
 import { css } from "emotion";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { array } from "@storybook/addon-knobs";
+import { withKnobs, object } from "@storybook/addon-knobs";
 import { PackageSelectorBox } from "../src";
 
-const packageSelectorList = array("Data", [
-  {
-    title: "Schools",
-    description:
-      "A short description of the sorts of things you can explore with this package. Data Sources?"
-  },
-  {
-    title: "Crimes",
-    description:
-      "A short description of the sorts of things you can explore with this package. Data Sources?"
-  },
-  {
-    title: "Demolitions",
-    description:
-      "A short description of the sorts of things you can explore with this package. Data Sources?"
-  },
-  {
-    title: "TriMet Ridership",
-    description:
-      "A short description of the sorts of things you can explore with this package. Data Sources?"
-  },
-  {
-    title: "Collisions",
-    description:
-      "A short description of the sorts of things you can explore with this package. Data Sources?"
-  },
-  {
-    title: "Mega-Quake",
-    description:
-      "A short description of the sorts of things you can explore with this package. Data Sources?"
-  }
-]);
-
-const PackageSelectorDemo = () => (
-  <div
-    className={css(`
-  @media (min-width: 600px) {
-    display: flex;
-    flex-wrap: wrap;
-  }
-`)}
-  >
-    {packageSelectorList.map(selector => (
-      <div
-        className={css(`
-        @media (min-width: 600px) {
-          width: 33%;
-        }
-      `)}
-      >
-        <PackageSelectorBox
-          title={selector.title}
-          description={selector.description}
-        />
-      </div>
-    ))}
-  </div>
-);
+const PackageSelectorDemo = () => {
+  const packageSelectorList = object("Data", [
+    {
+      title: "Schools",
+      description:
+        "A short description of the sorts of things you can explore with this package. Data Sources?"
+    },
+    {
+      title: "Crimes",
+      description:
+        "A short description of the sorts of things you can explore with this package. Data Sources?"
+    },
+    {
+      title: "Demolitions",
+      description:
+        "A short description of the sorts of things you can explore with this package. Data Sources?"
+    },
+    {
+      title: "TriMet Ridership",
+      description:
+        "A short description of the sorts of things you can explore with this package. Data Sources?"
+    },
+    {
+      title: "Collisions",
+      description:
+        "A short description of the sorts of things you can explore with this package. Data Sources?"
+    },
+    {
+      title: "Mega-Quake",
+      description:
+        "A short description of the sorts of things you can explore with this package. Data Sources?"
+    }
+  ]);
+  return (
+    <div
+      className={css(`
+    @media (min-width: 600px) {
+      display: flex;
+      flex-wrap: wrap;
+    }
+  `)}
+    >
+      {packageSelectorList.map(selector => (
+        <div
+          className={css(`
+          @media (min-width: 600px) {
+            width: 33%;
+          }
+        `)}
+        >
+          <PackageSelectorBox
+            title={selector.title}
+            description={selector.description}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
 
 const PackageSelectorCollection = () => (
   <div>
@@ -74,6 +75,7 @@ const PackageSelectorCollection = () => (
 
 export default () =>
   storiesOf("Component Lib|CIVIC Platform/Package Selector Box", module)
+    .addDecorator(withKnobs)
     .add(
       "Basic List of selection Options",
       // 'This is a basic list of selection options for the

--- a/packages/component-library/stories/PageLayout.story.js
+++ b/packages/component-library/stories/PageLayout.story.js
@@ -2,20 +2,19 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { text, array } from "@storybook/addon-knobs";
 import { CivicStoryCard, HorizontalBarChart, PageLayout } from "../src";
 import { wallOfRichText } from "./shared";
 
-const data = array("Data", [
+const data = [
   { sortOrder: 1, population: 2000, label: "Labrador Retriever" },
   { sortOrder: 2, population: 8000, label: "Standard Poodle" },
   { sortOrder: 3, population: 6000, label: "French Bulldog" },
   { sortOrder: 4, population: 3000, label: "Afghan Hound" },
   { sortOrder: 5, population: 1000, label: "Jack Russell Terrier" }
-]);
-const dataKey = text("Data key", "sortOrder");
-const dataValue = text("Data values", "population");
-const dataKeyLabel = text("Data key labels", "label");
+];
+const dataKey = "sortOrder";
+const dataValue = "population";
+const dataKeyLabel = "label";
 
 const housingExample = () => (
   <PageLayout
@@ -41,9 +40,9 @@ const housingExample = () => (
         <div style={{ display: "flex", justifyContent: "space-around" }}>
           <HorizontalBarChart
             data={data}
-            dataKey={dataKey}
+            sortOrder={dataKey}
             dataValue={dataValue}
-            dataKeyLabel={dataKeyLabel}
+            dataLabel={dataKeyLabel}
             title="Dogs x Income"
           />
         </div>
@@ -71,9 +70,9 @@ const housingExample = () => (
         <div style={{ display: "flex", justifyContent: "space-around" }}>
           <HorizontalBarChart
             data={data}
-            dataKey={dataKey}
+            sortOrder={dataKey}
             dataValue={dataValue}
-            dataKeyLabel={dataKeyLabel}
+            dataLabel={dataKeyLabel}
             title="Dogs x Income"
           />
         </div>
@@ -139,9 +138,10 @@ const campaignFinanceExample = () => (
         <div style={{ display: "flex", justifyContent: "space-around" }}>
           <HorizontalBarChart
             data={data}
-            dataKey={dataKey}
+            sortOrder={dataKey}
             dataValue={dataValue}
-            dataKeyLabel={dataKeyLabel}
+            dataLabel={dataKeyLabel}
+            title="Dogs x Income"
           />
         </div>
         <p className="Description">{wallOfRichText}</p>


### PR DESCRIPTION
This addresses #530.

I remember we had the same problem of extra knobs appearing in stories in #132 and the same solution from there worked here.

By moving knobs within the add story function, those extra knobs no longer appear. That's what I did in the Package Selector Box story. But I ended up removing the knobs for the Horizontal Bar Chart part of the Civic Story Card and Page Layout stories. 

