### PR TITLE
Design System - update scatterplot map story

### DIFF
--- a/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
+++ b/packages/component-library/src/ScatterPlotMap/ScatterPlotMap.js
@@ -82,9 +82,9 @@ ScatterPlotMap.propTypes = {
   onHover: PropTypes.func,
   children: PropTypes.node,
   stroked: PropTypes.bool,
-  getLineColor: PropTypes.func,
-  getLineWidth: PropTypes.func,
-  getFillColor: PropTypes.func
+  getLineColor: PropTypes.oneOfType([PropTypes.func, PropTypes.array]),
+  getLineWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  getFillColor: PropTypes.oneOfType([PropTypes.func, PropTypes.array])
 };
 
 ScatterPlotMap.defaultProps = {

--- a/packages/component-library/stories/ScatterPlotMap.notes.md
+++ b/packages/component-library/stories/ScatterPlotMap.notes.md
@@ -17,9 +17,9 @@ The Custom story shows all the possible properties that can be passed to the Sca
 
 - `data` : expects an array of objects.
 - `getPosition` : expects a function that returns the coordinates of each object in data array.
-- `opacity` : expects a number.
-- `getFillColor` : expects a function or an array in `[r, g, b, [a]]` format. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
-- `getLineColor` : expects a function or an array in `[r, g, b, [a]]` format. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
+- `opacity` : expects a number between 0 and 1.
+- `getFillColor` : expects a function or an array in `[r, g, b, [a]]` format, where `a` is a number between 0 and 255. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
+- `getLineColor` : expects a function or an array in `[r, g, b, [a]]` format, where `a` is a number between 0 and 255. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
 - `getRadius` : expects a function or a number. If a number is provided it is used as the radius for all objects. If a function is provided, it is called on each object to set the radius.
 - `radiusScale` : expects a number.
 - `stroked` : expects a boolean value.

--- a/packages/component-library/stories/ScatterPlotMap.notes.md
+++ b/packages/component-library/stories/ScatterPlotMap.notes.md
@@ -1,5 +1,39 @@
-# HorizontalBarChart Component
+# ScatterPlot Map Component
 
 ## Standard
 
+The Standard story shows the standard usage of the ScatterPlot Map Component for the CIVIC platform. ScatterPlot Map includes the standard styling.
+
+These properties can be set in the standard story:
+
+- `getFillColor`
+- `radiusScale`
+- `opacity`
+- `data`
+
 ## Custom
+
+The Custom story shows all the possible properties that can be passed to the ScatterPlot Map Component for customization.
+
+- `data` : expects an array of objects.
+- `getPosition` : expects a function that returns the coordinates of each object in data array.
+- `opacity` : expects a number.
+- `getFillColor` : expects a function or an array in `[r, g, b, [a]]` format. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
+- `getLineColor` : expects a function or an array in `[r, g, b, [a]]` format. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
+- `getRadius` : expects a function or a number. If a number is provided it is used as the radius for all objects. If a function is provided, it is called on each object to set the radius.
+- `radiusScale` : expects a number.
+- `stroked` : expects a boolean value.
+- `getLineWidth` : expects a function or a number. If a number is provided, it is used as the outline width for each object. If a function is provided, it is called on each object to set the outline width.
+- `autoHighlight` : expects a boolean value.
+- `highlightColor` : expects an array in the `[r, g, b, [a]]` format.
+- `onLayerClick` : expects a function.
+
+## Example: With Tooltip
+
+The Example: With Tooltip story shows an example of using the MapTooltip component with the ScatterPlot Map component.
+
+## Example: Data Driven Styling
+
+The Example: Data Driven Styling story shows an example of styling the fill color based on a data attribute. We perform a ternary operation to check if a property is over a certain value and style based on that operation.
+
+We also style the `getRadius` based on a numerical property of each object to create graduated circles.

--- a/packages/component-library/stories/ScatterPlotMap.notes.md
+++ b/packages/component-library/stories/ScatterPlotMap.notes.md
@@ -1,0 +1,5 @@
+# HorizontalBarChart Component
+
+## Standard
+
+## Custom

--- a/packages/component-library/stories/ScatterPlotMap.notes.md
+++ b/packages/component-library/stories/ScatterPlotMap.notes.md
@@ -10,6 +10,7 @@ These properties can be set in the standard story:
 - `radiusScale`
 - `opacity`
 - `data`
+- `getPosition`
 
 ## Custom
 

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -63,6 +63,26 @@ export default () =>
     .add(
       "Standard",
       () => {
+        const fillColorPicker = color(
+          "Fill Color:",
+          "#19B7AA",
+          GROUP_IDS.MARKER
+        );
+
+        const colorOption1 = colorPicker => {
+          return colorPicker
+            .slice(5, -1)
+            .split(",")
+            .map(n => parseInt(n, 10))
+            .filter((n, i) => i < 3);
+        };
+        const colorOption2 = [25, 183, 170, 255];
+
+        const getFillColor =
+          fillColorPicker.charAt(0) !== "#"
+            ? colorOption1(fillColorPicker)
+            : colorOption2;
+
         const opacity = number(
           "Opacity:",
           0.1,
@@ -89,7 +109,7 @@ export default () =>
                     data={data}
                     getPosition={getPosition}
                     opacity={opacity}
-                    getFillColor={getFillColorStandard}
+                    getFillColor={getFillColor}
                     getLineColor={getLineColorStandard}
                     getRadius={getCircleRadius}
                     radiusScale={radiusScale}

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -73,16 +73,11 @@ export default () =>
     .add(
       "Standard",
       () => {
-        const fillColorPicker = color(
-          "Fill Color:",
-          "#19B7AA",
+        const getFillColor = object(
+          "Fill Color",
+          [25, 183, 170, 255],
           GROUP_IDS.MARKER
         );
-
-        const getFillColor =
-          fillColorPicker.charAt(0) !== "#"
-            ? colorOption1(fillColorPicker)
-            : colorOption2;
 
         const opacity = number(
           "Opacity:",

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -58,6 +58,14 @@ const getLineColorStandard = f =>
 
 const getCircleRadius = f => Math.sqrt(f.properties.year_2017 / Math.PI) * 15;
 
+const colorOption1 = colorPicker => {
+  return colorPicker
+    .slice(5, -1)
+    .split(",")
+    .map(n => parseInt(n, 10))
+    .filter((n, i) => i < 3);
+};
+
 export default () =>
   storiesOf("Component Lib|Maps/Scatterplot Map", module)
     .addDecorator(withKnobs)
@@ -71,14 +79,6 @@ export default () =>
           GROUP_IDS.MARKER
         );
 
-        const colorOption1 = colorPicker => {
-          return colorPicker
-            .slice(5, -1)
-            .split(",")
-            .map(n => parseInt(n, 10))
-            .filter((n, i) => i < 3);
-        };
-
         const getFillColor =
           fillColorPicker.charAt(0) !== "#"
             ? colorOption1(fillColorPicker)
@@ -90,6 +90,7 @@ export default () =>
           opacityOptions,
           GROUP_IDS.MARKER
         );
+
         const radiusScale = number(
           "Radius Scale:",
           1,
@@ -140,14 +141,6 @@ export default () =>
           GROUP_IDS.MARKER
         );
 
-        const colorOption1 = colorPicker => {
-          return colorPicker
-            .slice(5, -1)
-            .split(",")
-            .map(n => parseInt(n, 10))
-            .filter((n, i) => i < 3);
-        };
-
         const getFillColor =
           fillColorPicker.charAt(0) !== "#"
             ? colorOption1(fillColorPicker)
@@ -159,6 +152,7 @@ export default () =>
           opacityOptions,
           GROUP_IDS.MARKER
         );
+
         const radiusScale = number(
           "Radius Scale:",
           1,
@@ -187,7 +181,7 @@ export default () =>
         );
 
         const autoHighlight = boolean(
-          "Auto hightlight:",
+          "Auto Highlight:",
           true,
           GROUP_IDS.MARKER
         );
@@ -244,26 +238,41 @@ export default () =>
         return (
           <DemoJSONLoader urls={mapData}>
             {data => {
-              const opacity = number("Opacity:", 0.1, opacityOptions);
+              const fillColorPicker = color(
+                "Fill Color:",
+                "#19B7AA",
+                GROUP_IDS.MARKER
+              );
+
+              const getFillColor =
+                fillColorPicker.charAt(0) !== "#"
+                  ? colorOption1(fillColorPicker)
+                  : colorOption2;
+
+              const opacity = number(
+                "Opacity:",
+                0.1,
+                opacityOptions,
+                GROUP_IDS.MARKER
+              );
               const radiusScale = number(
                 "Radius Scale:",
                 1,
-                radiusScaleOptions
+                radiusScaleOptions,
+                GROUP_IDS.MARKER
               );
-              const stroked = boolean("Stroke Only:", false);
-              const getLineWidth = number("Line Width:", 1, lineWidthOptions);
               return (
                 <BaseMap>
                   <ScatterPlotMap
                     data={data.slide_data.features}
                     getPosition={getPosition}
                     opacity={opacity}
-                    getFillColor={getFillColorStandard}
+                    getFillColor={getFillColor}
                     getLineColor={getLineColorStandard}
                     getRadius={getCircleRadius}
                     radiusScale={radiusScale}
-                    stroked={stroked}
-                    getLineWidth={getLineWidth}
+                    stroked={false}
+                    getLineWidth={1}
                     autoHighlight
                     highlightColor={highlightColor}
                     onLayerClick={info =>
@@ -277,6 +286,57 @@ export default () =>
                       secondaryField="year_2017"
                     />
                   </ScatterPlotMap>
+                </BaseMap>
+              );
+            }}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    )
+    .add(
+      "Examples: Data Driven Styling",
+      () => {
+        const opacity = number(
+          "Opacity:",
+          0.1,
+          opacityOptions,
+          GROUP_IDS.MARKER
+        );
+
+        const radiusScale = number(
+          "Radius Scale:",
+          1,
+          radiusScaleOptions,
+          GROUP_IDS.MARKER
+        );
+
+        return (
+          <DemoJSONLoader urls={mapData}>
+            {allData => {
+              const data = object(
+                "Data",
+                allData.slide_data.features,
+                GROUP_IDS.DATA
+              );
+              return (
+                <BaseMap>
+                  <ScatterPlotMap
+                    data={data}
+                    getPosition={getPosition}
+                    opacity={opacity}
+                    getFillColor={getFillColorStandard}
+                    getLineColor={getLineColorStandard}
+                    getRadius={getCircleRadius}
+                    radiusScale={radiusScale}
+                    stroked={false}
+                    getLineWidth={1}
+                    autoHighlight
+                    highlightColor={highlightColor}
+                    onLayerClick={info =>
+                      action("Layer clicked:", { depth: 2 })(info, info.object)
+                    }
+                  />
                 </BaseMap>
               );
             }}

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -1,11 +1,23 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { withKnobs, number, boolean, object } from "@storybook/addon-knobs";
+import {
+  withKnobs,
+  number,
+  boolean,
+  object,
+  color
+} from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
 import { BaseMap, ScatterPlotMap, MapTooltip, DemoJSONLoader } from "../src";
 import notes from "./ScatterPlotMap.notes.md";
+
+const mapData = [
+  "https://service.civicpdx.org/neighborhood-development/sandbox/slides/bikecounts/"
+];
+
+const highlightColor = [255, 165, 0, 155];
 
 const GROUP_IDS = {
   MARKER: "Marker",
@@ -18,23 +30,6 @@ const opacityOptions = {
   max: 1,
   step: 0.05
 };
-
-// const getPositionLoop = f => {
-//   return f.map(feature => {
-//     return feature.geometry ? feature.geometry.coordinates : [-124.664355, 45.615779]
-//   })
-// }
-
-const getPosition = f =>
-  f.geometry ? f.geometry.coordinates : [-124.664355, 45.615779];
-
-const getFillColor = f =>
-  f.properties.year_2017 > 1000 ? [255, 0, 0, 255] : [0, 0, 255, 255];
-
-const getLineColor = f =>
-  f.properties.year_2017 > 1000 ? [0, 0, 255, 255] : [255, 0, 0, 255];
-
-const getCircleRadius = f => Math.sqrt(f.properties.year_2017 / Math.PI) * 15;
 
 const radiusScaleOptions = {
   range: true,
@@ -50,11 +45,16 @@ const lineWidthOptions = {
   step: 0.5
 };
 
-const highlightColor = [255, 165, 0, 155];
+const getPosition = f =>
+  f.geometry ? f.geometry.coordinates : [-124.664355, 45.615779];
 
-const mapData = [
-  "https://service.civicpdx.org/neighborhood-development/sandbox/slides/bikecounts/"
-];
+const getFillColorStandard = f =>
+  f.properties.year_2017 > 1000 ? [255, 0, 0, 255] : [0, 0, 255, 255];
+
+const getLineColorStandard = f =>
+  f.properties.year_2017 > 1000 ? [0, 0, 255, 255] : [255, 0, 0, 255];
+
+const getCircleRadius = f => Math.sqrt(f.properties.year_2017 / Math.PI) * 15;
 
 export default () =>
   storiesOf("Component Lib|Maps/Scatterplot Map", module)
@@ -75,14 +75,6 @@ export default () =>
           radiusScaleOptions,
           GROUP_IDS.MARKER
         );
-        const stroked = boolean("Stroke Only:", false, GROUP_IDS.MARKER);
-        const getLineWidth = number(
-          "Line Width:",
-          1,
-          lineWidthOptions,
-          GROUP_IDS.MARKER
-        );
-
         return (
           <DemoJSONLoader urls={mapData}>
             {allData => {
@@ -97,12 +89,12 @@ export default () =>
                     data={data}
                     getPosition={getPosition}
                     opacity={opacity}
-                    getFillColor={getFillColor}
-                    getLineColor={getLineColor}
+                    getFillColor={getFillColorStandard}
+                    getLineColor={getLineColorStandard}
                     getRadius={getCircleRadius}
                     radiusScale={radiusScale}
-                    stroked={stroked}
-                    getLineWidth={getLineWidth}
+                    stroked={false}
+                    getLineWidth={1}
                     autoHighlight
                     highlightColor={highlightColor}
                     onLayerClick={info =>
@@ -120,6 +112,26 @@ export default () =>
     .add(
       "Custom",
       () => {
+        const fillColorPicker = color(
+          "Fill Color:",
+          "#19B7AA",
+          GROUP_IDS.MARKER
+        );
+
+        const colorOption1 = colorPicker => {
+          return colorPicker
+            .slice(5, -1)
+            .split(",")
+            .map(n => parseInt(n, 10))
+            .filter((n, i) => i < 3);
+        };
+        const colorOption2 = [25, 183, 170, 255];
+
+        const getFillColor =
+          fillColorPicker.charAt(0) !== "#"
+            ? colorOption1(fillColorPicker)
+            : colorOption2;
+
         const opacity = number(
           "Opacity:",
           0.1,
@@ -132,9 +144,22 @@ export default () =>
           radiusScaleOptions,
           GROUP_IDS.MARKER
         );
-        const stroked = boolean("Stroke Only:", false, GROUP_IDS.MARKER);
+
+        const stroked = boolean("Stroked:", false, GROUP_IDS.MARKER);
+
+        const lineColorPicker = color(
+          "Stroke Line Color:",
+          "#19B7AA",
+          GROUP_IDS.MARKER
+        );
+
+        const getLineColor =
+          lineColorPicker.charAt(0) !== "#"
+            ? colorOption1(lineColorPicker)
+            : colorOption2;
+
         const getLineWidth = number(
-          "Line Width:",
+          "Stroke Line Width:",
           1,
           lineWidthOptions,
           GROUP_IDS.MARKER
@@ -148,6 +173,7 @@ export default () =>
                 allData.slide_data.features,
                 GROUP_IDS.DATA
               );
+
               return (
                 <BaseMap>
                   <ScatterPlotMap
@@ -194,8 +220,8 @@ export default () =>
                     data={data.slide_data.features}
                     getPosition={getPosition}
                     opacity={opacity}
-                    getFillColor={getFillColor}
-                    getLineColor={getLineColor}
+                    getFillColor={getFillColorStandard}
+                    getLineColor={getLineColorStandard}
                     getRadius={getCircleRadius}
                     radiusScale={radiusScale}
                     stroked={stroked}

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -113,16 +113,7 @@ export default () =>
                     getPosition={getPosition}
                     opacity={opacity}
                     getFillColor={getFillColor}
-                    getLineColor={getLineColorDataDriven}
-                    getRadius={getCircleRadius}
                     radiusScale={radiusScale}
-                    stroked={false}
-                    getLineWidth={1}
-                    autoHighlight
-                    highlightColor={highlightColor}
-                    onLayerClick={info =>
-                      action("Layer clicked:", { depth: 2 })(info, info.object)
-                    }
                   />
                 </BaseMap>
               );

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -186,6 +186,12 @@ export default () =>
           GROUP_IDS.MARKER
         );
 
+        const autoHighlight = boolean(
+          "Auto hightlight:",
+          true,
+          GROUP_IDS.MARKER
+        );
+
         const highlightColorPicker = color(
           "Highlight Color:",
           "#ffa500",
@@ -218,7 +224,7 @@ export default () =>
                     radiusScale={radiusScale}
                     stroked={stroked}
                     getLineWidth={getLineWidth}
-                    autoHighlight
+                    autoHighlight={autoHighlight}
                     highlightColor={getHighlightColor}
                     onLayerClick={info =>
                       action("Layer clicked:", { depth: 2 })(info, info.object)

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -19,6 +19,8 @@ const mapData = [
 
 const highlightColor = [255, 165, 0, 155];
 
+const colorOption2 = [25, 183, 170, 255];
+
 const GROUP_IDS = {
   MARKER: "Marker",
   DATA: "Data"
@@ -76,7 +78,6 @@ export default () =>
             .map(n => parseInt(n, 10))
             .filter((n, i) => i < 3);
         };
-        const colorOption2 = [25, 183, 170, 255];
 
         const getFillColor =
           fillColorPicker.charAt(0) !== "#"
@@ -95,6 +96,7 @@ export default () =>
           radiusScaleOptions,
           GROUP_IDS.MARKER
         );
+
         return (
           <DemoJSONLoader urls={mapData}>
             {allData => {
@@ -145,7 +147,6 @@ export default () =>
             .map(n => parseInt(n, 10))
             .filter((n, i) => i < 3);
         };
-        const colorOption2 = [25, 183, 170, 255];
 
         const getFillColor =
           fillColorPicker.charAt(0) !== "#"
@@ -185,6 +186,17 @@ export default () =>
           GROUP_IDS.MARKER
         );
 
+        const highlightColorPicker = color(
+          "Highlight Color:",
+          "#ffa500",
+          GROUP_IDS.MARKER
+        );
+
+        const getHighlightColor =
+          highlightColorPicker.charAt(0) !== "#"
+            ? colorOption1(highlightColorPicker)
+            : highlightColor;
+
         return (
           <DemoJSONLoader urls={mapData}>
             {allData => {
@@ -207,7 +219,7 @@ export default () =>
                     stroked={stroked}
                     getLineWidth={getLineWidth}
                     autoHighlight
-                    highlightColor={highlightColor}
+                    highlightColor={getHighlightColor}
                     onLayerClick={info =>
                       action("Layer clicked:", { depth: 2 })(info, info.object)
                     }

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -1,10 +1,16 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { withKnobs, number, boolean } from "@storybook/addon-knobs";
+import { withKnobs, number, boolean, object } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
 import { BaseMap, ScatterPlotMap, MapTooltip, DemoJSONLoader } from "../src";
+import notes from "./ScatterPlotMap.notes.md";
+
+const GROUP_IDS = {
+  MARKER: "Marker",
+  DATA: "Data"
+};
 
 const opacityOptions = {
   range: true,
@@ -44,78 +50,115 @@ const mapData = [
   "https://service.civicpdx.org/neighborhood-development/sandbox/slides/bikecounts/"
 ];
 
-const demoMap = () => (
-  <DemoJSONLoader urls={mapData}>
-    {data => {
-      const opacity = number("Opacity:", 0.1, opacityOptions);
-      const radiusScale = number("Radius Scale:", 1, radiusScaleOptions);
-      const stroked = boolean("Stroke Only:", false);
-      const getLineWidth = number("Line Width:", 1, lineWidthOptions);
-      return (
-        <BaseMap>
-          <ScatterPlotMap
-            data={data.slide_data.features}
-            getPosition={getPosition}
-            opacity={opacity}
-            getFillColor={getFillColor}
-            getLineColor={getLineColor}
-            getRadius={getCircleRadius}
-            radiusScale={radiusScale}
-            stroked={stroked}
-            getLineWidth={getLineWidth}
-            autoHighlight
-            highlightColor={highlightColor}
-            onLayerClick={info =>
-              action("Layer clicked:", { depth: 2 })(info, info.object)
-            }
-          />
-        </BaseMap>
-      );
-    }}
-  </DemoJSONLoader>
-);
-
-const tooltipMap = () => (
-  <DemoJSONLoader urls={mapData}>
-    {data => {
-      const opacity = number("Opacity:", 0.1, opacityOptions);
-      const radiusScale = number("Radius Scale:", 1, radiusScaleOptions);
-      const stroked = boolean("Stroke Only:", false);
-      const getLineWidth = number("Line Width:", 1, lineWidthOptions);
-      return (
-        <BaseMap>
-          <ScatterPlotMap
-            data={data.slide_data.features}
-            getPosition={getPosition}
-            opacity={opacity}
-            getFillColor={getFillColor}
-            getLineColor={getLineColor}
-            getRadius={getCircleRadius}
-            radiusScale={radiusScale}
-            stroked={stroked}
-            getLineWidth={getLineWidth}
-            autoHighlight
-            highlightColor={highlightColor}
-            onLayerClick={info =>
-              action("Layer clicked:", { depth: 2 })(info, info.object)
-            }
-          >
-            <MapTooltip
-              primaryName="Count Time"
-              primaryField="count_time"
-              secondaryName="Bike Count"
-              secondaryField="year_2017"
-            />
-          </ScatterPlotMap>
-        </BaseMap>
-      );
-    }}
-  </DemoJSONLoader>
-);
-
 export default () =>
   storiesOf("Component Lib|Maps/Scatterplot Map", module)
     .addDecorator(withKnobs)
     .addDecorator(checkA11y)
-    .add("Simple usage", demoMap)
-    .add("With tooltip", tooltipMap);
+    .add(
+      "Standard",
+      () => {
+        const opacity = number(
+          "Opacity:",
+          0.1,
+          opacityOptions,
+          GROUP_IDS.MARKER
+        );
+        const radiusScale = number(
+          "Radius Scale:",
+          1,
+          radiusScaleOptions,
+          GROUP_IDS.MARKER
+        );
+        const stroked = boolean("Stroke Only:", false, GROUP_IDS.MARKER);
+        const getLineWidth = number(
+          "Line Width:",
+          1,
+          lineWidthOptions,
+          GROUP_IDS.MARKER
+        );
+        return (
+          <DemoJSONLoader urls={mapData}>
+            {allData => {
+              const getPositionKnob = number(
+                "Position",
+                getPosition,
+                GROUP_IDS.DATA
+              );
+              const data = object(
+                "Data",
+                allData.slide_data.features,
+                GROUP_IDS.DATA
+              );
+              return (
+                <BaseMap>
+                  <ScatterPlotMap
+                    data={data}
+                    getPosition={getPositionKnob}
+                    opacity={opacity}
+                    getFillColor={getFillColor}
+                    getLineColor={getLineColor}
+                    getRadius={getCircleRadius}
+                    radiusScale={radiusScale}
+                    stroked={stroked}
+                    getLineWidth={getLineWidth}
+                    autoHighlight
+                    highlightColor={highlightColor}
+                    onLayerClick={info =>
+                      action("Layer clicked:", { depth: 2 })(info, info.object)
+                    }
+                  />
+                </BaseMap>
+              );
+            }}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    )
+    .add(
+      "Examples: With Tooltip",
+      () => {
+        return (
+          <DemoJSONLoader urls={mapData}>
+            {data => {
+              const opacity = number("Opacity:", 0.1, opacityOptions);
+              const radiusScale = number(
+                "Radius Scale:",
+                1,
+                radiusScaleOptions
+              );
+              const stroked = boolean("Stroke Only:", false);
+              const getLineWidth = number("Line Width:", 1, lineWidthOptions);
+              return (
+                <BaseMap>
+                  <ScatterPlotMap
+                    data={data.slide_data.features}
+                    getPosition={getPosition}
+                    opacity={opacity}
+                    getFillColor={getFillColor}
+                    getLineColor={getLineColor}
+                    getRadius={getCircleRadius}
+                    radiusScale={radiusScale}
+                    stroked={stroked}
+                    getLineWidth={getLineWidth}
+                    autoHighlight
+                    highlightColor={highlightColor}
+                    onLayerClick={info =>
+                      action("Layer clicked:", { depth: 2 })(info, info.object)
+                    }
+                  >
+                    <MapTooltip
+                      primaryName="Count Time"
+                      primaryField="count_time"
+                      secondaryName="Bike Count"
+                      secondaryField="year_2017"
+                    />
+                  </ScatterPlotMap>
+                </BaseMap>
+              );
+            }}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    );

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -19,6 +19,12 @@ const opacityOptions = {
   step: 0.05
 };
 
+// const getPositionLoop = f => {
+//   return f.map(feature => {
+//     return feature.geometry ? feature.geometry.coordinates : [-124.664355, 45.615779]
+//   })
+// }
+
 const getPosition = f =>
   f.geometry ? f.geometry.coordinates : [-124.664355, 45.615779];
 
@@ -76,14 +82,10 @@ export default () =>
           lineWidthOptions,
           GROUP_IDS.MARKER
         );
+
         return (
           <DemoJSONLoader urls={mapData}>
             {allData => {
-              const getPositionKnob = number(
-                "Position",
-                getPosition,
-                GROUP_IDS.DATA
-              );
               const data = object(
                 "Data",
                 allData.slide_data.features,
@@ -93,7 +95,64 @@ export default () =>
                 <BaseMap>
                   <ScatterPlotMap
                     data={data}
-                    getPosition={getPositionKnob}
+                    getPosition={getPosition}
+                    opacity={opacity}
+                    getFillColor={getFillColor}
+                    getLineColor={getLineColor}
+                    getRadius={getCircleRadius}
+                    radiusScale={radiusScale}
+                    stroked={stroked}
+                    getLineWidth={getLineWidth}
+                    autoHighlight
+                    highlightColor={highlightColor}
+                    onLayerClick={info =>
+                      action("Layer clicked:", { depth: 2 })(info, info.object)
+                    }
+                  />
+                </BaseMap>
+              );
+            }}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    )
+    .add(
+      "Custom",
+      () => {
+        const opacity = number(
+          "Opacity:",
+          0.1,
+          opacityOptions,
+          GROUP_IDS.MARKER
+        );
+        const radiusScale = number(
+          "Radius Scale:",
+          1,
+          radiusScaleOptions,
+          GROUP_IDS.MARKER
+        );
+        const stroked = boolean("Stroke Only:", false, GROUP_IDS.MARKER);
+        const getLineWidth = number(
+          "Line Width:",
+          1,
+          lineWidthOptions,
+          GROUP_IDS.MARKER
+        );
+
+        return (
+          <DemoJSONLoader urls={mapData}>
+            {allData => {
+              const data = object(
+                "Data",
+                allData.slide_data.features,
+                GROUP_IDS.DATA
+              );
+              return (
+                <BaseMap>
+                  <ScatterPlotMap
+                    data={data}
+                    getPosition={getPosition}
                     opacity={opacity}
                     getFillColor={getFillColor}
                     getLineColor={getLineColor}

--- a/packages/component-library/stories/ScatterPlotMap.story.js
+++ b/packages/component-library/stories/ScatterPlotMap.story.js
@@ -50,10 +50,10 @@ const lineWidthOptions = {
 const getPosition = f =>
   f.geometry ? f.geometry.coordinates : [-124.664355, 45.615779];
 
-const getFillColorStandard = f =>
+const getFillColorDataDriven = f =>
   f.properties.year_2017 > 1000 ? [255, 0, 0, 255] : [0, 0, 255, 255];
 
-const getLineColorStandard = f =>
+const getLineColorDataDriven = f =>
   f.properties.year_2017 > 1000 ? [0, 0, 255, 255] : [255, 0, 0, 255];
 
 const getCircleRadius = f => Math.sqrt(f.properties.year_2017 / Math.PI) * 15;
@@ -113,7 +113,7 @@ export default () =>
                     getPosition={getPosition}
                     opacity={opacity}
                     getFillColor={getFillColor}
-                    getLineColor={getLineColorStandard}
+                    getLineColor={getLineColorDataDriven}
                     getRadius={getCircleRadius}
                     radiusScale={radiusScale}
                     stroked={false}
@@ -268,7 +268,7 @@ export default () =>
                     getPosition={getPosition}
                     opacity={opacity}
                     getFillColor={getFillColor}
-                    getLineColor={getLineColorStandard}
+                    getLineColor={getLineColorDataDriven}
                     getRadius={getCircleRadius}
                     radiusScale={radiusScale}
                     stroked={false}
@@ -325,8 +325,8 @@ export default () =>
                     data={data}
                     getPosition={getPosition}
                     opacity={opacity}
-                    getFillColor={getFillColorStandard}
-                    getLineColor={getLineColorStandard}
+                    getFillColor={getFillColorDataDriven}
+                    getLineColor={getLineColorDataDriven}
                     getRadius={getCircleRadius}
                     radiusScale={radiusScale}
                     stroked={false}


### PR DESCRIPTION
Addresses #567 

Summary:

I updated the standard and with tooltip examples, and created the custom and data driven styling examples. I also added a notes file that describes the different props and explains each example in the story. 

I currently display the data array in the data tab in the knobs. Requested in the issue is to add `getPostion` knob. I did not add it because the user can see/edit the coordinates in the data array and the prop is explained in the notes file. 

Additionally, with the current configuration I receive prop-type warnings for `getLineWidth`, `getLineColor` and `getFillColor` because they are expecting functions, where I am returning arrays or numbers. According to the [deck.gl](https://github.com/uber/deck.gl/blob/master/docs/layers/scatterplot-layer.md) documentation you can supply either data types. We could either change the prop types to be `onOfType` or try to rewrite my code to supply functions. I tried to supply functions to these props but was having difficulty connecting them to the knobs. 

Looking forward to feedback 🚀 