### PR TITLE
39 yarn bootstrap includes build comp lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,17 @@ $ cd civic
 # Sets your Node.js version to match what the project uses.
 $ nvm use
 
-# Note for next two steps, if you get an error, keep trying the same command again.
-
 # Installs all package dependencies and links cross-dependencies.
+# Also builds the component library
+$ yarn bootstrap
+
+# This can take a while (approximately 5mins), so grab some coffee☕️, tea🍵 or another beverage of your choosing.
+
+# If you're getting an error like this one: "Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`",
+# you may consider running
 $ yarn install
-
-# This will build all packages. Since some packages are used internally, they need to be built before the dependent packages are worked on.
-$ yarn build
-
-# Take a pizza break! 🍕! This takes a while, but only needs to run at the project root once.
+# and then
+$ yarn bootstrap
 ```
 
 ## Setting up your text editor

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "private": true,
   "scripts": {
-    "bootstrap": "yarn install --frozen-lockfile",
+    "bootstrap": "yarn install --frozen-lockfile && yarn --cwd ./packages/component-library/ build",
     "build": "lerna run build",
     "configure": "lerna run configure",
     "publish-patch": "lerna publish bump patch --yes",


### PR DESCRIPTION
I update the bootstrap script on in the root folder to build only the component-library, but not the other packages.
Link to the issue below:
[Incorporate yarn build into yarn bootstrap #39](https://github.com/hackoregon/civic/issues/39)
