### PR TITLE
Fix storybook continuous deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,5 +112,5 @@ deploy-component-library:
 	@echo "Publishing canary versions of packages to npm"
 	yarn run publish-canary
 	@echo "Deploying the component library"
-	yarn run deploy-storybook -- --ci
+	yarn run deploy-storybook --ci
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "clean": "lerna clean && rimraf node_modules",
     "watch": "node scripts/watch",
     "start": "node scripts/start",
-    "deploy-storybook": "BABEL_ENV=esm storybook-to-ghpages",
+    "deploy-storybook": "NODE_OPTIONS=--max_old_space_size=4096 BABEL_ENV=esm storybook-to-ghpages",
     "in": "lerna run --scope",
     "lint": "lerna run lint",
     "lint:fix": "lerna run lint --no-bail -- --fix",


### PR DESCRIPTION
The webpack minification step hits the max memory and aborts otherwise.

This particular error was being masked by the more vague error shown in Travis builds:

```
$ BABEL_ENV=esm storybook-to-ghpages --ci
=> Getting the git remote URL
   executing: git config --get remote.origin.url
=> Building storybook for: @hackoregon/civic
   executing: build-storybook  -o out5427
/home/travis/build/hackoregon/civic/node_modules/@storybook/storybook-deployer/src/utils.js:14
  throw new Error(
  ^
Error: Exec code(134) on executing: build-storybook  -o out5427
undefined
```

The only interesting thing here is the `Exec code(134)` bit, which means the subtask of `build-storybook` was aborted. Not the typical error code 1 for a generic error, and not an abort of the outer task from Travis itself.

Turns out the abort was coming from node itself, specifically V8, due to being out of memory.

There were two options:

1. Set the node flag to allow for more heap space
2. Disable minification in the storybook webpack config

I went for option 1.