### PR TITLE
Design System - Map Overlay

### DIFF
--- a/packages/component-library/src/MapOverlay/MapOverlay.js
+++ b/packages/component-library/src/MapOverlay/MapOverlay.js
@@ -1,32 +1,39 @@
 import React from "react";
-import PropTypes from "prop-types";
+import {
+  shape,
+  bool,
+  number,
+  func,
+  node,
+  oneOfType,
+  arrayOf,
+  string
+} from "prop-types";
 import DeckGL, { GeoJsonLayer } from "deck.gl";
 
 const MapOverlay = props => {
   const {
     id,
+    viewport,
     children,
     data,
-    viewport,
-    autoHighlight,
-    extruded,
-    filled,
-    getRadius,
-    onHover,
-    onLayerClick,
-    opacity,
-    strokeWidth,
-    tooltipInfo,
-    x,
-    y,
-    visible,
-    wireframe,
     pickable,
-    getElevation,
+    opacity,
+    filled,
     getFillColor,
+    stroked,
     getLineColor,
     getLineWidth,
-    stroked
+    extruded,
+    getElevation,
+    getRadius,
+    autoHighlight,
+    highlightColor,
+    onLayerClick,
+    onHover,
+    tooltipInfo,
+    x,
+    y
   } = props;
 
   const tooltip = React.Children.map(children, child => {
@@ -39,89 +46,74 @@ const MapOverlay = props => {
 
   const tooltipRender = tooltipInfo && x && y ? tooltip : null;
 
-  const LIGHT_SETTINGS = {
-    lightsPosition: [-125, 50.5, 5000, -122.8, 48.5, 8000],
-    ambientRatio: 0.2,
-    diffuseRatio: 0.5,
-    specularRatio: 0.3,
-    lightsStrength: [1.0, 0.0, 2.0, 0.0],
-    numberOfLights: 2
-  };
-
-  const layer = new GeoJsonLayer({
-    id,
-    data,
-    visible,
-    autoHighlight,
-    extruded,
-    opacity,
-    filled,
-    onHover,
-    wireframe,
-    getRadius,
-    getLineWidth,
-    stroked,
-    pickable,
-    lineWidthScale: 20,
-    lineWidthMinPixels: strokeWidth,
-    fp64: true,
-    lightSettings: LIGHT_SETTINGS,
-    onClick: onLayerClick,
-    getElevation,
-    getFillColor,
-    getLineColor
-  });
-
   return (
     <div>
-      <DeckGL
-        {...viewport}
-        layers={[layer]}
-        className="MapOverlay"
-        getCursor={() => "crosshair"}
-      />
+      <DeckGL {...viewport} className="DeckGL" getCursor={() => "crosshair"}>
+        <GeoJsonLayer
+          id={id}
+          className="GeoJSONMap"
+          pickable={pickable}
+          data={data}
+          opacity={opacity}
+          filled={filled}
+          getFillColor={getFillColor}
+          stroked={stroked}
+          getLineColor={getLineColor}
+          getLineWidth={getLineWidth}
+          lineWidthMinPixels={1}
+          extruded={extruded}
+          getElevation={getElevation}
+          getRadius={getRadius}
+          autoHighlight={autoHighlight}
+          highlightColor={highlightColor}
+          onClick={onLayerClick}
+          onHover={onHover}
+          updateTriggers={{
+            getFillColor,
+            getLineColor,
+            getLineWidth
+          }}
+        />
+      </DeckGL>
       {tooltipRender}
     </div>
   );
 };
 
 MapOverlay.propTypes = {
-  id: PropTypes.string,
-  children: PropTypes.node,
-  data: PropTypes.arrayOf(PropTypes.shape({})),
-  viewport: PropTypes.shape({}),
-  autoHighlight: PropTypes.bool,
-  extruded: PropTypes.bool,
-  elevation: PropTypes.number,
-  filled: PropTypes.bool,
-  getColor: PropTypes.func,
-  getRadius: PropTypes.func,
-  onHover: PropTypes.func,
-  onLayerClick: PropTypes.func,
-  opacity: PropTypes.number,
-  strokeWidth: PropTypes.number,
-  tooltipInfo: PropTypes.shape({}),
-  x: PropTypes.number,
-  y: PropTypes.number,
-  visible: PropTypes.bool,
-  wireframe: PropTypes.bool,
-  pickable: PropTypes.bool,
-  getElevation: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-  getFillColor: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.number),
-    PropTypes.func
-  ]),
-  getLineColor: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-  getLineWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-  stroked: PropTypes.bool
+  viewport: shape({}),
+  children: node,
+  id: string,
+  data: oneOfType([shape({}), arrayOf(shape({}))]).isRequired,
+  pickable: bool,
+  opacity: number,
+  filled: bool,
+  getFillColor: oneOfType([arrayOf(number), func]),
+  stroked: bool,
+  getLineColor: oneOfType([arrayOf(number), func]),
+  getLineWidth: oneOfType([number, func]),
+  extruded: bool,
+  getElevation: oneOfType([number, func]),
+  getRadius: oneOfType([number, func]),
+  autoHighlight: bool,
+  highlightColor: arrayOf(number),
+  onLayerClick: func,
+  onHover: func,
+  tooltipInfo: shape({}),
+  x: number,
+  y: number
 };
 
 MapOverlay.defaultProps = {
-  id: "geojson",
-  stroked: false,
-  strokeWidth: 1,
-  visible: true,
-  pickable: true
+  pickable: true,
+  opacity: 0.8,
+  filled: true,
+  getFillColor: [0, 0, 0],
+  stroked: true,
+  getLineColor: [112, 122, 122, 100],
+  getLineWidth: 10,
+  extruded: false,
+  autoHighlight: false
 };
 
 export default MapOverlay;

--- a/packages/component-library/src/MapOverlay/MapOverlay.test.js
+++ b/packages/component-library/src/MapOverlay/MapOverlay.test.js
@@ -32,18 +32,10 @@ describe("MapOverlay", () => {
   });
 
   it("should render with the same class name", () => {
-    expect(wrapper.find(".MapOverlay")).length(1);
+    expect(wrapper.find("DeckGL")).length(1);
   });
 
   it("should render a DeckGL component", () => {
     expect(wrapper.find(DeckGL)).length(1);
-  });
-
-  it("should render without stroked", () => {
-    expect(wrapper.props().layers);
-  });
-
-  it("should render without stroked", () => {
-    expect(wrapper.props().filled);
   });
 });

--- a/packages/component-library/stories/MapOverlay.story.js
+++ b/packages/component-library/stories/MapOverlay.story.js
@@ -1,85 +1,287 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { withKnobs } from "@storybook/addon-knobs";
+import {
+  withKnobs,
+  select,
+  object,
+  boolean,
+  number
+} from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
+import { scaleQuantize, extent } from "d3";
 import { BaseMap, MapOverlay, MapTooltip, DemoJSONLoader } from "../src";
+import notes from "./mapOverlay.notes.md";
 
-const demoMap = () => {
-  return (
-    <DemoJSONLoader
-      urls={[
-        "https://service.civicpdx.org/neighborhood-development/sandbox/foundations/under18/"
-      ]}
-    >
-      {data => {
-        return (
-          <BaseMap>
-            <MapOverlay
-              data={data.slide_data.features}
-              opacity={0.1}
-              filled
-              getPosition={f => f.geometry.coordinates}
-              onLayerClick={info => action("Layer clicked:")(info)}
-              getElevation={f =>
-                f.properties.pc_household_with_children_under_18 * 100
-              }
-              getFillColor={() => [0, 100, 255, 255]}
-              getLineColor={() => [0, 0, 0, 0]}
-            />
-          </BaseMap>
-        );
-      }}
-    </DemoJSONLoader>
-  );
+const GROUP_IDS = {
+  MARKER: "Polygon",
+  DATA: "Data",
+  CUSTOM: "Custom"
 };
 
-const tooltipMap = () => {
-  return (
-    <DemoJSONLoader
-      urls={[
-        "https://service.civicpdx.org/neighborhood-development/sandbox/foundations/under18/"
-      ]}
-    >
-      {data => {
-        return (
-          <BaseMap>
-            <MapOverlay
-              data={data.slide_data.features}
-              getPosition={f => f.geometry.coordinates}
-              opacity={1.0}
-              filled
-              onLayerHover={info =>
-                action("Layer")(
-                  info.layer.props.data[info.index].properties.NAME
-                )
-              }
-              getElevation={f =>
-                f.properties.pc_household_with_children_under_18 * 100
-              }
-              getFillColor={() => [0, 100, 255, 255]}
-              getLineColor={() => [0, 0, 0, 0]}
-              x={120}
-              y={120}
-            >
-              <MapTooltip
-                primaryName="Percent of Households with Children under 18"
-                primaryField="pc_household_with_children_under_18"
-                secondaryName="Year"
-                secondaryField="year"
-              />
-            </MapOverlay>
-          </BaseMap>
-        );
-      }}
-    </DemoJSONLoader>
-  );
+const opacityOptions = {
+  range: true,
+  min: 0,
+  max: 1,
+  step: 0.05
 };
+
+const strokeWidthOptions = {
+  range: true,
+  min: 0,
+  max: 200,
+  step: 1
+};
+
+const CIVIC_API_URL =
+  "http://service.civicpdx.org/disaster-resilience/api/DisasterNeighborhoodView/?format=json&limit=100";
 
 export default () =>
   storiesOf("Component Lib|Maps/Map Overlay", module)
     .addDecorator(checkA11y)
     .addDecorator(withKnobs)
-    .add("Simple usage", demoMap)
-    .add("With tooltip", tooltipMap);
+    .add(
+      "Standard",
+      () => {
+        const getFillColor = object(
+          "Fill Color:",
+          [25, 183, 170],
+          GROUP_IDS.MARKER
+        );
+        const getLineColor = object(
+          "Stroke Color",
+          [112, 122, 122],
+          GROUP_IDS.MARKER
+        );
+        const getLineWidth = number(
+          "Stroke Width",
+          1,
+          strokeWidthOptions,
+          GROUP_IDS.MARKER
+        );
+        const opacity = number(
+          "Opacity:",
+          0.9,
+          opacityOptions,
+          GROUP_IDS.MARKER
+        );
+        return (
+          <DemoJSONLoader urls={[CIVIC_API_URL]}>
+            {data => {
+              // eslint-disable-next-line
+              const singleFeatureObj = object(
+                "Data: First Feature Object from GeoJSON",
+                data.results.features.slice(0, 1),
+                GROUP_IDS.DATA
+              );
+              return (
+                <BaseMap>
+                  <MapOverlay
+                    data={data.results.features}
+                    getFillColor={getFillColor}
+                    getLineColor={getLineColor}
+                    getLineWidth={getLineWidth}
+                    opacity={opacity}
+                  />
+                </BaseMap>
+              );
+            }}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    )
+    .add(
+      "Custom",
+      () => {
+        const getFillColor = object(
+          "Fill Color:",
+          [25, 183, 170],
+          GROUP_IDS.MARKER
+        );
+        const getLineColor = object(
+          "Stroke Color",
+          [112, 122, 122],
+          GROUP_IDS.MARKER
+        );
+        const getLineWidth = number(
+          "Stroke Width",
+          1,
+          strokeWidthOptions,
+          GROUP_IDS.MARKER
+        );
+        const opacity = number(
+          "Opacity:",
+          0.9,
+          opacityOptions,
+          GROUP_IDS.MARKER
+        );
+
+        const filled = boolean("Filled", true, GROUP_IDS.CUSTOM);
+        const stroked = boolean("Stroked", true, GROUP_IDS.CUSTOM);
+        const autoHighlight = boolean("autoHighlight", true, GROUP_IDS.CUSTOM);
+        const highlightColor = object(
+          "highlightColor",
+          [255, 255, 0, 155],
+          GROUP_IDS.CUSTOM
+        );
+        const onLayerClick = info => action("Layer Clicked:")(info);
+        return (
+          <DemoJSONLoader urls={[CIVIC_API_URL]}>
+            {data => {
+              // eslint-disable-next-line
+              const singleFeatureObj = object(
+                "Data: First Feature Object from GeoJSON",
+                data.results.features.slice(0, 1),
+                GROUP_IDS.DATA
+              );
+              return (
+                <BaseMap>
+                  <MapOverlay
+                    data={data.results.features}
+                    filled={filled}
+                    getFillColor={getFillColor}
+                    stroked={stroked}
+                    getLineColor={getLineColor}
+                    getLineWidth={getLineWidth}
+                    opacity={opacity}
+                    autoHighlight={autoHighlight}
+                    highlightColor={highlightColor}
+                    onLayerClick={onLayerClick}
+                  />
+                </BaseMap>
+              );
+            }}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    )
+    .add(
+      "Example: Choropleth Map",
+      () => {
+        const colorSchemeOptions = {
+          Thermal: [
+            [255, 255, 204],
+            [255, 237, 160],
+            [254, 217, 118],
+            [254, 178, 76],
+            [253, 141, 60],
+            [252, 78, 42],
+            [227, 26, 28],
+            [189, 0, 38],
+            [128, 0, 38]
+          ],
+          Planet: [
+            [247, 244, 249],
+            [231, 225, 239],
+            [212, 185, 218],
+            [201, 148, 199],
+            [223, 101, 176],
+            [231, 41, 138],
+            [206, 18, 86],
+            [152, 0, 67],
+            [103, 0, 31]
+          ],
+          Space: [
+            [247, 252, 253],
+            [224, 236, 244],
+            [191, 211, 230],
+            [158, 188, 218],
+            [140, 150, 198],
+            [140, 107, 177],
+            [136, 65, 157],
+            [129, 15, 124],
+            [77, 0, 75]
+          ],
+          Earth: [
+            [255, 247, 251],
+            [236, 226, 240],
+            [208, 209, 230],
+            [166, 189, 219],
+            [103, 169, 207],
+            [54, 144, 192],
+            [2, 129, 138],
+            [1, 108, 89],
+            [1, 70, 54]
+          ],
+          Ocean: [
+            [255, 255, 217],
+            [237, 248, 177],
+            [199, 233, 180],
+            [127, 205, 187],
+            [65, 182, 196],
+            [29, 145, 192],
+            [34, 94, 168],
+            [37, 52, 148],
+            [8, 29, 88]
+          ]
+        };
+
+        const colorOptions = {
+          Thermal: "Thermal",
+          Planet: "Planet",
+          Space: "Space",
+          Earth: "Earth",
+          Ocean: "Ocean"
+        };
+        const colorScheme = select(
+          "Fill Color:",
+          colorOptions,
+          colorOptions.Ocean,
+          GROUP_IDS.MARKER
+        );
+        const propertyFieldName = "injuriestotal_day";
+
+        return (
+          <DemoJSONLoader urls={[CIVIC_API_URL]}>
+            {data => {
+              const findDataMinMax = extent(data.results.features, f =>
+                parseFloat(f.properties[propertyFieldName])
+              );
+              const colorScale = scaleQuantize()
+                .domain(findDataMinMax)
+                .range(colorSchemeOptions[colorScheme]);
+
+              return (
+                <BaseMap>
+                  <MapOverlay
+                    data={data.results.features}
+                    getFillColor={f =>
+                      colorScale(f.properties[propertyFieldName])
+                    }
+                  />
+                </BaseMap>
+              );
+            }}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    )
+    .add(
+      "Example: With Tooltip",
+      () => {
+        return (
+          <DemoJSONLoader urls={[CIVIC_API_URL]}>
+            {data => (
+              <BaseMap>
+                <MapOverlay
+                  data={data.results.features}
+                  getFillColor={[25, 183, 170]}
+                >
+                  <MapTooltip
+                    primaryName="Earthquake - Total Day Injuries"
+                    primaryField="injuriestotal_day"
+                    secondaryName="Earthquake - Total Night Injuries"
+                    secondaryField="injuriestotal_night"
+                  />
+                </MapOverlay>
+              </BaseMap>
+            )}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    );

--- a/packages/component-library/stories/mapOverlay.notes.md
+++ b/packages/component-library/stories/mapOverlay.notes.md
@@ -1,0 +1,54 @@
+# MapOverlay Component
+
+## Standard
+
+The Standard story shows the basic usage of the MapOverlay component for the CIVIC platform.
+
+These props can be set in the Standard story:
+
+- **data:** this prop expects a valid [GeoJSON object](https://tools.ietf.org/html/rfc7946#section-3) or an [array of feature objects](https://tools.ietf.org/html/rfc7946#section-3.2)
+- **getFillColor:** the color of each feature
+  - This prop expects an array in `[r, g, b, [a]]` format or a function
+  - Each value in the array should be between 0 and 255
+  - The fourth value in the array is optional and represents opacity
+  - If an array is provided, the color is applied to all features
+  - If a function is provided, it is called on each feature to set the fill color
+- **getLineColor:** the color of the stroke for each feature
+  - This prop expects an array in `[r, g, b, [a]]` format or a function
+  - Each value in the array should be between 0 and 255
+  - The fourth value in the array is optional and represents opacity
+  - If an array is provided, the color is applied to all features
+  - If a function is provided, it is called on each feature to set the fill color
+- **getLineWidth:** the width of the stroke for each feature
+  - This prop expects a number or a function
+  - If a number is provided, it is used as the stroke width for all features
+  - If a function is provided, it is called on each feature to set the stroke width
+- **opacity:** the opacity of each feature
+  - This prop expects a decimal between 0 and 1
+
+## Custom
+
+The Custom story shows additional props that can be passed to the MapOverlay component.
+
+These props can be set in the Custom story:
+
+- **filled:** whether features are filled with a color
+  - This prop expects a boolean value
+- **stroked:** whether features are outlined with a color
+  - This prop expects a boolean value
+- **autoHighlight:** whether current feature when hovered over is highlighted
+  - This prop expects a boolean value
+- **highlightColor:** the color used to highlight a feature
+  - This prop expects an array in the `[r, g, b, [a]]` format
+  - Each value in the array should be between 0 and 255
+  - The fourth value in the array is optional and represents opacity
+- **onLayerClick:** this function will be called when a feature is clicked
+  - This prop expects a function
+
+## Example: Choropleth Map
+
+This story shows MapOverlay used to create a choropleth map.
+
+## Example: With Tooltip
+
+This story shows MapOverlay used with the MapTooltip component.

--- a/packages/emergency-response/src/components/FmaMap/index.js
+++ b/packages/emergency-response/src/components/FmaMap/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React from "react";
 import { BaseMap, MapOverlay } from "@hackoregon/component-library";
 import { isEmpty } from "ramda";
@@ -18,6 +19,12 @@ class FmaMap extends React.Component {
 
   render() {
     const { fmasData, fmaPanelData, renderPanel } = this.props;
+    const getFillColor = f => {
+      if (fmaPanelData && fmaPanelData.fma_id === f.properties.fma_id) {
+        return [220, 69, 86, 255];
+      }
+      return [0, 100, 255, 115];
+    };
 
     return (
       <div>
@@ -25,14 +32,13 @@ class FmaMap extends React.Component {
           <BaseMap>
             <MapOverlay
               data={fmasData}
-              opacity={0.1}
-              filled
-              stroked
-              getPosition={f => f.geometry.coordinates}
+              opacity={0.8}
               onLayerClick={info => renderPanel(info.object.properties)}
-              getElevation={f => 100}
-              getFillColor={f => [0, 100, 255, 255]}
-              getLineColor={f => [220, 69, 86, 255]}
+              getFillColor={getFillColor}
+              getLineColor={[220, 69, 86, 155]}
+              getLineWidth={4}
+              autoHighlight
+              highlightColor={[220, 69, 86, 155]}
             />
           </BaseMap>
         )}

--- a/packages/housing/src/components/Map/index.js
+++ b/packages/housing/src/components/Map/index.js
@@ -31,40 +31,32 @@ const Map = ({ neighborhoodData, activeNeighborhood, onSelect }) => {
   return (
     <BaseMap initialZoom={9.8}>
       <MapOverlay
-        filled
-        stroked
+        pickable={false}
         data={neighborhoodData}
         opacity={0.4}
-        getPosition={f => f.geometry.coordinates}
         getFillColor={getNeighborhoodColor}
-        getLineColor={() => [255, 255, 255]}
-        getRadius={10}
+        getLineColor={[255, 255, 255]}
         getLineWidth={4}
       />
       <MapOverlay
         visible={!!activeNeighborhood}
         id="selected-neighborhood"
-        stroked
         pickable={false}
         data={{
           features: [asLine(activeNeighborhood)],
           type: "FeatureCollection"
         }}
         opacity={1}
-        getPosition={f => f.geometry.coordinates}
-        getLineColor={() => [238, 73, 92]}
-        getLineWidth={8}
+        getFillColor={[0, 0, 0, 0]}
+        getLineColor={[238, 73, 92]}
+        getLineWidth={145}
       />
       <MapOverlay
         id="interaction-layer"
-        filled
-        stroked
         data={neighborhoodData}
         opacity={0.0}
-        getPosition={f => f.geometry.coordinates}
-        getFillColor={() => [255, 255, 255]}
-        getLineColor={() => [255, 255, 255]}
-        getRadius={10}
+        getFillColor={[255, 255, 255]}
+        getLineColor={[255, 255, 255]}
         getLineWidth={4}
         onLayerClick={onSelect}
       />

--- a/packages/transportation/src/components/TransportMap/index.js
+++ b/packages/transportation/src/components/TransportMap/index.js
@@ -1,9 +1,10 @@
+/* eslint-disable */
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { BaseMap, MapOverlay } from "@hackoregon/component-library";
-import { MapPanel } from "../index";
 import PropTypes from "prop-types";
 import { isEmpty } from "ramda";
+import { MapPanel } from "../index";
 import { setPanelValues } from "../../state";
 
 class TransportMap extends Component {
@@ -80,12 +81,8 @@ class TransportMap extends Component {
         >
           {geoData && (
             <MapOverlay
-              filled
-              stroked
               data={geoData}
               opacity={0.5}
-              getPosition={f => f.geometry.coordinates}
-              getElevation={() => 100}
               getFillColor={() => [232, 114, 32, 255]}
               getLineColor={() => [232, 114, 32, 255]}
               getRadius={radiusFor[mapType]}


### PR DESCRIPTION
This addresses #571.

The MapOverlay component and stories were updated to conform to the new design system standard.

- Updated the MapOverlay component's props, propTypes, and defaultProps
- Renamed the MapOverlay stories to Standard, Custom, and Examples: With Tooltip
- Added a data knob to the Standard and Custom stories to show the first feature object from the GeoJSON passed to it
- Created an Examples: Choropleth Map story 
- Added a MapOverlay notes markdown file
- Updated components that use MapOverlay in transportation and housing packages
- I was also able to address an item from #447 by making the selected polygon on the FMA maps persistently highlighted 



