### PR TITLE
Update link colors

### DIFF
--- a/packages/component-library/assets/global.styles.css
+++ b/packages/component-library/assets/global.styles.css
@@ -101,7 +101,7 @@ body {
 }
 
 a {
-  color: rgba(238, 73, 80, 1);
+  color: #1e62bd;
   text-decoration: none;
   cursor: pointer;
   opacity: 0.9;
@@ -109,7 +109,7 @@ a {
 }
 
 a:hover {
-  color: rgba(238, 73, 80, 1);
+  color: #1e62bd;
   text-decoration: none;
   cursor: pointer;
   opacity: 1;
@@ -199,6 +199,6 @@ p {
 }
 
 .SecondaryColor {
-  color: rgba(238, 73, 92, 1);
-  fill: rgba(238, 73, 92, 1);
+  color: #1e62bd;
+  fill: #1e62bd;
 }

--- a/packages/component-library/src/Button/Button.js
+++ b/packages/component-library/src/Button/Button.js
@@ -53,7 +53,7 @@ Button.propTypes = {
 Button.defaultProps = {
   display: "block",
   margin: "12px",
-  accentColor: "#DC4556",
+  accentColor: "#1E62BD",
   bkgndColor: "#FFFFFF",
   transition: "all .2s ease-in-out"
 };

--- a/packages/component-library/src/PullQuote/PullQuote.js
+++ b/packages/component-library/src/PullQuote/PullQuote.js
@@ -6,7 +6,7 @@ import { TwitterShareButton, TwitterIcon } from "react-share";
 const quoteClass = css`
   font-family: "Merriweather", serif;
   font-size: 24px;
-  color: #eb4d5f;
+  color: #1e62bd;
   margin-bottom: 12px;
 `;
 
@@ -41,7 +41,7 @@ const PullQuote = ({ quoteText, quoteAttribution, url }) => (
         ) : null}
       </blockquote>
       <div className={iconClass}>
-        <TwitterIcon size={24} round iconBgStyle={{ fill: "#eb4d5f" }} />
+        <TwitterIcon size={24} round iconBgStyle={{ fill: "#1E62BD" }} />
       </div>
     </TwitterShareButton>
   </div>

--- a/packages/component-library/src/utils/civicFormat.js
+++ b/packages/component-library/src/utils/civicFormat.js
@@ -36,6 +36,41 @@ const numeric = d => {
   return formatted;
 };
 
+const scalesShort = [
+  [1000000000000, "t"],
+  [1000000000, "b"],
+  [1000000, "m"],
+  [1000, "k"]
+];
+
+const abbreviateLargeShort = number => {
+  let num;
+  let scale;
+
+  for (let i = 0; i <= scalesShort.length; i += 1) {
+    if (Math.abs(number) >= scalesShort[i][0]) {
+      num = format(".2~r")(number / scalesShort[i][0]);
+      scale = scalesShort[i][1]; // eslint-disable-line prefer-destructuring
+      break;
+    }
+  }
+
+  return `${num}${scale}`;
+};
+
+const numericShort = d => {
+  let formatted;
+
+  // We want to specifically format numbers greater than one million.
+  if (Math.abs(d) >= 1000) {
+    formatted = abbreviateLargeShort(d);
+  } else {
+    formatted = format(",.0f")(d);
+  }
+
+  return formatted;
+};
+
 const year = format(".0f");
 const percentage = format(".0%");
 const dollars = d => `$${numeric(d)}`;
@@ -51,7 +86,8 @@ const civicFormat = {
   dollars,
   titleCase,
   unformatted,
-  monthYear
+  monthYear,
+  numericShort
 };
 
 export default civicFormat;

--- a/packages/component-library/src/utils/civicFormat.js
+++ b/packages/component-library/src/utils/civicFormat.js
@@ -71,6 +71,18 @@ const numericShort = d => {
   return formatted;
 };
 
+const decimalToPercent = num => {
+  let formated;
+
+  if (Number.isInteger(num)) {
+    formated = format(",~%")(num);
+  } else {
+    formated = format(",.1%")(num);
+  }
+
+  return formated;
+};
+
 const year = format(".0f");
 const percentage = format(".0%");
 const dollars = d => `$${numeric(d)}`;
@@ -87,7 +99,8 @@ const civicFormat = {
   titleCase,
   unformatted,
   monthYear,
-  numericShort
+  numericShort,
+  decimalToPercent
 };
 
 export default civicFormat;

--- a/packages/component-library/src/utils/civicFormat.js
+++ b/packages/component-library/src/utils/civicFormat.js
@@ -61,7 +61,7 @@ const abbreviateLargeShort = number => {
 const numericShort = d => {
   let formatted;
 
-  // We want to specifically format numbers greater than one million.
+  // We want to specifically format numbers greater than one thousand.
   if (Math.abs(d) >= 1000) {
     formatted = abbreviateLargeShort(d);
   } else {
@@ -72,15 +72,15 @@ const numericShort = d => {
 };
 
 const decimalToPercent = num => {
-  let formated;
+  let formatted;
 
   if (Number.isInteger(num)) {
-    formated = format(",~%")(num);
+    formatted = format(",~%")(num);
   } else {
-    formated = format(",.1%")(num);
+    formatted = format(",.1%")(num);
   }
 
-  return formated;
+  return formatted;
 };
 
 const year = format(".0f");

--- a/packages/component-library/src/utils/civicFormat.test.js
+++ b/packages/component-library/src/utils/civicFormat.test.js
@@ -23,6 +23,10 @@ describe("civicFormat", () => {
     expect(civicFormat.numericShort(73000000000)).to.eql("73b");
   });
 
+  it("takes decimal, changes to percentage", () => {
+    // test goes here
+  });
+
   it("should format percentages correctly", () => {
     expect(civicFormat.percentage(0.75)).to.eql("75%");
     expect(civicFormat.percentage(0.2379)).to.eql("24%");

--- a/packages/component-library/src/utils/civicFormat.test.js
+++ b/packages/component-library/src/utils/civicFormat.test.js
@@ -24,7 +24,16 @@ describe("civicFormat", () => {
   });
 
   it("takes decimal, changes to percentage", () => {
-    // test goes here
+    expect(civicFormat.decimalToPercent(0)).to.eql("0%");
+    expect(civicFormat.decimalToPercent(0.3456)).to.eql("34.6%");
+    expect(civicFormat.decimalToPercent(1.3456)).to.eql("134.6%");
+    expect(civicFormat.decimalToPercent(-1.3456)).to.eql("-134.6%");
+    expect(civicFormat.decimalToPercent(1)).to.eql("100%");
+    expect(civicFormat.decimalToPercent(10)).to.eql("1,000%");
+    expect(civicFormat.decimalToPercent(100)).to.eql("10,000%");
+    expect(civicFormat.decimalToPercent(1000)).to.eql("100,000%");
+    expect(civicFormat.decimalToPercent(10000)).to.eql("1,000,000%");
+    expect(civicFormat.decimalToPercent(-10000)).to.eql("-1,000,000%");
   });
 
   it("should format percentages correctly", () => {
@@ -37,6 +46,4 @@ describe("civicFormat", () => {
     expect(civicFormat.dollars(230.5)).to.eql("$231");
     expect(civicFormat.dollars(7300000)).to.eql("$7.3 million");
   });
-
-  it("abreviates 2000 to 2k", () => {});
 });

--- a/packages/component-library/src/utils/civicFormat.test.js
+++ b/packages/component-library/src/utils/civicFormat.test.js
@@ -12,6 +12,17 @@ describe("civicFormat", () => {
     expect(civicFormat.numeric(73000000000)).to.eql("73 billion");
   });
 
+  it("should abbriviate numbers correctly", () => {
+    expect(civicFormat.numericShort(0.1)).to.eql("0");
+    expect(civicFormat.numericShort(0.5)).to.eql("1");
+    expect(civicFormat.numericShort(1000)).to.eql("1k");
+    expect(civicFormat.numericShort(1500)).to.eql("1.5k");
+    expect(civicFormat.numericShort(1000000)).to.eql("1m");
+    expect(civicFormat.numericShort(7300000)).to.eql("7.3m");
+    expect(civicFormat.numericShort(-7300000)).to.eql("-7.3m");
+    expect(civicFormat.numericShort(73000000000)).to.eql("73b");
+  });
+
   it("should format percentages correctly", () => {
     expect(civicFormat.percentage(0.75)).to.eql("75%");
     expect(civicFormat.percentage(0.2379)).to.eql("24%");
@@ -22,4 +33,6 @@ describe("civicFormat", () => {
     expect(civicFormat.dollars(230.5)).to.eql("$231");
     expect(civicFormat.dollars(7300000)).to.eql("$7.3 million");
   });
+
+  it("abreviates 2000 to 2k", () => {});
 });


### PR DESCRIPTION
Addressing issues #311 and #509. 

Also searched in `civic/packages/**/src/**/*.js`, replaced red ( #eb4d5f, rgb(235, 77, 95) ) with blue #1E62BD.