### PR TITLE
BarChart story:  Import getKeyNames from shared.js

### DIFF
--- a/packages/component-library/stories/BarChart.story.js
+++ b/packages/component-library/stories/BarChart.story.js
@@ -1,8 +1,6 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import civicFormat from "../src/utils/civicFormat";
-
 import {
   withKnobs,
   text,
@@ -11,6 +9,9 @@ import {
   number,
   optionsKnob as options
 } from "@storybook/addon-knobs";
+import civicFormat from "../src/utils/civicFormat";
+
+import { getKeyNames } from "./shared";
 import notes from "./barchart.notes.md";
 import { BarChart } from "../src";
 
@@ -18,13 +19,6 @@ const GROUP_IDS = {
   LABELS: "Labels",
   DATA: "Data",
   CUSTOM: "Custom"
-};
-const getKeyNames = obj => {
-  const keyNames = {};
-  Object.keys(obj).forEach(key => {
-    keyNames[key] = key;
-  });
-  return keyNames;
 };
 
 export default () =>


### PR DESCRIPTION
Extracted getKeyNames from BarChart.story.js and imported it from shared.js.

This utility function was moved to shared.js, so it was extracted from BarChart.story.js and imported instead.