### PR TITLE
replaced getColor() with getFillColor() and getLineColor()

### DIFF
--- a/packages/2018-neighborhood-development/src/components/ExploreUrbanCampsiteSweeps/index.js
+++ b/packages/2018-neighborhood-development/src/components/ExploreUrbanCampsiteSweeps/index.js
@@ -47,7 +47,8 @@ export class ExploreUrbanCampsiteSweeps extends React.Component {
       <ScatterPlotMap
         data={data}
         autoHighlight={false}
-        getColor={() => [220, 69, 86]}
+        getFillColor={() => [220, 69, 86]}
+        getLineColor={() => [220, 69, 86]}
         getRadius={() => 100}
       />
     );


### PR DESCRIPTION
- Because `outline()` & `strokeWidth()` were not already used in [Expore Urban Campsites Sweeps](https://github.com/hackoregon/civic/blob/master/packages/2018-neighborhood-development/src/components/ExploreUrbanCampsiteSweeps/index.js), I didn't add `stroked()` & `getLineWidth()` as props there.
- Let me know if I should have, and if so, what those values should be.  I assumed, they'd just use the default values specified in the ScatterPlotMap story.
Thanks! 😃 
