### PR TITLE
Design system/scatterplot

### DIFF
--- a/packages/component-library/stories/Scatterplot.story.js
+++ b/packages/component-library/stories/Scatterplot.story.js
@@ -1,15 +1,15 @@
 import React from "react";
-// import { css } from "emotion";
+import { css } from "emotion";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
 import {
   object,
   text,
-  // boolean,
+  boolean,
   withKnobs,
   optionsKnob as options
 } from "@storybook/addon-knobs";
-import { Scatterplot /* SimpleLegend */ } from "../src";
+import { Scatterplot, SimpleLegend } from "../src";
 import notes from "./scatterplot.notes.md";
 import civicFormat from "../src/utils/civicFormat";
 import { getKeyNames } from "./shared";
@@ -20,58 +20,49 @@ const GROUP_IDS = {
   CUSTOM: "Custom"
 };
 
-// const sampleDomain = { x: [0, 6], y: [0, 8] };
-// const sampleSize = { key: "y", minSize: 3, maxSize: 10 };
-// const sampleSubtitle = "A description of this chart.";
-// const sampleTitle = "Some title";
-// const sampleXKey = "x";
-// const sampleXLabel = "Number";
-// const sampleYKey = "y";
-// const sampleYLabel = "Rating";
+const customLegend = legendData => {
+  const legendStyle = css`
+    font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, sans-serif;
+    font-size: 14px;
+    font-weight: bold;
+    text-align: center;
+    margin: 10px 0 0 0;
+  `;
 
-// const customLegend = legendData => {
-//   const legendStyle = css`
-//     font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, sans-serif;
-//     font-size: 14px;
-//     font-weight: bold;
-//     text-align: center;
-//     margin: 10px 0 0 0;
-//   `;
+  const legendContainer = css`
+    display: flex;
+    width: 100%;
+    justify-content: center;
+  `;
 
-//   const legendContainer = css`
-//     display: flex;
-//     width: 100%;
-//     justify-content: center;
-//   `;
-
-//   return (
-//     <div className={legendContainer}>
-//       <SimpleLegend legendData={legendData} />
-//       <legend className={legendStyle}>
-//         <span
-//           className={css`
-//             margin-left: 5px;
-//           `}
-//         >
-//           <svg viewBox="0 0 50 10" width="50px">
-//             <circle cx="5" cy="5" r="1" />
-//             <circle cx="15" cy="5" r="2" />
-//             <circle cx="25" cy="5" r="3" />
-//             <circle cx="35" cy="5" r="4" />
-//             <circle cx="45" cy="5" r="5" />
-//           </svg>
-//           <span
-//             className={css`
-//               margin-left: 5px;
-//             `}
-//           >
-//             Population
-//           </span>
-//         </span>
-//       </legend>
-//     </div>
-//   );
-// };
+  return (
+    <div className={legendContainer}>
+      <SimpleLegend legendData={legendData} />
+      <legend className={legendStyle}>
+        <span
+          className={css`
+            margin-left: 5px;
+          `}
+        >
+          <svg viewBox="0 0 50 10" width="50px">
+            <circle cx="5" cy="5" r="1" />
+            <circle cx="15" cy="5" r="2" />
+            <circle cx="25" cy="5" r="3" />
+            <circle cx="35" cy="5" r="4" />
+            <circle cx="45" cy="5" r="5" />
+          </svg>
+          <span
+            className={css`
+              margin-left: 5px;
+            `}
+          >
+            Students
+          </span>
+        </span>
+      </legend>
+    </div>
+  );
+};
 
 export default () =>
   storiesOf("Component Lib|Charts/Scatterplot", module)
@@ -184,91 +175,127 @@ export default () =>
         notes
       }
     )
-    // .add(
-    //   "Custom",
-    //   () => {
-    //     const sampleData = [
-    //       { experience: 10.75, students: 22, series: "high" },
-    //       { experience: 10.25, students: 24, series: "high" },
-    //       { experience: 11, students: 26, series: "high" },
-    //       { experience: 11.25, students: 25, series: "high" },
-    //       { experience: 12, students: 25, series: "high" },
-    //       { experience: 12.5, students: 12, series: "high" },
-    //       { experience: 12.25, students: 26, series: "high" },
-    //       { experience: 12.75, students: 27, series: "high" },
-    //       { experience: 13, students: 27, series: "high" },
-    //       { experience: 8, students: 25, series: "middle" },
-    //       { experience: 10.25, students: 23, series: "middle" },
-    //       { experience: 11, students: 28, series: "middle" },
-    //       { experience: 12.15, students: 28, series: "middle" },
-    //       { experience: 12.3, students: 23, series: "middle" },
-    //       { experience: 13.4, students: 29, series: "middle" },
-    //       { experience: 13.75, students: 28, series: "middle" },
-    //       { experience: 14.5, students: 28, series: "middle" },
-    //       { experience: 14.75, students: 27, series: "middle" },
-    //       { experience: 16, students: 28, series: "middle" },
-    //       { experience: 7, students: 21, series: "elementary" },
-    //       { experience: 8.75, students: 23, series: "elementary" },
-    //       { experience: 9, students: 21, series: "elementary" },
-    //       { experience: 10.5, students: 26, series: "elementary" },
-    //       { experience: 10, students: 24, series: "elementary" },
-    //       { experience: 11.75, students: 23, series: "elementary" },
-    //       { experience: 12.6, students: 19, series: "elementary" },
-    //       { experience: 12.8, students: 22, series: "elementary" },
-    //       { experience: 13.25, students: 23, series: "elementary" },
-    //       { experience: 13.8, students: 26, series: "elementary" },
-    //       { experience: 14, students: 24, series: "elementary" },
-    //       { experience: 15, students: 22, series: "elementary" },
-    //       { experience: 16, students: 25, series: "elementary" },
-    //       { experience: 17, students: 25, series: "elementary" },
-    //       { experience: 18, students: 26, series: "elementary" }
-    //     ];
-    //     const sampleDataSeries = "series";
-    //     const sampledataSeriesLabel = [
-    //       { category: "high", label: "High School" },
-    //       { category: "middle", label: "Middle School" },
-    //       { category: "elementary", label: "Elementary School" }
-    //     ];
+    .add(
+      "Custom",
+      () => {
+        const sampleData = [
+          { experience: 10.75, students: 22, series: "high" },
+          { experience: 10.25, students: 24, series: "high" },
+          { experience: 11, students: 26, series: "high" },
+          { experience: 11.25, students: 25, series: "high" },
+          { experience: 12, students: 25, series: "high" },
+          { experience: 12.5, students: 12, series: "high" },
+          { experience: 12.25, students: 26, series: "high" },
+          { experience: 12.75, students: 27, series: "high" },
+          { experience: 13, students: 27, series: "high" },
+          { experience: 8, students: 25, series: "middle" },
+          { experience: 10.25, students: 23, series: "middle" },
+          { experience: 11, students: 28, series: "middle" },
+          { experience: 12.15, students: 28, series: "middle" },
+          { experience: 12.3, students: 23, series: "middle" },
+          { experience: 13.4, students: 29, series: "middle" },
+          { experience: 13.75, students: 28, series: "middle" },
+          { experience: 14.5, students: 28, series: "middle" },
+          { experience: 14.75, students: 27, series: "middle" },
+          { experience: 16, students: 28, series: "middle" },
+          { experience: 7, students: 21, series: "elementary" },
+          { experience: 8.75, students: 23, series: "elementary" },
+          { experience: 9, students: 21, series: "elementary" },
+          { experience: 10.5, students: 26, series: "elementary" },
+          { experience: 10, students: 24, series: "elementary" },
+          { experience: 11.75, students: 23, series: "elementary" },
+          { experience: 12.6, students: 19, series: "elementary" },
+          { experience: 12.8, students: 22, series: "elementary" },
+          { experience: 13.25, students: 23, series: "elementary" },
+          { experience: 13.8, students: 26, series: "elementary" },
+          { experience: 14, students: 24, series: "elementary" },
+          { experience: 15, students: 22, series: "elementary" },
+          { experience: 16, students: 25, series: "elementary" },
+          { experience: 17, students: 25, series: "elementary" },
+          { experience: 18, students: 26, series: "elementary" }
+        ];
+        const sampleDataSeries = "series";
+        const sampledataSeriesLabel = [
+          { category: "high", label: "High School" },
+          { category: "middle", label: "Middle School" },
+          { category: "elementary", label: "Elementary School" }
+        ];
 
-    //     const data = object("Data", sampleData);
-    //     const dataKey = text("dataKey", sampleXKey);
-    //     const dataValue = text("dataValue", sampleYKey);
-    //     const dataSeries = text("dataSeries", sampleDataSeries);
-    //     const dataSeriesLabel = object(
-    //       "Data Series Labels",
-    //       sampledataSeriesLabel
-    //     );
-    //     const size = object("Size", sampleSize);
-    //     const subtitle = text("Subtitle", sampleSubtitle);
-    //     const title = text("Title", sampleTitle);
-    //     const xLabel = text("xLabel", sampleXLabel);
-    //     const yLabel = text("yLabel", sampleYLabel);
-    //     const invertX = boolean("invertX", false);
-    //     const invertY = boolean("invertY", false);
+        const title = text(
+          "Title",
+          "Class Sizes and Teacher Experience",
+          GROUP_IDS.LABELS
+        );
+        const subtitle = text(
+          "Subtitle",
+          "Average student / teacher ratio by average years of teacher experience - 2017",
+          GROUP_IDS.LABELS
+        );
+        const xLabel = text("X-axis label", "Experience", GROUP_IDS.LABELS);
+        const xFormatterOptions = getKeyNames(civicFormat);
+        const optionSelectX = options(
+          "X-axis value format",
+          xFormatterOptions,
+          "numeric",
+          { display: "select" },
+          GROUP_IDS.LABELS
+        );
+        const yLabel = text("Y-axis label", "Students", GROUP_IDS.LABELS);
+        const yFormatterOptions = getKeyNames(civicFormat);
+        const optionSelectY = options(
+          "Y-axis value format",
+          yFormatterOptions,
+          "numeric",
+          { display: "select" },
+          GROUP_IDS.LABELS
+        );
 
-    //     return (
-    //       <Scatterplot
-    //         data={data}
-    //         dataKey={dataKey}
-    //         dataValue={dataValue}
-    //         dataSeries={dataSeries}
-    //         dataSeriesLabel={dataSeriesLabel}
-    //         domain={sampleDomain}
-    //         size={size}
-    //         subtitle={subtitle}
-    //         title={title}
-    //         xLabel={xLabel}
-    //         yLabel={yLabel}
-    //         invertX={invertX}
-    //         invertY={invertY}
-    //         legendComponent={customLegend}
-    //       />
-    //     );
-    //   },
-    //   {
-    //     notes
-    //   }
-    // )
+        const dataKey = text("Data key", "experience", GROUP_IDS.DATA);
+        const dataValue = text("Data value", "students", GROUP_IDS.DATA);
+        const dataSeries = text(
+          "Data series",
+          sampleDataSeries,
+          GROUP_IDS.DATA
+        );
+        const dataSeriesLabel = object(
+          "Data Series Labels",
+          sampledataSeriesLabel,
+          GROUP_IDS.DATA
+        );
+        const data = object("Data", sampleData, GROUP_IDS.DATA);
+
+        const sampleSize = { key: "experience", minSize: 3, maxSize: 8 };
+        const size = object("Size", sampleSize, GROUP_IDS.CUSTOM);
+        const sampleDomain = { x: [5, 20], y: [10, 35] };
+        const domain = object("Domain", sampleDomain, GROUP_IDS.CUSTOM);
+        const invertX = boolean("Invert X", false, GROUP_IDS.CUSTOM);
+        const invertY = boolean("Invert Y", false, GROUP_IDS.CUSTOM);
+
+        return (
+          <Scatterplot
+            data={data}
+            dataKey={dataKey}
+            dataValue={dataValue}
+            dataSeries={dataSeries}
+            dataSeriesLabel={dataSeriesLabel}
+            domain={domain}
+            size={size}
+            subtitle={subtitle}
+            title={title}
+            xLabel={xLabel}
+            yLabel={yLabel}
+            xNumberFormatter={x => civicFormat[optionSelectX](x)}
+            yNumberFormatter={y => civicFormat[optionSelectY](y)}
+            invertX={invertX}
+            invertY={invertY}
+            legendComponent={customLegend}
+          />
+        );
+      },
+      {
+        notes
+      }
+    )
     .add(
       "Example: Simple",
       () => {

--- a/packages/component-library/stories/Scatterplot.story.js
+++ b/packages/component-library/stories/Scatterplot.story.js
@@ -1,176 +1,292 @@
 import React from "react";
-import { css } from "emotion";
+// import { css } from "emotion";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { object, text, boolean, withKnobs } from "@storybook/addon-knobs";
-import { Scatterplot, SimpleLegend } from "../src";
+import {
+  object,
+  text,
+  // boolean,
+  withKnobs,
+  optionsKnob as options
+} from "@storybook/addon-knobs";
+import { Scatterplot /* SimpleLegend */ } from "../src";
+import notes from "./scatterplot.notes.md";
+import civicFormat from "../src/utils/civicFormat";
+import { getKeyNames } from "./shared";
 
-const sampleData = [
-  { x: 1, y: 2, series: "cat" },
-  { x: 2, y: 3, series: "cat" },
-  { x: 3, y: 5, series: "fish" },
-  { x: 4, y: 4, series: "fish" },
-  { x: 5, y: 7, series: "cat" },
-  { x: 1, y: 3, series: "dog" },
-  { x: 3, y: 3, series: "dog" }
-];
-const sampleDataSeries = "series";
-const sampledataSeriesLabel = [
-  { category: "cat", label: "Cat" },
-  { category: "dog", label: "Dog" },
-  { category: "fish", label: "Fish" }
-];
-const sampleDomain = { x: [0, 6], y: [0, 8] };
-const sampleSize = { key: "y", minSize: 3, maxSize: 10 };
-const sampleSubtitle = "A description of this chart.";
-const sampleTitle = "Some title";
-const sampleXKey = "x";
-const sampleXLabel = "Number";
-const sampleYKey = "y";
-const sampleYLabel = "Rating";
-
-const sampleUnstructuredData = [
-  { size: 1, age: 2, type: "cat" },
-  { size: 2, age: 3, type: "cat" },
-  { size: 3, age: 5, type: "fish" },
-  { size: 4, age: 4, type: "fish" },
-  { size: 5, age: 7, type: "cat" },
-  { size: 1, age: 3, type: "dog" },
-  { size: 3, age: 3, type: "dog" }
-];
-const sampleUnstructuredXKey = "size";
-const sampleUnstructuredYKey = "age";
-const sampleUnstructuredDataSeries = "type";
-const sampleUnstructuredXLabel = "Size (ft)";
-const sampleUnstructuredYLabel = "Age (yrs)";
-
-const customLegend = legendData => {
-  const legendStyle = css`
-    font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, sans-serif;
-    font-size: 14px;
-    font-weight: bold;
-    text-align: center;
-    margin: 10px 0 0 0;
-  `;
-
-  const legendContainer = css`
-    display: flex;
-    width: 100%;
-    justify-content: center;
-  `;
-
-  return (
-    <div className={legendContainer}>
-      <SimpleLegend legendData={legendData} />
-      <legend className={legendStyle}>
-        <span
-          className={css`
-            margin-left: 5px;
-          `}
-        >
-          <svg viewBox="0 0 50 10" width="50px">
-            <circle cx="5" cy="5" r="1" />
-            <circle cx="15" cy="5" r="2" />
-            <circle cx="25" cy="5" r="3" />
-            <circle cx="35" cy="5" r="4" />
-            <circle cx="45" cy="5" r="5" />
-          </svg>
-          <span
-            className={css`
-              margin-left: 5px;
-            `}
-          >
-            Population
-          </span>
-        </span>
-      </legend>
-    </div>
-  );
+const GROUP_IDS = {
+  LABELS: "Labels",
+  DATA: "Data",
+  CUSTOM: "Custom"
 };
+
+// const sampleDomain = { x: [0, 6], y: [0, 8] };
+// const sampleSize = { key: "y", minSize: 3, maxSize: 10 };
+// const sampleSubtitle = "A description of this chart.";
+// const sampleTitle = "Some title";
+// const sampleXKey = "x";
+// const sampleXLabel = "Number";
+// const sampleYKey = "y";
+// const sampleYLabel = "Rating";
+
+// const customLegend = legendData => {
+//   const legendStyle = css`
+//     font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, sans-serif;
+//     font-size: 14px;
+//     font-weight: bold;
+//     text-align: center;
+//     margin: 10px 0 0 0;
+//   `;
+
+//   const legendContainer = css`
+//     display: flex;
+//     width: 100%;
+//     justify-content: center;
+//   `;
+
+//   return (
+//     <div className={legendContainer}>
+//       <SimpleLegend legendData={legendData} />
+//       <legend className={legendStyle}>
+//         <span
+//           className={css`
+//             margin-left: 5px;
+//           `}
+//         >
+//           <svg viewBox="0 0 50 10" width="50px">
+//             <circle cx="5" cy="5" r="1" />
+//             <circle cx="15" cy="5" r="2" />
+//             <circle cx="25" cy="5" r="3" />
+//             <circle cx="35" cy="5" r="4" />
+//             <circle cx="45" cy="5" r="5" />
+//           </svg>
+//           <span
+//             className={css`
+//               margin-left: 5px;
+//             `}
+//           >
+//             Population
+//           </span>
+//         </span>
+//       </legend>
+//     </div>
+//   );
+// };
 
 export default () =>
   storiesOf("Component Lib|Charts/Scatterplot", module)
     .addDecorator(withKnobs)
-    .add("Simple usage", () => <Scatterplot data={sampleData} />)
-    .add("With some props", () => {
-      const data = object("Data", sampleData);
-      const dataKey = text("dataKey", sampleXKey);
-      const dataValue = text("dataValue", sampleYKey);
-      const dataSeries = text("dataSeries", sampleDataSeries);
-      const subtitle = text("Subtitle", sampleSubtitle);
-      const title = text("Title", sampleTitle);
-      const xLabel = text("xLabel", sampleXLabel);
-      const yLabel = text("yLabel", sampleYLabel);
+    .add(
+      "Standard",
+      () => {
+        const sampleData = [
+          { experience: 10.75, students: 22, series: "high" },
+          { experience: 10.25, students: 24, series: "high" },
+          { experience: 11, students: 26, series: "high" },
+          { experience: 11.25, students: 25, series: "high" },
+          { experience: 12, students: 25, series: "high" },
+          { experience: 12.5, students: 12, series: "high" },
+          { experience: 12.25, students: 26, series: "high" },
+          { experience: 12.75, students: 27, series: "high" },
+          { experience: 13, students: 27, series: "high" },
+          { experience: 8, students: 25, series: "middle" },
+          { experience: 10.25, students: 23, series: "middle" },
+          { experience: 11, students: 28, series: "middle" },
+          { experience: 12.15, students: 28, series: "middle" },
+          { experience: 12.3, students: 23, series: "middle" },
+          { experience: 13.4, students: 29, series: "middle" },
+          { experience: 13.75, students: 28, series: "middle" },
+          { experience: 14.5, students: 28, series: "middle" },
+          { experience: 14.75, students: 27, series: "middle" },
+          { experience: 16, students: 28, series: "middle" },
+          { experience: 7, students: 21, series: "elementary" },
+          { experience: 8.75, students: 23, series: "elementary" },
+          { experience: 9, students: 21, series: "elementary" },
+          { experience: 10.5, students: 26, series: "elementary" },
+          { experience: 10, students: 24, series: "elementary" },
+          { experience: 11.75, students: 23, series: "elementary" },
+          { experience: 12.6, students: 19, series: "elementary" },
+          { experience: 12.8, students: 22, series: "elementary" },
+          { experience: 13.25, students: 23, series: "elementary" },
+          { experience: 13.8, students: 26, series: "elementary" },
+          { experience: 14, students: 24, series: "elementary" },
+          { experience: 15, students: 22, series: "elementary" },
+          { experience: 16, students: 25, series: "elementary" },
+          { experience: 17, students: 25, series: "elementary" },
+          { experience: 18, students: 26, series: "elementary" }
+        ];
+        const sampleDataSeries = "series";
+        const sampledataSeriesLabel = [
+          { category: "high", label: "High School" },
+          { category: "middle", label: "Middle School" },
+          { category: "elementary", label: "Elementary School" }
+        ];
 
-      return (
-        <Scatterplot
-          data={data}
-          dataKey={dataKey}
-          dataValue={dataValue}
-          dataSeries={dataSeries}
-          subtitle={subtitle}
-          title={title}
-          xLabel={xLabel}
-          yLabel={yLabel}
-        />
-      );
-    })
-    .add("With some props and unstructured data", () => {
-      const data = object("Data", sampleUnstructuredData);
-      const dataKey = text("dataKey", sampleUnstructuredXKey);
-      const dataValue = text("dataValue", sampleUnstructuredYKey);
-      const dataSeries = text("dataSeries", sampleUnstructuredDataSeries);
-      const subtitle = text("Subtitle", sampleSubtitle);
-      const title = text("Title", sampleTitle);
-      const xLabel = text("xLabel", sampleUnstructuredXLabel);
-      const yLabel = text("yLabel", sampleUnstructuredYLabel);
+        const title = text(
+          "Title",
+          "Class Sizes and Teacher Experience",
+          GROUP_IDS.LABELS
+        );
+        const subtitle = text(
+          "Subtitle",
+          "Average student / teacher ratio by average years of teacher experience - 2017",
+          GROUP_IDS.LABELS
+        );
+        const xLabel = text("X-axis label", "Experience", GROUP_IDS.LABELS);
+        const xFormatterOptions = getKeyNames(civicFormat);
+        const optionSelectX = options(
+          "X-axis value format",
+          xFormatterOptions,
+          "numeric",
+          { display: "select" },
+          GROUP_IDS.LABELS
+        );
+        const yLabel = text("Y-axis label", "Students", GROUP_IDS.LABELS);
+        const yFormatterOptions = getKeyNames(civicFormat);
+        const optionSelectY = options(
+          "Y-axis value format",
+          yFormatterOptions,
+          "numeric",
+          { display: "select" },
+          GROUP_IDS.LABELS
+        );
+        const dataKey = text("Data key", "experience", GROUP_IDS.DATA);
+        const dataValue = text("Data value", "students", GROUP_IDS.DATA);
+        const dataSeries = text(
+          "Data series",
+          sampleDataSeries,
+          GROUP_IDS.DATA
+        );
+        const dataSeriesLabel = object(
+          "Data series labels",
+          sampledataSeriesLabel,
+          GROUP_IDS.DATA
+        );
+        const data = object("Data", sampleData, GROUP_IDS.DATA);
 
-      return (
-        <Scatterplot
-          data={data}
-          dataKey={dataKey}
-          dataValue={dataValue}
-          dataSeries={dataSeries}
-          subtitle={subtitle}
-          title={title}
-          xLabel={xLabel}
-          yLabel={yLabel}
-        />
-      );
-    })
-    .add("With more optional props", () => {
-      const data = object("Data", sampleData);
-      const dataKey = text("dataKey", sampleXKey);
-      const dataValue = text("dataValue", sampleYKey);
-      const dataSeries = text("dataSeries", sampleDataSeries);
-      const dataSeriesLabel = object(
-        "Data Series Labels",
-        sampledataSeriesLabel
-      );
-      const size = object("Size", sampleSize);
-      const subtitle = text("Subtitle", sampleSubtitle);
-      const title = text("Title", sampleTitle);
-      const xLabel = text("xLabel", sampleXLabel);
-      const yLabel = text("yLabel", sampleYLabel);
-      const invertX = boolean("invertX", false);
-      const invertY = boolean("invertY", false);
+        return (
+          <Scatterplot
+            data={data}
+            dataKey={dataKey}
+            dataValue={dataValue}
+            dataSeries={dataSeries}
+            dataSeriesLabel={dataSeriesLabel}
+            subtitle={subtitle}
+            title={title}
+            xLabel={xLabel}
+            yLabel={yLabel}
+            xNumberFormatter={x => civicFormat[optionSelectX](x)}
+            yNumberFormatter={y => civicFormat[optionSelectY](y)}
+          />
+        );
+      },
+      {
+        notes
+      }
+    )
+    // .add(
+    //   "Custom",
+    //   () => {
+    //     const sampleData = [
+    //       { experience: 10.75, students: 22, series: "high" },
+    //       { experience: 10.25, students: 24, series: "high" },
+    //       { experience: 11, students: 26, series: "high" },
+    //       { experience: 11.25, students: 25, series: "high" },
+    //       { experience: 12, students: 25, series: "high" },
+    //       { experience: 12.5, students: 12, series: "high" },
+    //       { experience: 12.25, students: 26, series: "high" },
+    //       { experience: 12.75, students: 27, series: "high" },
+    //       { experience: 13, students: 27, series: "high" },
+    //       { experience: 8, students: 25, series: "middle" },
+    //       { experience: 10.25, students: 23, series: "middle" },
+    //       { experience: 11, students: 28, series: "middle" },
+    //       { experience: 12.15, students: 28, series: "middle" },
+    //       { experience: 12.3, students: 23, series: "middle" },
+    //       { experience: 13.4, students: 29, series: "middle" },
+    //       { experience: 13.75, students: 28, series: "middle" },
+    //       { experience: 14.5, students: 28, series: "middle" },
+    //       { experience: 14.75, students: 27, series: "middle" },
+    //       { experience: 16, students: 28, series: "middle" },
+    //       { experience: 7, students: 21, series: "elementary" },
+    //       { experience: 8.75, students: 23, series: "elementary" },
+    //       { experience: 9, students: 21, series: "elementary" },
+    //       { experience: 10.5, students: 26, series: "elementary" },
+    //       { experience: 10, students: 24, series: "elementary" },
+    //       { experience: 11.75, students: 23, series: "elementary" },
+    //       { experience: 12.6, students: 19, series: "elementary" },
+    //       { experience: 12.8, students: 22, series: "elementary" },
+    //       { experience: 13.25, students: 23, series: "elementary" },
+    //       { experience: 13.8, students: 26, series: "elementary" },
+    //       { experience: 14, students: 24, series: "elementary" },
+    //       { experience: 15, students: 22, series: "elementary" },
+    //       { experience: 16, students: 25, series: "elementary" },
+    //       { experience: 17, students: 25, series: "elementary" },
+    //       { experience: 18, students: 26, series: "elementary" }
+    //     ];
+    //     const sampleDataSeries = "series";
+    //     const sampledataSeriesLabel = [
+    //       { category: "high", label: "High School" },
+    //       { category: "middle", label: "Middle School" },
+    //       { category: "elementary", label: "Elementary School" }
+    //     ];
 
-      return (
-        <Scatterplot
-          data={data}
-          dataKey={dataKey}
-          dataValue={dataValue}
-          dataSeries={dataSeries}
-          dataSeriesLabel={dataSeriesLabel}
-          domain={sampleDomain}
-          size={size}
-          subtitle={subtitle}
-          title={title}
-          xLabel={xLabel}
-          yLabel={yLabel}
-          invertX={invertX}
-          invertY={invertY}
-          legendComponent={customLegend}
-        />
-      );
-    });
+    //     const data = object("Data", sampleData);
+    //     const dataKey = text("dataKey", sampleXKey);
+    //     const dataValue = text("dataValue", sampleYKey);
+    //     const dataSeries = text("dataSeries", sampleDataSeries);
+    //     const dataSeriesLabel = object(
+    //       "Data Series Labels",
+    //       sampledataSeriesLabel
+    //     );
+    //     const size = object("Size", sampleSize);
+    //     const subtitle = text("Subtitle", sampleSubtitle);
+    //     const title = text("Title", sampleTitle);
+    //     const xLabel = text("xLabel", sampleXLabel);
+    //     const yLabel = text("yLabel", sampleYLabel);
+    //     const invertX = boolean("invertX", false);
+    //     const invertY = boolean("invertY", false);
+
+    //     return (
+    //       <Scatterplot
+    //         data={data}
+    //         dataKey={dataKey}
+    //         dataValue={dataValue}
+    //         dataSeries={dataSeries}
+    //         dataSeriesLabel={dataSeriesLabel}
+    //         domain={sampleDomain}
+    //         size={size}
+    //         subtitle={subtitle}
+    //         title={title}
+    //         xLabel={xLabel}
+    //         yLabel={yLabel}
+    //         invertX={invertX}
+    //         invertY={invertY}
+    //         legendComponent={customLegend}
+    //       />
+    //     );
+    //   },
+    //   {
+    //     notes
+    //   }
+    // )
+    .add(
+      "Example: Simple",
+      () => {
+        const xLabel = text("X-axis label", "X", GROUP_IDS.LABELS);
+        const yLabel = text("Y-axis label", "Y", GROUP_IDS.LABELS);
+        const sampleSimpleData = [
+          { x: 1, y: 2 },
+          { x: 2, y: 3 },
+          { x: 3, y: 5 },
+          { x: 4, y: 4 },
+          { x: 5, y: 7 },
+          { x: 1, y: 3 },
+          { x: 3, y: 3 }
+        ];
+        const data = object("Data", sampleSimpleData, GROUP_IDS.DATA);
+        return <Scatterplot data={data} xLabel={xLabel} yLabel={yLabel} />;
+      },
+      {
+        notes
+      }
+    );

--- a/packages/component-library/stories/Scatterplot.story.js
+++ b/packages/component-library/stories/Scatterplot.story.js
@@ -316,4 +316,62 @@ export default () =>
       {
         notes
       }
+    )
+    .add(
+      "Example: With negative values",
+      () => {
+        const sampleData = [
+          { x: -1.75, y: -1 },
+          { x: -1.25, y: -7 },
+          { x: -2.5, y: -2 },
+          { x: -2.35, y: -7.5 },
+          { x: -3, y: 2.5 },
+          { x: -3.5, y: 1 },
+          { x: -4.25, y: 3 },
+          { x: -4.75, y: 3.5 },
+          { x: 2.5, y: -3.5 },
+          { x: 2, y: -2.5 },
+          { x: 2.25, y: -4.5 },
+          { x: 2.5, y: -2 },
+          { x: 3.15, y: -9 },
+          { x: 3.3, y: -6.25 },
+          { x: 3.4, y: 3.5 },
+          { x: 3.75, y: 3 },
+          { x: 4.5, y: 3.5 },
+          { x: 7.75, y: 10.5 },
+          { x: 8, y: 5 },
+          { x: 3.5, y: 10.5 },
+          { x: 4.75, y: 11.5 },
+          { x: 4.5, y: 10.75 },
+          { x: 10.5, y: 26 },
+          { x: 10, y: 24 },
+          { x: 11.75, y: 23 },
+          { x: 12.6, y: 19 },
+          { x: 12.8, y: 22 },
+          { x: 13.25, y: 23 },
+          { x: 13.8, y: 26 },
+          { x: 14, y: 24 },
+          { x: 15, y: 22 },
+          { x: 16, y: 25 },
+          { x: 17, y: 25 },
+          { x: 18, y: 26 }
+        ];
+        const xLabel = text("X-axis label", "X", GROUP_IDS.LABELS);
+        const yLabel = text("Y-axis label", "Y", GROUP_IDS.LABELS);
+        // const dataKey = text("Data key", "x", GROUP_IDS.DATA);
+        // const dataValue = text("Data value", "y", GROUP_IDS.DATA);
+        const data = object("Data", sampleData, GROUP_IDS.DATA);
+        return (
+          <Scatterplot
+            data={data}
+            // dataKey={dataKey}
+            // dataValue={dataValue}
+            xLabel={xLabel}
+            yLabel={yLabel}
+          />
+        );
+      },
+      {
+        notes
+      }
     );

--- a/packages/component-library/stories/Scatterplot.story.js
+++ b/packages/component-library/stories/Scatterplot.story.js
@@ -56,7 +56,7 @@ const customLegend = legendData => {
               margin-left: 5px;
             `}
           >
-            Students
+            Experience
           </span>
         </span>
       </legend>
@@ -106,8 +106,7 @@ export default () =>
           { experience: 17, students: 25, series: "elementary" },
           { experience: 18, students: 26, series: "elementary" }
         ];
-        const sampleDataSeries = "series";
-        const sampledataSeriesLabel = [
+        const sampleDataSeriesLabel = [
           { category: "high", label: "High School" },
           { category: "middle", label: "Middle School" },
           { category: "elementary", label: "Elementary School" }
@@ -143,14 +142,10 @@ export default () =>
         );
         const dataKey = text("Data key", "experience", GROUP_IDS.DATA);
         const dataValue = text("Data value", "students", GROUP_IDS.DATA);
-        const dataSeries = text(
-          "Data series",
-          sampleDataSeries,
-          GROUP_IDS.DATA
-        );
+        const dataSeries = text("Data series", "series", GROUP_IDS.DATA);
         const dataSeriesLabel = object(
           "Data series labels",
-          sampledataSeriesLabel,
+          sampleDataSeriesLabel,
           GROUP_IDS.DATA
         );
         const data = object("Data", sampleData, GROUP_IDS.DATA);
@@ -214,8 +209,7 @@ export default () =>
           { experience: 17, students: 25, series: "elementary" },
           { experience: 18, students: 26, series: "elementary" }
         ];
-        const sampleDataSeries = "series";
-        const sampledataSeriesLabel = [
+        const sampleDataSeriesLabel = [
           { category: "high", label: "High School" },
           { category: "middle", label: "Middle School" },
           { category: "elementary", label: "Elementary School" }
@@ -252,14 +246,10 @@ export default () =>
 
         const dataKey = text("Data key", "experience", GROUP_IDS.DATA);
         const dataValue = text("Data value", "students", GROUP_IDS.DATA);
-        const dataSeries = text(
-          "Data series",
-          sampleDataSeries,
-          GROUP_IDS.DATA
-        );
+        const dataSeries = text("Data series", "series", GROUP_IDS.DATA);
         const dataSeriesLabel = object(
           "Data Series Labels",
-          sampledataSeriesLabel,
+          sampleDataSeriesLabel,
           GROUP_IDS.DATA
         );
         const data = object("Data", sampleData, GROUP_IDS.DATA);
@@ -358,18 +348,8 @@ export default () =>
         ];
         const xLabel = text("X-axis label", "X", GROUP_IDS.LABELS);
         const yLabel = text("Y-axis label", "Y", GROUP_IDS.LABELS);
-        // const dataKey = text("Data key", "x", GROUP_IDS.DATA);
-        // const dataValue = text("Data value", "y", GROUP_IDS.DATA);
         const data = object("Data", sampleData, GROUP_IDS.DATA);
-        return (
-          <Scatterplot
-            data={data}
-            // dataKey={dataKey}
-            // dataValue={dataValue}
-            xLabel={xLabel}
-            yLabel={yLabel}
-          />
-        );
+        return <Scatterplot data={data} xLabel={xLabel} yLabel={yLabel} />;
       },
       {
         notes

--- a/packages/component-library/stories/scatterplot.notes.md
+++ b/packages/component-library/stories/scatterplot.notes.md
@@ -1,0 +1,31 @@
+# Scatterplot Component
+
+## Standard
+
+The Standard story shows the standard usage of Scatterplot for the CIVIC platform; it includes standard styling. The properties that can be passed to Scatterplot are:
+
+- Title
+- Subtitle
+- X-axis label
+- X-axis value format
+- Y-axis label
+- Y-axis value format
+- Data key
+- Data value
+- Data series
+- Data series labels
+- Data
+
+## Custom
+
+The Custom story shows all possible properties that can be passed to the Scatterplot for customization. They include the properties in the Standard Scatterplot story, plus these:
+
+- xxx
+
+## Example: Simple
+
+The example Simple story shows the minimal properties needed for the Scatterplot.
+
+- X-axis label
+- Y-axis label
+- Data

--- a/packages/component-library/stories/scatterplot.notes.md
+++ b/packages/component-library/stories/scatterplot.notes.md
@@ -34,3 +34,11 @@ The example Simple story shows the minimal properties needed for the Scatterplot
 - X-axis label
 - Y-axis label
 - Data
+
+## Example: With negative values
+
+The example story with negative values shows the minimal properties needed for the Scatterplot.
+
+- X-axis label
+- Y-axis label
+- Data

--- a/packages/component-library/stories/scatterplot.notes.md
+++ b/packages/component-library/stories/scatterplot.notes.md
@@ -20,7 +20,12 @@ The Standard story shows the standard usage of Scatterplot for the CIVIC platfor
 
 The Custom story shows all possible properties that can be passed to the Scatterplot for customization. They include the properties in the Standard Scatterplot story, plus these:
 
-- xxx
+- Size
+- Domain
+- Invert X
+- Invert Y
+
+The Custom story also shows the use of a custom legend, which is a separate component.
 
 ## Example: Simple
 


### PR DESCRIPTION
This update to the Scatterplot component follows the Civic design system pattern established in #508, #553, and #565.

Working with the existing stories the following stories were created:

Standard - the common, default use of the Scatterplot component in the CIVIC platform
Custom - add knobs for all props of the Scatterplot component
Examples - examples of the component that show non-standard, but useful, configurations of the component:
The simple story shows only the most basic props.

A notes file was added; it describes each story and list the props/knobs that can be changed.