### PR TITLE
Storybook Slider bug: The slider in storybook is not responding to value changes

### DIFF
--- a/packages/component-library/stories/Slider.story.js
+++ b/packages/component-library/stories/Slider.story.js
@@ -22,7 +22,7 @@ const basicSlider = () => {
               action("onChange")(value);
             }}
             step={number("step", 10)}
-            value={number("value", get("value"))}
+            value={get("value")}
           />
         );
       }}


### PR DESCRIPTION
The slider updates work in storybook when running locally, but the deployed version is not responding to changes to the value.

It's hard to know what will fix it since I can't reproduce the bug locally, but since the <StatefulWrapper /> is still responding to value changes but the component value knob isn't, testing if removing value knob will allow the slider to respond to the value change.