### PR TITLE
Design System- update path map story

### DIFF
--- a/packages/component-library/src/PathMap/PathMap.js
+++ b/packages/component-library/src/PathMap/PathMap.js
@@ -65,10 +65,10 @@ const PathMap = props => {
 PathMap.propTypes = {
   viewport: PropTypes.shape({}),
   data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  getColor: PropTypes.func,
+  getColor: PropTypes.oneOfType([PropTypes.func, PropTypes.array]),
   opacity: PropTypes.number,
   getPath: PropTypes.func,
-  getWidth: PropTypes.func,
+  getWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   widthScale: PropTypes.number,
   rounded: PropTypes.bool,
   autoHighlight: PropTypes.bool,

--- a/packages/component-library/src/PathMap/PathMap.js
+++ b/packages/component-library/src/PathMap/PathMap.js
@@ -65,7 +65,10 @@ const PathMap = props => {
 PathMap.propTypes = {
   viewport: PropTypes.shape({}),
   data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  getColor: PropTypes.oneOfType([PropTypes.func, PropTypes.array]),
+  getColor: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.number)
+  ]),
   opacity: PropTypes.number,
   getPath: PropTypes.func,
   getWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),

--- a/packages/component-library/stories/PathMap.notes.md
+++ b/packages/component-library/stories/PathMap.notes.md
@@ -19,7 +19,7 @@ The Custom story shows all the possible properties that can be passed to the Pat
 - `data` : expects an array of objects.
 - `getPath` : expects a function that returns an array of coordinates for each path. It is compatible with GeoJSON LineStrings.
 - `getColor` : expects a function or an array in `[r, g, b, [a]]` format, where `a` is a number between 0 and 255. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
-- `getWidth` : expects a function or a number. If a number is provided it is used as the radius for all objects. If a function is provided, it is called on each object to set the radius.
+- `getWidth` : expects a function or a number. If a number is provided it is used as the width for all objects. If a function is provided, it is called on each object to set the width.
 - `opacity` : expects a number between 0 and 1.
 - `widthScale` : expects a number.
 - `rounded` : expects a boolean value.

--- a/packages/component-library/stories/PathMap.notes.md
+++ b/packages/component-library/stories/PathMap.notes.md
@@ -2,39 +2,33 @@
 
 ## Standard
 
-The Standard story shows the standard usage of the ScatterPlot Map Component for the CIVIC platform. ScatterPlot Map includes the standard styling.
+The Standard story shows the standard usage of the Path Map Component for the CIVIC platform. Path Map includes the standard styling.
 
 These properties can be set in the standard story:
 
-- `getFillColor`
-- `radiusScale`
+- `getColor`
+- `getWidth`
 - `opacity`
 - `data`
-- `getPosition`
+- `getPath`
 
 ## Custom
 
-The Custom story shows all the possible properties that can be passed to the ScatterPlot Map Component for customization.
+The Custom story shows all the possible properties that can be passed to the Path Map Component for customization.
 
 - `data` : expects an array of objects.
-- `getPosition` : expects a function that returns the coordinates of each object in data array.
+- `getPath` : expects a function that returns an array of coordinates for each path. It is compatible with GeoJSON LineStrings.
+- `getColor` : expects a function or an array in `[r, g, b, [a]]` format, where `a` is a number between 0 and 255. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
+- `getWidth` : expects a function or a number. If a number is provided it is used as the radius for all objects. If a function is provided, it is called on each object to set the radius.
 - `opacity` : expects a number between 0 and 1.
-- `getFillColor` : expects a function or an array in `[r, g, b, [a]]` format, where `a` is a number between 0 and 255. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
-- `getLineColor` : expects a function or an array in `[r, g, b, [a]]` format, where `a` is a number between 0 and 255. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
-- `getRadius` : expects a function or a number. If a number is provided it is used as the radius for all objects. If a function is provided, it is called on each object to set the radius.
-- `radiusScale` : expects a number.
-- `stroked` : expects a boolean value.
-- `getLineWidth` : expects a function or a number. If a number is provided, it is used as the outline width for each object. If a function is provided, it is called on each object to set the outline width.
+- `widthScale` : expects a number.
+- `rounded` : expects a boolean value.
 - `autoHighlight` : expects a boolean value.
 - `highlightColor` : expects an array in the `[r, g, b, [a]]` format.
 - `onLayerClick` : expects a function.
 
+In this example we are styling the `getColor` prop based on a data attribute. We have a preset color scheme and use D3's `scaleThreshold()` to calculate a scale based on the provided data.
+
 ## Example: With Tooltip
 
-The Example: With Tooltip story shows an example of using the MapTooltip component with the ScatterPlot Map component.
-
-## Example: Data Driven Styling
-
-The Example: Data Driven Styling story shows an example of styling the fill color based on a data attribute. We perform a ternary operation to check if a property is over a certain value and style based on that operation.
-
-We also style the `getRadius` based on a numerical property of each object to create graduated circles.
+The Example: With Tooltip story shows an example of using the MapTooltip component with the Path Map component.

--- a/packages/component-library/stories/PathMap.notes.md
+++ b/packages/component-library/stories/PathMap.notes.md
@@ -1,0 +1,40 @@
+# Path Map Component
+
+## Standard
+
+The Standard story shows the standard usage of the ScatterPlot Map Component for the CIVIC platform. ScatterPlot Map includes the standard styling.
+
+These properties can be set in the standard story:
+
+- `getFillColor`
+- `radiusScale`
+- `opacity`
+- `data`
+- `getPosition`
+
+## Custom
+
+The Custom story shows all the possible properties that can be passed to the ScatterPlot Map Component for customization.
+
+- `data` : expects an array of objects.
+- `getPosition` : expects a function that returns the coordinates of each object in data array.
+- `opacity` : expects a number between 0 and 1.
+- `getFillColor` : expects a function or an array in `[r, g, b, [a]]` format, where `a` is a number between 0 and 255. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
+- `getLineColor` : expects a function or an array in `[r, g, b, [a]]` format, where `a` is a number between 0 and 255. If an array is provided, the color is applied to all objects. If a function is provided, it is called on each object to set the fill color.
+- `getRadius` : expects a function or a number. If a number is provided it is used as the radius for all objects. If a function is provided, it is called on each object to set the radius.
+- `radiusScale` : expects a number.
+- `stroked` : expects a boolean value.
+- `getLineWidth` : expects a function or a number. If a number is provided, it is used as the outline width for each object. If a function is provided, it is called on each object to set the outline width.
+- `autoHighlight` : expects a boolean value.
+- `highlightColor` : expects an array in the `[r, g, b, [a]]` format.
+- `onLayerClick` : expects a function.
+
+## Example: With Tooltip
+
+The Example: With Tooltip story shows an example of using the MapTooltip component with the ScatterPlot Map component.
+
+## Example: Data Driven Styling
+
+The Example: Data Driven Styling story shows an example of styling the fill color based on a data attribute. We perform a ternary operation to check if a property is over a certain value and style based on that operation.
+
+We also style the `getRadius` based on a numerical property of each object to create graduated circles.

--- a/packages/component-library/stories/PathMap.story.js
+++ b/packages/component-library/stories/PathMap.story.js
@@ -63,6 +63,8 @@ const getPath = f => f.geometry.coordinates;
 
 // const getWidthSandard = () => 15;
 
+const standardColor = [25, 183, 170, 255];
+
 export default () => {
   storiesOf("Component Lib|Maps/Path Map", module)
     .addDecorator(withKnobs)
@@ -70,11 +72,7 @@ export default () => {
     .add(
       "Standard",
       () => {
-        const getColor = object(
-          "Color: ",
-          [25, 183, 170, 255],
-          GROUP_IDS.MARKER
-        );
+        const getColor = object("Color: ", standardColor, GROUP_IDS.MARKER);
 
         const opacity = number(
           "Opacity:",
@@ -163,6 +161,18 @@ export default () => {
 
         const rounded = boolean("Rounded:", true, GROUP_IDS.MARKER);
 
+        const autoHighlight = boolean(
+          "Auto Highlight:",
+          true,
+          GROUP_IDS.MARKER
+        );
+
+        const getHighlightColor = object(
+          "Highlight Color: ",
+          highlightColor,
+          GROUP_IDS.MARKER
+        );
+
         return (
           <DemoJSONLoader urls={mapData}>
             {data => {
@@ -181,7 +191,8 @@ export default () => {
                     getWidth={getWidth}
                     widthScale={widthScale}
                     rounded={rounded}
-                    highlightColor={highlightColor}
+                    autoHighlight={autoHighlight}
+                    highlightColor={getHighlightColor}
                     onLayerClick={info =>
                       action("Layer clicked:", { depth: 2 })(info, info.object)
                     }

--- a/packages/component-library/stories/PathMap.story.js
+++ b/packages/component-library/stories/PathMap.story.js
@@ -1,7 +1,13 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { withKnobs, number, select, boolean } from "@storybook/addon-knobs";
+import {
+  withKnobs,
+  number,
+  select,
+  boolean,
+  object
+} from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
 import { scaleThreshold } from "d3";
@@ -26,11 +32,23 @@ const opacityOptions = {
   step: 0.05
 };
 
+const getWidthOptions = {
+  range: true,
+  min: 0,
+  max: 100,
+  step: 1
+};
+
 const widthScaleOptions = {
   range: true,
   min: 1,
   max: 10,
   step: 0.5
+};
+
+const GROUP_IDS = {
+  MARKER: "Marker",
+  DATA: "Data"
 };
 
 const mapData = [
@@ -42,7 +60,8 @@ const highlightColor = [125, 125, 125, 125];
 const parseColors = colorScheme => JSON.parse(colorScheme);
 
 const getPath = f => f.geometry.coordinates;
-const getWidth = () => 15;
+
+// const getWidthSandard = () => 15;
 
 export default () => {
   storiesOf("Component Lib|Maps/Path Map", module)
@@ -54,7 +73,8 @@ export default () => {
         const colorScheme = select(
           "Color Scheme:",
           colorSchemeOptions,
-          colorSchemeOptions["Purple Green"]
+          colorSchemeOptions["Purple Green"],
+          GROUP_IDS.MARKER
         );
         const colors = parseColors(colorScheme);
 
@@ -67,10 +87,92 @@ export default () => {
           return divergingScale(percentChange);
         };
 
-        const opacity = number("Opacity:", 0.95, opacityOptions);
+        const opacity = number(
+          "Opacity:",
+          0.95,
+          opacityOptions,
+          GROUP_IDS.MARKER
+        );
 
-        const widthScale = number("Width Scale:", 1, widthScaleOptions);
-        const rounded = boolean("Rounded:", true);
+        const getWidth = number(
+          "Width:",
+          15,
+          getWidthOptions,
+          GROUP_IDS.MARKER
+        );
+
+        return (
+          <DemoJSONLoader urls={mapData}>
+            {allData => {
+              const data = object(
+                "Data",
+                allData.slide_data.features,
+                GROUP_IDS.DATA
+              );
+              return (
+                <BaseMap
+                  mapboxStyle={baseMapStyle}
+                  initialZoom={12}
+                  initialLatitude={45.523027}
+                  initialLongitude={-122.67037}
+                >
+                  <PathMap
+                    data={data}
+                    getColor={getPathColor}
+                    opacity={opacity}
+                    getPath={getPath}
+                    getWidth={getWidth}
+                  />
+                </BaseMap>
+              );
+            }}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    )
+    .add(
+      "Custom",
+      () => {
+        const colorScheme = select(
+          "Color Scheme:",
+          colorSchemeOptions,
+          colorSchemeOptions["Purple Green"],
+          GROUP_IDS.MARKER
+        );
+        const colors = parseColors(colorScheme);
+
+        const divergingScale = scaleThreshold()
+          .domain([-100, -75, -50, -25, 0, 25, 50, 75, 100])
+          .range(colors);
+
+        const getPathColor = f => {
+          const value = f.properties.pct_change;
+          return divergingScale(value);
+        };
+
+        const opacity = number(
+          "Opacity:",
+          0.95,
+          opacityOptions,
+          GROUP_IDS.MARKER
+        );
+
+        const getWidth = number(
+          "Width:",
+          15,
+          getWidthOptions,
+          GROUP_IDS.MARKER
+        );
+
+        const widthScale = number(
+          "Width Scale:",
+          1,
+          widthScaleOptions,
+          GROUP_IDS.MARKER
+        );
+
+        const rounded = boolean("Rounded:", true, GROUP_IDS.MARKER);
 
         return (
           <DemoJSONLoader urls={mapData}>
@@ -109,7 +211,8 @@ export default () => {
         const colorScheme = select(
           "Color Scheme:",
           colorSchemeOptions,
-          colorSchemeOptions["Purple Green"]
+          colorSchemeOptions["Purple Green"],
+          GROUP_IDS.MARKER
         );
         const colors = parseColors(colorScheme);
 
@@ -118,18 +221,32 @@ export default () => {
           .range(colors);
 
         const getPathColor = f => {
-          const value = f.properties.pct_change;
-          return divergingScale(value);
+          const percentChange = f.properties.pct_change;
+          return divergingScale(percentChange);
         };
 
-        const opacity = number("Opacity:", 0.95, opacityOptions);
+        const opacity = number(
+          "Opacity:",
+          0.95,
+          opacityOptions,
+          GROUP_IDS.MARKER
+        );
 
-        const widthScale = number("Width Scale:", 1, widthScaleOptions);
-        const rounded = boolean("Rounded:", true);
+        const getWidth = number(
+          "Width:",
+          15,
+          getWidthOptions,
+          GROUP_IDS.MARKER
+        );
 
         return (
           <DemoJSONLoader urls={mapData}>
-            {data => {
+            {allData => {
+              const data = object(
+                "Data",
+                allData.slide_data.features,
+                GROUP_IDS.DATA
+              );
               return (
                 <BaseMap
                   mapboxStyle={baseMapStyle}
@@ -138,17 +255,11 @@ export default () => {
                   initialLongitude={-122.67037}
                 >
                   <PathMap
-                    data={data.slide_data.features}
+                    data={data}
                     getColor={getPathColor}
                     opacity={opacity}
                     getPath={getPath}
                     getWidth={getWidth}
-                    widthScale={widthScale}
-                    rounded={rounded}
-                    highlightColor={highlightColor}
-                    onLayerClick={info =>
-                      action("Layer clicked:", { depth: 2 })(info, info.object)
-                    }
                   >
                     <MapTooltip
                       primaryName="Percent Change"

--- a/packages/component-library/stories/PathMap.story.js
+++ b/packages/component-library/stories/PathMap.story.js
@@ -175,7 +175,12 @@ export default () => {
 
         return (
           <DemoJSONLoader urls={mapData}>
-            {data => {
+            {allData => {
+              const data = object(
+                "Data",
+                allData.slide_data.features,
+                GROUP_IDS.DATA
+              );
               return (
                 <BaseMap
                   mapboxStyle={baseMapStyle}
@@ -184,7 +189,7 @@ export default () => {
                   initialLongitude={-122.67037}
                 >
                   <PathMap
-                    data={data.slide_data.features}
+                    data={data}
                     getColor={getPathColor}
                     opacity={opacity}
                     getPath={getPath}

--- a/packages/component-library/stories/PathMap.story.js
+++ b/packages/component-library/stories/PathMap.story.js
@@ -8,13 +8,7 @@ import { scaleThreshold } from "d3";
 import { BaseMap, PathMap, MapTooltip, DemoJSONLoader } from "../src";
 import notes from "./PathMap.notes.md";
 
-const optionsStyle = {
-  "Hack Oregon Light": "mapbox://styles/hackoregon/cjiazbo185eib2srytwzleplg",
-  "Hack Oregon Dark": "mapbox://styles/hackoregon/cjie02elo1vyw2rohd24kbtbd",
-  "Navigation Guidance Night v2":
-    "mapbox://styles/mapbox/navigation-guidance-night-v2",
-  "Dark v9": "mapbox://styles/mapbox/dark-v9"
-};
+const baseMapStyle = "mapbox://styles/hackoregon/cjiazbo185eib2srytwzleplg";
 
 const colorSchemeOptions = {
   "Red Yellow Blue":
@@ -43,6 +37,13 @@ const mapData = [
   "https://service.civicpdx.org/transportation-systems/sandbox/slides/routechange/"
 ];
 
+const highlightColor = [125, 125, 125, 125];
+
+const parseColors = colorScheme => JSON.parse(colorScheme);
+
+const getPath = f => f.geometry.coordinates;
+const getWidth = () => 15;
+
 export default () => {
   storiesOf("Component Lib|Maps/Path Map", module)
     .addDecorator(withKnobs)
@@ -50,41 +51,33 @@ export default () => {
     .add(
       "Standard",
       () => {
-        const mapboxStyle = select(
-          "Mapbox Style",
-          optionsStyle,
-          optionsStyle["Hack Oregon Light"]
-        );
-
         const colorScheme = select(
           "Color Scheme:",
           colorSchemeOptions,
           colorSchemeOptions["Purple Green"]
         );
-        const colors = JSON.parse(colorScheme);
+        const colors = parseColors(colorScheme);
 
         const divergingScale = scaleThreshold()
           .domain([-100, -75, -50, -25, 0, 25, 50, 75, 100])
           .range(colors);
 
         const getPathColor = f => {
-          const value = f.properties.pct_change;
-          return divergingScale(value);
+          const percentChange = f.properties.pct_change;
+          return divergingScale(percentChange);
         };
 
         const opacity = number("Opacity:", 0.95, opacityOptions);
-        const getPath = f => f.geometry.coordinates;
-        const getWidth = () => 15;
+
         const widthScale = number("Width Scale:", 1, widthScaleOptions);
         const rounded = boolean("Rounded:", true);
-        const highlightColor = [125, 125, 125, 125];
 
         return (
           <DemoJSONLoader urls={mapData}>
             {data => {
               return (
                 <BaseMap
-                  mapboxStyle={mapboxStyle}
+                  mapboxStyle={baseMapStyle}
                   initialZoom={12}
                   initialLatitude={45.523027}
                   initialLongitude={-122.67037}
@@ -113,18 +106,12 @@ export default () => {
     .add(
       "Example: With Tooltip",
       () => {
-        const mapboxStyle = select(
-          "Mapbox Style",
-          optionsStyle,
-          optionsStyle["Hack Oregon Light"]
-        );
-
         const colorScheme = select(
           "Color Scheme:",
           colorSchemeOptions,
           colorSchemeOptions["Purple Green"]
         );
-        const colors = JSON.parse(colorScheme);
+        const colors = parseColors(colorScheme);
 
         const divergingScale = scaleThreshold()
           .domain([-100, -75, -50, -25, 0, 25, 50, 75, 100])
@@ -136,18 +123,16 @@ export default () => {
         };
 
         const opacity = number("Opacity:", 0.95, opacityOptions);
-        const getPath = f => f.geometry.coordinates;
-        const getWidth = () => 15;
+
         const widthScale = number("Width Scale:", 1, widthScaleOptions);
         const rounded = boolean("Rounded:", true);
-        const highlightColor = [125, 125, 125, 125];
 
         return (
           <DemoJSONLoader urls={mapData}>
             {data => {
               return (
                 <BaseMap
-                  mapboxStyle={mapboxStyle}
+                  mapboxStyle={baseMapStyle}
                   initialZoom={12}
                   initialLatitude={45.523027}
                   initialLongitude={-122.67037}

--- a/packages/component-library/stories/PathMap.story.js
+++ b/packages/component-library/stories/PathMap.story.js
@@ -70,22 +70,11 @@ export default () => {
     .add(
       "Standard",
       () => {
-        const colorScheme = select(
-          "Color Scheme:",
-          colorSchemeOptions,
-          colorSchemeOptions["Purple Green"],
+        const getColor = object(
+          "Color: ",
+          [25, 183, 170, 255],
           GROUP_IDS.MARKER
         );
-        const colors = parseColors(colorScheme);
-
-        const divergingScale = scaleThreshold()
-          .domain([-100, -75, -50, -25, 0, 25, 50, 75, 100])
-          .range(colors);
-
-        const getPathColor = f => {
-          const percentChange = f.properties.pct_change;
-          return divergingScale(percentChange);
-        };
 
         const opacity = number(
           "Opacity:",
@@ -118,7 +107,7 @@ export default () => {
                 >
                   <PathMap
                     data={data}
-                    getColor={getPathColor}
+                    getColor={getColor}
                     opacity={opacity}
                     getPath={getPath}
                     getWidth={getWidth}
@@ -208,22 +197,11 @@ export default () => {
     .add(
       "Example: With Tooltip",
       () => {
-        const colorScheme = select(
-          "Color Scheme:",
-          colorSchemeOptions,
-          colorSchemeOptions["Purple Green"],
+        const getColor = object(
+          "Color: ",
+          [25, 183, 170, 255],
           GROUP_IDS.MARKER
         );
-        const colors = parseColors(colorScheme);
-
-        const divergingScale = scaleThreshold()
-          .domain([-100, -75, -50, -25, 0, 25, 50, 75, 100])
-          .range(colors);
-
-        const getPathColor = f => {
-          const percentChange = f.properties.pct_change;
-          return divergingScale(percentChange);
-        };
 
         const opacity = number(
           "Opacity:",
@@ -256,7 +234,7 @@ export default () => {
                 >
                   <PathMap
                     data={data}
-                    getColor={getPathColor}
+                    getColor={getColor}
                     opacity={opacity}
                     getPath={getPath}
                     getWidth={getWidth}

--- a/packages/component-library/stories/PathMap.story.js
+++ b/packages/component-library/stories/PathMap.story.js
@@ -6,6 +6,7 @@ import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
 import { scaleThreshold } from "d3";
 import { BaseMap, PathMap, MapTooltip, DemoJSONLoader } from "../src";
+import notes from "./PathMap.notes.md";
 
 const optionsStyle = {
   "Hack Oregon Light": "mapbox://styles/hackoregon/cjiazbo185eib2srytwzleplg",
@@ -42,130 +43,139 @@ const mapData = [
   "https://service.civicpdx.org/transportation-systems/sandbox/slides/routechange/"
 ];
 
-const demoMap = () => (
-  <DemoJSONLoader urls={mapData}>
-    {data => {
-      const mapboxStyle = select(
-        "Mapbox Style",
-        optionsStyle,
-        optionsStyle["Hack Oregon Light"]
-      );
-
-      const colorScheme = select(
-        "Color Scheme:",
-        colorSchemeOptions,
-        colorSchemeOptions["Purple Green"]
-      );
-      const colors = JSON.parse(colorScheme);
-
-      const divergingScale = scaleThreshold()
-        .domain([-100, -75, -50, -25, 0, 25, 50, 75, 100])
-        .range(colors);
-
-      const getPathColor = f => {
-        const value = f.properties.pct_change;
-        return divergingScale(value);
-      };
-
-      const opacity = number("Opacity:", 0.95, opacityOptions);
-      const getPath = f => f.geometry.coordinates;
-      const getWidth = () => 15;
-      const widthScale = number("Width Scale:", 1, widthScaleOptions);
-      const rounded = boolean("Rounded:", true);
-      const highlightColor = [125, 125, 125, 125];
-
-      return (
-        <BaseMap
-          mapboxStyle={mapboxStyle}
-          initialZoom={12}
-          initialLatitude={45.523027}
-          initialLongitude={-122.67037}
-        >
-          <PathMap
-            data={data.slide_data.features}
-            getColor={getPathColor}
-            opacity={opacity}
-            getPath={getPath}
-            getWidth={getWidth}
-            widthScale={widthScale}
-            rounded={rounded}
-            highlightColor={highlightColor}
-            onLayerClick={info =>
-              action("Layer clicked:", { depth: 2 })(info, info.object)
-            }
-          />
-        </BaseMap>
-      );
-    }}
-  </DemoJSONLoader>
-);
-
-const tooltipMap = () => (
-  <DemoJSONLoader urls={mapData}>
-    {data => {
-      const mapboxStyle = select(
-        "Mapbox Style",
-        optionsStyle,
-        optionsStyle["Hack Oregon Light"]
-      );
-
-      const colorScheme = select(
-        "Color Scheme:",
-        colorSchemeOptions,
-        colorSchemeOptions["Purple Green"]
-      );
-      const colors = JSON.parse(colorScheme);
-
-      const divergingScale = scaleThreshold()
-        .domain([-100, -75, -50, -25, 0, 25, 50, 75, 100])
-        .range(colors);
-
-      const getPathColor = f => {
-        const value = f.properties.pct_change;
-        return divergingScale(value);
-      };
-
-      const opacity = number("Opacity:", 0.95, opacityOptions);
-      const getPath = f => f.geometry.coordinates;
-      const getWidth = () => 15;
-      const widthScale = number("Width Scale:", 1, widthScaleOptions);
-      const rounded = boolean("Rounded:", true);
-      const highlightColor = [125, 125, 125, 125];
-
-      return (
-        <BaseMap
-          mapboxStyle={mapboxStyle}
-          initialZoom={12}
-          initialLatitude={45.523027}
-          initialLongitude={-122.67037}
-        >
-          <PathMap
-            data={data.slide_data.features}
-            getColor={getPathColor}
-            opacity={opacity}
-            getPath={getPath}
-            getWidth={getWidth}
-            widthScale={widthScale}
-            rounded={rounded}
-            highlightColor={highlightColor}
-            onLayerClick={info =>
-              action("Layer clicked:", { depth: 2 })(info, info.object)
-            }
-          >
-            <MapTooltip
-              primaryName="Percent Change"
-              primaryField="pct_change"
-            />
-          </PathMap>
-        </BaseMap>
-      );
-    }}
-  </DemoJSONLoader>
-);
-
-export default () =>
+export default () => {
   storiesOf("Component Lib|Maps/Path Map", module)
     .addDecorator(withKnobs)
     .addDecorator(checkA11y)
-    .add("Simple usage", demoMap)
-    .add("With tooltip", tooltipMap);
+    .add(
+      "Standard",
+      () => {
+        const mapboxStyle = select(
+          "Mapbox Style",
+          optionsStyle,
+          optionsStyle["Hack Oregon Light"]
+        );
+
+        const colorScheme = select(
+          "Color Scheme:",
+          colorSchemeOptions,
+          colorSchemeOptions["Purple Green"]
+        );
+        const colors = JSON.parse(colorScheme);
+
+        const divergingScale = scaleThreshold()
+          .domain([-100, -75, -50, -25, 0, 25, 50, 75, 100])
+          .range(colors);
+
+        const getPathColor = f => {
+          const value = f.properties.pct_change;
+          return divergingScale(value);
+        };
+
+        const opacity = number("Opacity:", 0.95, opacityOptions);
+        const getPath = f => f.geometry.coordinates;
+        const getWidth = () => 15;
+        const widthScale = number("Width Scale:", 1, widthScaleOptions);
+        const rounded = boolean("Rounded:", true);
+        const highlightColor = [125, 125, 125, 125];
+
+        return (
+          <DemoJSONLoader urls={mapData}>
+            {data => {
+              return (
+                <BaseMap
+                  mapboxStyle={mapboxStyle}
+                  initialZoom={12}
+                  initialLatitude={45.523027}
+                  initialLongitude={-122.67037}
+                >
+                  <PathMap
+                    data={data.slide_data.features}
+                    getColor={getPathColor}
+                    opacity={opacity}
+                    getPath={getPath}
+                    getWidth={getWidth}
+                    widthScale={widthScale}
+                    rounded={rounded}
+                    highlightColor={highlightColor}
+                    onLayerClick={info =>
+                      action("Layer clicked:", { depth: 2 })(info, info.object)
+                    }
+                  />
+                </BaseMap>
+              );
+            }}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    )
+    .add(
+      "Example: With Tooltip",
+      () => {
+        const mapboxStyle = select(
+          "Mapbox Style",
+          optionsStyle,
+          optionsStyle["Hack Oregon Light"]
+        );
+
+        const colorScheme = select(
+          "Color Scheme:",
+          colorSchemeOptions,
+          colorSchemeOptions["Purple Green"]
+        );
+        const colors = JSON.parse(colorScheme);
+
+        const divergingScale = scaleThreshold()
+          .domain([-100, -75, -50, -25, 0, 25, 50, 75, 100])
+          .range(colors);
+
+        const getPathColor = f => {
+          const value = f.properties.pct_change;
+          return divergingScale(value);
+        };
+
+        const opacity = number("Opacity:", 0.95, opacityOptions);
+        const getPath = f => f.geometry.coordinates;
+        const getWidth = () => 15;
+        const widthScale = number("Width Scale:", 1, widthScaleOptions);
+        const rounded = boolean("Rounded:", true);
+        const highlightColor = [125, 125, 125, 125];
+
+        return (
+          <DemoJSONLoader urls={mapData}>
+            {data => {
+              return (
+                <BaseMap
+                  mapboxStyle={mapboxStyle}
+                  initialZoom={12}
+                  initialLatitude={45.523027}
+                  initialLongitude={-122.67037}
+                >
+                  <PathMap
+                    data={data.slide_data.features}
+                    getColor={getPathColor}
+                    opacity={opacity}
+                    getPath={getPath}
+                    getWidth={getWidth}
+                    widthScale={widthScale}
+                    rounded={rounded}
+                    highlightColor={highlightColor}
+                    onLayerClick={info =>
+                      action("Layer clicked:", { depth: 2 })(info, info.object)
+                    }
+                  >
+                    <MapTooltip
+                      primaryName="Percent Change"
+                      primaryField="pct_change"
+                    />
+                  </PathMap>
+                </BaseMap>
+              );
+            }}
+          </DemoJSONLoader>
+        );
+      },
+      { notes }
+    );
+};


### PR DESCRIPTION
Addresses #568 

Summary:

I updated the Standard and With Tooltip examples and created the Custom example. I also added a notes file that describes the different props and examples. I updated the `getColor` and `getWidth` props to be `onOfType` based on the [deck.gl ](https://github.com/uber/deck.gl/blob/master/docs/layers/path-layer.md) doumentation. 

I am currently using the object knob to display color, as it seems like the preferred method based on our conversation in this [PR](https://github.com/hackoregon/civic/pull/583). I am using the color schemes generated in the previous iteration of this story in the custom example. 

💥🚀✨
