### PR TITLE
Bugfix: Stop using a knob for the value of controlled components

### DIFF
--- a/packages/component-library/src/utils/StatefulWrapper.js
+++ b/packages/component-library/src/utils/StatefulWrapper.js
@@ -18,6 +18,9 @@ import { func, shape } from "prop-types";
  *      );
  *    }}
  *  </StatefulWrapper>
+ *
+ * ⚠️ Do not set `value` as a knob when using this wrapper, it causes issues with
+ * Civic's deployed version of Storybook that you will not see locally ⚠️
  */
 class StatefulWrapper extends Component {
   static propTypes = {

--- a/packages/component-library/stories/Slider.story.js
+++ b/packages/component-library/stories/Slider.story.js
@@ -22,7 +22,7 @@ const basicSlider = () => {
               action("onChange")(value);
             }}
             step={number("step", 10)}
-            value={number("value", get("value"))}
+            value={get("value")}
           />
         );
       }}


### PR DESCRIPTION
The test fix I tried for fixing the slider story worked, so this is also removing the value knob from the other slider story. I also added a comment to the StatefulWrapper to avoid this from happening again