### PR TITLE
Storybook DemoJSONLoader update

### DIFF
--- a/packages/component-library/src/DemoJSONLoader/DemoJSONLoader.js
+++ b/packages/component-library/src/DemoJSONLoader/DemoJSONLoader.js
@@ -1,18 +1,12 @@
-import React from "react";
-import { string, arrayOf, node } from "prop-types";
+import React, { useState, useEffect } from "react";
+import { string, arrayOf, func } from "prop-types";
 /* global fetch */
 
-class StorybookJSONLoader extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      data: null
-    };
-  }
+const DemoJSONLoader = props => {
+  const [data, setData] = useState(null);
 
-  componentDidMount() {
-    const { urls } = this.props;
-    const promisesArr = urls.map(url => {
+  useEffect(() => {
+    const promisesArr = props.urls.map(url => {
       return fetch(url)
         .then(response => response)
         .then(response =>
@@ -25,26 +19,22 @@ class StorybookJSONLoader extends React.Component {
               }
         );
     });
-
     Promise.all(promisesArr)
-      .then(data => this.setState({ data }))
-      // eslint-disable-next-line no-console
-      .catch(error => console.log(error));
-  }
+      .then(data => setData(data))
+      .catch(error => {
+        throw new Error(error);
+      });
+  }, [props.urls[0]]);
 
-  render() {
-    const { data } = this.state;
-    const { children } = this.props;
-    if (data === null) {
-      return null;
-    }
-    return data.length === 1 ? children(data[0]) : children(data);
+  if (data === null) {
+    return null;
   }
-}
-
-StorybookJSONLoader.propTypes = {
-  urls: arrayOf(string).isRequired,
-  children: node
+  return data.length === 1 ? props.children(data[0]) : props.children(data);
 };
 
-export default StorybookJSONLoader;
+DemoJSONLoader.propTypes = {
+  urls: arrayOf(string).isRequired,
+  children: func
+};
+
+export default DemoJSONLoader;

--- a/packages/component-library/src/HeatMap/HeatMap.js
+++ b/packages/component-library/src/HeatMap/HeatMap.js
@@ -22,6 +22,9 @@ class HeatMap extends React.Component {
     const heatmapId = `heat-layer-${this.props.id}`;
     const circleId = `circle-layer-${this.props.id}`;
 
+    mapboxgl.accessToken =
+      "pk.eyJ1IjoiaGFja29yZWdvbiIsImEiOiJjamk0MGZhc2cwNDl4M3FsdHAwaG54a3BnIn0.Fq1KA0IUwpeKQlFIoaEn_Q";
+
     this.map = new mapboxgl.Map({
       container: this.mapContainer,
       style: this.props.mapStyle,

--- a/packages/component-library/src/HeatMap/HeatMap.js
+++ b/packages/component-library/src/HeatMap/HeatMap.js
@@ -21,10 +21,8 @@ class HeatMap extends React.Component {
     const dataId = `data-source-${this.props.id}`;
     const heatmapId = `heat-layer-${this.props.id}`;
     const circleId = `circle-layer-${this.props.id}`;
-
     mapboxgl.accessToken =
       "pk.eyJ1IjoiaGFja29yZWdvbiIsImEiOiJjamk0MGZhc2cwNDl4M3FsdHAwaG54a3BnIn0.Fq1KA0IUwpeKQlFIoaEn_Q";
-
     this.map = new mapboxgl.Map({
       container: this.mapContainer,
       style: this.props.mapStyle,

--- a/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
+++ b/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
@@ -58,6 +58,7 @@ const ScatterPlotMap = props => {
           getLineColor={getLineColor}
           getLineWidth={getLineWidth}
           getFillColor={getFillColor}
+          updateTriggers={{ getRadius }}
         />
       </DeckGL>
       {tooltipRender}
@@ -70,7 +71,7 @@ ScatterPlotMap.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   getPosition: PropTypes.func,
   opacity: PropTypes.number,
-  getRadius: PropTypes.func,
+  getRadius: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   radiusScale: PropTypes.number,
   autoHighlight: PropTypes.bool,
   highlightColor: PropTypes.arrayOf(PropTypes.number),
@@ -83,7 +84,7 @@ ScatterPlotMap.propTypes = {
   children: PropTypes.node,
   stroked: PropTypes.bool,
   getLineColor: PropTypes.func,
-  getLineWidth: PropTypes.func,
+  getLineWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   getFillColor: PropTypes.func
 };
 

--- a/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
+++ b/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
@@ -71,7 +71,7 @@ ScatterPlotMap.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   getPosition: PropTypes.func,
   opacity: PropTypes.number,
-  getRadius: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  getRadius: PropTypes.func,
   radiusScale: PropTypes.number,
   autoHighlight: PropTypes.bool,
   highlightColor: PropTypes.arrayOf(PropTypes.number),
@@ -84,7 +84,7 @@ ScatterPlotMap.propTypes = {
   children: PropTypes.node,
   stroked: PropTypes.bool,
   getLineColor: PropTypes.func,
-  getLineWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  getLineWidth: PropTypes.func,
   getFillColor: PropTypes.func
 };
 

--- a/packages/component-library/stories/HeatMap.story.js
+++ b/packages/component-library/stories/HeatMap.story.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { withKnobs, number, select } from "@storybook/addon-knobs";
+import { withKnobs, select } from "@storybook/addon-knobs";
 import { checkA11y } from "@storybook/addon-a11y";
 import { HeatMap, DemoJSONLoader } from "../src";
 
@@ -130,12 +130,7 @@ const heatmapComponent = data => {
       "rgb(175, 240, 91)"
     ]
   };
-  const colorScale = select(
-    "Heat Color",
-    colorOptions,
-    colorOptions.Plasma,
-    "Heat Map"
-  );
+  const colorScale = select("Heat Color", colorOptions, colorOptions.Plasma);
 
   const heatMapColorScale = [
     "interpolate",
@@ -229,34 +224,10 @@ export default () =>
     .addDecorator(withKnobs)
     .addDecorator(checkA11y)
     .add("Simple usage", () => {
-      const selectionOptions = {
-        "Single Family":
-          "?new_type=Single+Family+Dwelling&new_class=New+Construction&is_adu=false",
-        "Multi Family":
-          "?new_type=Apartments/Condos,Duplex,Rowhouse,Townhouse&new_class=New+Construction&is_adu=false",
-        "Accessory Dwelling Units":
-          "?new_class=New+Construction,Alteration,Addition&is_adu=true"
-      };
-      const selection = select(
-        "Data:",
-        selectionOptions,
-        selectionOptions["Single Family"],
-        "Heat Map"
-      );
-
-      const yearOptions = {
-        range: true,
-        min: 1995,
-        max: 2016,
-        step: 1
-      };
-      const year = number("Year", 1995, yearOptions, "Heat Map");
-
-      const base =
-        "https://service.civicpdx.org/housing-affordability/api/permits/";
-      const options = "&format=json&limit=30000&year=";
-      const url = base + selection + options + year;
-
+      const url =
+        "https://service.civicpdx.org/housing-affordability/api/permits/" +
+        "?new_type=Apartments/Condos,Duplex,Rowhouse,Townhouse&new_class=New+Construction&is_adu=false" +
+        "&format=json&limit=3000&year=2015";
       return (
         <DemoJSONLoader urls={[url]}>
           {data => heatmapComponent(data)}

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -1,7 +1,7 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { withKnobs, number, boolean } from "@storybook/addon-knobs";
+import { withKnobs, number, boolean, text } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
 import { BaseMap, ScatterPlotMap, MapTooltip, DemoJSONLoader } from "../src";
@@ -36,6 +36,13 @@ const lineWidthOptions = {
   min: 0,
   max: 20,
   step: 0.5
+};
+
+const radiusOptions = {
+  range: true,
+  min: 0,
+  max: 100,
+  step: 1
 };
 
 const highlightColor = [255, 165, 0, 155];
@@ -113,9 +120,43 @@ const tooltipMap = () => (
   </DemoJSONLoader>
 );
 
+const sandboxFormStory = () => {
+  const url = text(
+    "Data url:",
+    "https://service.civicpdx.org/neighborhood-development/sandbox/slides/bikeparking/"
+  );
+  return (
+    <DemoJSONLoader urls={[url]}>
+      {data => {
+        const opacity = number("Opacity:", 0.1, opacityOptions);
+        const radius = number("Radius:", 1, radiusOptions);
+        const stroked = boolean("Stroke:", false);
+        const getLineWidth = number("Stroke Width:", 1, lineWidthOptions);
+        return (
+          <BaseMap initialZoom={14} updateViewport={false}>
+            <ScatterPlotMap
+              data={data.slide_data.features}
+              getPosition={getPosition}
+              opacity={opacity}
+              getFillColor={getFillColor}
+              getLineColor={getLineColor}
+              getRadius={() => radius}
+              stroked={stroked}
+              getLineWidth={getLineWidth}
+              autoHighlight
+              highlightColor={highlightColor}
+            />
+          </BaseMap>
+        );
+      }}
+    </DemoJSONLoader>
+  );
+};
+
 export default () =>
   storiesOf("Component Lib|Maps/Scatterplot Map", module)
     .addDecorator(withKnobs)
     .addDecorator(checkA11y)
     .add("Simple usage", demoMap)
-    .add("With tooltip", tooltipMap);
+    .add("With tooltip", tooltipMap)
+    .add("Sandbox Form", sandboxFormStory);

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -1,7 +1,7 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { withKnobs, number, boolean, text } from "@storybook/addon-knobs";
+import { withKnobs, number, boolean } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
 import { BaseMap, ScatterPlotMap, MapTooltip, DemoJSONLoader } from "../src";
@@ -36,13 +36,6 @@ const lineWidthOptions = {
   min: 0,
   max: 20,
   step: 0.5
-};
-
-const radiusOptions = {
-  range: true,
-  min: 0,
-  max: 100,
-  step: 1
 };
 
 const highlightColor = [255, 165, 0, 155];
@@ -120,43 +113,9 @@ const tooltipMap = () => (
   </DemoJSONLoader>
 );
 
-const sandboxFormStory = () => {
-  const url = text(
-    "Data url:",
-    "https://service.civicpdx.org/neighborhood-development/sandbox/slides/bikeparking/"
-  );
-  return (
-    <DemoJSONLoader urls={[url]}>
-      {data => {
-        const opacity = number("Opacity:", 0.1, opacityOptions);
-        const radius = number("Radius:", 1, radiusOptions);
-        const stroked = boolean("Stroke:", false);
-        const getLineWidth = number("Stroke Width:", 1, lineWidthOptions);
-        return (
-          <BaseMap initialZoom={14} updateViewport={false}>
-            <ScatterPlotMap
-              data={data.slide_data.features}
-              getPosition={getPosition}
-              opacity={opacity}
-              getFillColor={getFillColor}
-              getLineColor={getLineColor}
-              getRadius={() => radius}
-              stroked={stroked}
-              getLineWidth={getLineWidth}
-              autoHighlight
-              highlightColor={highlightColor}
-            />
-          </BaseMap>
-        );
-      }}
-    </DemoJSONLoader>
-  );
-};
-
 export default () =>
   storiesOf("Component Lib|Maps/Scatterplot Map", module)
     .addDecorator(withKnobs)
     .addDecorator(checkA11y)
     .add("Simple usage", demoMap)
-    .add("With tooltip", tooltipMap)
-    .add("Sandbox Form", sandboxFormStory);
+    .add("With tooltip", tooltipMap);


### PR DESCRIPTION
This addresses #552.

It updates the DemoJSONLoader component in the storybook to accept a `urls` prop that loads a GeoJSON from a story. So the ScatterPlotMap story now has a Sandbox Form story that implements this new feature.

It also fixes #549 and gets the HeatMap component/story working again.

