### PR TITLE
StackedAreaChart Stories

### DIFF
--- a/packages/component-library/stories/StackedAreaChart.story.js
+++ b/packages/component-library/stories/StackedAreaChart.story.js
@@ -6,7 +6,6 @@ import { storiesOf } from "@storybook/react";
 import {
   object,
   text,
-  array,
   withKnobs,
   optionsKnob as options
 } from "@storybook/addon-knobs";
@@ -242,23 +241,11 @@ export default () =>
         );
 
         const dataKey = text("Data key", "year", GROUP_IDS.DATA);
-        // const dataKeyLabel = text("Data key label", "Year", GROUP_IDS.CUSTOM);
-        const dataKeyLabel = array(
-          "Data key label",
-          ["Year"],
-          ",",
-          GROUP_IDS.CUSTOM
-        );
+        const dataKeyLabel = text("Data key label", "Year", GROUP_IDS.CUSTOM);
         const dataValue = text("Data value", "students", GROUP_IDS.DATA);
-        // const dataValueLabel = text(
-        //   "Data value label",
-        //   "Enrolled students",
-        //   GROUP_IDS.CUSTOM
-        // );
-        const dataValueLabel = array(
+        const dataValueLabel = text(
           "Data value label",
-          ["Enrolled students"],
-          ",",
+          "Enrolled students",
           GROUP_IDS.CUSTOM
         );
         const dataSeries = text(

--- a/packages/component-library/stories/StackedAreaChart.story.js
+++ b/packages/component-library/stories/StackedAreaChart.story.js
@@ -1,14 +1,17 @@
 import React from "react";
 import { css } from "emotion";
+
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
 import {
   object,
   text,
+  array,
   withKnobs,
   optionsKnob as options
 } from "@storybook/addon-knobs";
-import { StackedAreaChart, SimpleLegend, civicFormat } from "../src";
+import { StackedAreaChart, civicFormat, SimpleLegend } from "../src";
+import { getKeyNames } from "./shared";
 import notes from "./stackedAreaChart.notes.md";
 
 const GROUP_IDS = {
@@ -19,51 +22,6 @@ const GROUP_IDS = {
 
 const xFormatterOptions = getKeyNames(civicFormat);
 const yFormatterOptions = getKeyNames(civicFormat);
-
-const sampleData = [
-  { x: 0, y: 2, series: "cat" },
-  { x: 1, y: 3, series: "cat" },
-  { x: 2, y: 5, series: "cat" },
-  { x: 3, y: 4, series: "cat" },
-  { x: 4, y: 7, series: "cat" },
-  { x: 0, y: 4, series: "dog" },
-  { x: 1, y: 5, series: "dog" },
-  { x: 2, y: 2, series: "dog" },
-  { x: 3, y: 3, series: "dog" },
-  { x: 4, y: 4, series: "dog" }
-];
-const sampleDataSeries = "series";
-const sampledataSeriesLabel = [
-  { category: "cat", label: "Cat" },
-  { category: "dog", label: "Dog" }
-];
-const sampleDomain = { x: [0, 6], y: [0, 8] };
-const sampleSize = { key: "y" };
-const sampleSubtitle = "A description of this chart.";
-const sampleTitle = "Some title";
-const sampleXKey = "x";
-const sampleXLabel = "Number of animals";
-const sampleYKey = "y";
-const sampleYLabel = "Cuteness rating";
-const sampleDataKeyLabel = "Animals";
-const sampleDataValueLabel = "Cuteness";
-
-const sampleUnstructuredData = [
-  { size: 0, age: 2000000, group: "cat" },
-  { size: 5, age: 3000000, group: "cat" },
-  { size: 10, age: 7000000, group: "cat" },
-  { size: 0, age: 5000320, group: "fish" },
-  { size: 5, age: 40002300, group: "fish" },
-  { size: 10, age: 5007000, group: "fish" },
-  { size: 0, age: 3000000, group: "dog" },
-  { size: 5, age: 3000500, group: "dog" },
-  { size: 10, age: 3000000.5, group: "dog" }
-];
-const sampleUnstructuredXKey = "year";
-const sampleUnstructuredYKey = "students";
-const sampleUnstructuredDataSeries = "group";
-const sampleUnstructuredXLabel = "Size (ft)";
-const sampleUnstructuredYLabel = "Age (yrs)";
 
 const customLegend = legendData => {
   const legendStyle = css`
@@ -101,7 +59,7 @@ const customLegend = legendData => {
               margin-left: 5px;
             `}
           >
-            Population
+            Students
           </span>
         </span>
       </legend>
@@ -113,6 +71,46 @@ export default () =>
   storiesOf("Component Lib|Charts/Stacked Area Chart", module)
     .addDecorator(withKnobs)
     .add("Standard", () => {
+      const sampleEnrollmentData = [
+        { year: 2005, students: 34, group: "BAA" },
+        { year: 2006, students: 28, group: "BAA" },
+        { year: 2007, students: 17, group: "BAA" },
+        { year: 2008, students: 18, group: "BAA" },
+        { year: 2009, students: 14, group: "BAA" },
+        { year: 2010, students: 23, group: "BAA" },
+        { year: 2011, students: 21, group: "BAA" },
+        { year: 2012, students: 17, group: "BAA" },
+        { year: 2013, students: 19, group: "BAA" },
+        { year: 2014, students: 16, group: "BAA" },
+
+        { year: 2005, students: 34, group: "HIS" },
+        { year: 2006, students: 28, group: "HIS" },
+        { year: 2007, students: 24, group: "HIS" },
+        { year: 2008, students: 24, group: "HIS" },
+        { year: 2009, students: 37, group: "HIS" },
+        { year: 2010, students: 37, group: "HIS" },
+        { year: 2011, students: 44, group: "HIS" },
+        { year: 2012, students: 42, group: "HIS" },
+        { year: 2013, students: 48, group: "HIS" },
+        { year: 2014, students: 45, group: "HIS" },
+
+        { year: 2005, students: 0, group: "MULTI" },
+        { year: 2006, students: 0, group: "MULTI" },
+        { year: 2007, students: 28, group: "MULTI" },
+        { year: 2008, students: 41, group: "MULTI" },
+        { year: 2009, students: 23, group: "MULTI" },
+        { year: 2010, students: 42, group: "MULTI" },
+        { year: 2011, students: 54, group: "MULTI" },
+        { year: 2012, students: 55, group: "MULTI" },
+        { year: 2013, students: 56, group: "MULTI" },
+        { year: 2014, students: 59, group: "MULTI" }
+      ];
+      const enrollmentDataSeries = "group";
+      const enrollmentDataSeriesLabels = [
+        { category: "BAA", label: "Black/African American" },
+        { category: "HIS", label: "Hispanic/Latino" },
+        { category: "MULTI", label: "Multi-Ethnic" }
+      ];
       const title = text(
         "Title:",
         "Students from Historically Underrepresented Groups",
@@ -135,27 +133,23 @@ export default () =>
       const optionSelectY = options(
         "Y-axis value format",
         yFormatterOptions,
-        "students",
+        "numeric",
         { display: "select" },
         GROUP_IDS.LABELS
       );
-      const sampleEnrollmentData = [
-        { year: 0, students: 2000000, group: "cat" },
-        { year: 5, students: 3000000, group: "cat" },
-        { year: 10, students: 7000000, group: "cat" },
-        { year: 0, students: 5000320, group: "fish" },
-        { year: 5, students: 40002300, group: "fish" },
-        { year: 10, students: 5007000, group: "fish" },
-        { year: 0, students: 3000000, group: "dog" },
-        { year: 5, students: 3000500, group: "dog" },
-        { year: 10, students: 3000000.5, group: "dog" }
-      ];
-      // const sampleUnstructuredXKey = "year";
-      // const sampleUnstructuredYKey = "students";
-      // const sampleUnstructuredDataSeries = "group";
-      const dataKey = text("dataKey", "year", GROUP_IDS.DATA);
-      const dataValue = text("dataValue", "students", GROUP_IDS.DATA);
-      const dataSeries = text("dataSeries", "group", GROUP_IDS.DATA);
+
+      const dataKey = text("Data key", "year", GROUP_IDS.DATA);
+      const dataValue = text("Data value", "students", GROUP_IDS.DATA);
+      const dataSeries = text(
+        "Data series",
+        enrollmentDataSeries,
+        GROUP_IDS.DATA
+      );
+      const dataSeriesLabel = object(
+        "Data series labels:",
+        enrollmentDataSeriesLabels,
+        GROUP_IDS.DATA
+      );
       const data = object("Data", sampleEnrollmentData, GROUP_IDS.DATA);
 
       return (
@@ -164,6 +158,7 @@ export default () =>
           dataKey={dataKey}
           dataValue={dataValue}
           dataSeries={dataSeries}
+          dataSeriesLabel={dataSeriesLabel}
           subtitle={subtitle}
           title={title}
           xLabel={xLabel}
@@ -173,66 +168,138 @@ export default () =>
         />
       );
     })
-    .add("With some props and unstructured data", () => {
-      const data = object("Data", sampleUnstructuredData);
-      const dataKey = text("dataKey", sampleUnstructuredXKey);
-      const dataValue = text("dataValue", sampleUnstructuredYKey);
-      const dataSeries = text("dataSeries", sampleUnstructuredDataSeries);
-      const subtitle = text("Subtitle", sampleSubtitle);
-      const title = text("Title", sampleTitle);
-      const xLabel = text("xLabel", sampleUnstructuredXLabel);
-      const yLabel = text("yLabel", sampleUnstructuredYLabel);
+    .add(
+      "Custom",
+      () => {
+        const sampleEnrollmentData = [
+          { year: 2005, students: 34, group: "BAA" },
+          { year: 2006, students: 28, group: "BAA" },
+          { year: 2007, students: 17, group: "BAA" },
+          { year: 2008, students: 18, group: "BAA" },
+          { year: 2009, students: 14, group: "BAA" },
+          { year: 2010, students: 23, group: "BAA" },
+          { year: 2011, students: 21, group: "BAA" },
+          { year: 2012, students: 17, group: "BAA" },
+          { year: 2013, students: 19, group: "BAA" },
+          { year: 2014, students: 16, group: "BAA" },
 
-      return (
-        <StackedAreaChart
-          data={data}
-          dataKey={dataKey}
-          dataValue={dataValue}
-          dataSeries={dataSeries}
-          subtitle={subtitle}
-          title={title}
-          xLabel={xLabel}
-          yLabel={yLabel}
-        />
-      );
-    })
-    .add("With more optional props", () => {
-      const data = object("Data", sampleData);
-      const dataKey = text("dataKey", sampleXKey);
-      const dataKeyLabel = text("dataKeyLabel", sampleDataKeyLabel);
-      const dataValue = text("dataValue", sampleYKey);
-      const dataValueLabel = text("dataValueLabel", sampleDataValueLabel);
-      const dataSeries = text("dataSeries", sampleDataSeries);
-      const dataSeriesLabel = object(
-        "Data Series Labels",
-        sampledataSeriesLabel
-      );
-      const domain = object("Domain", sampleDomain);
-      const size = object("Size", sampleSize);
-      const subtitle = text("Subtitle", sampleSubtitle);
-      const title = text("Title", sampleTitle);
-      const xLabel = text("xLabel", sampleXLabel);
-      const yLabel = text("yLabel", sampleYLabel);
+          { year: 2005, students: 34, group: "HIS" },
+          { year: 2006, students: 28, group: "HIS" },
+          { year: 2007, students: 24, group: "HIS" },
+          { year: 2008, students: 24, group: "HIS" },
+          { year: 2009, students: 37, group: "HIS" },
+          { year: 2010, students: 37, group: "HIS" },
+          { year: 2011, students: 44, group: "HIS" },
+          { year: 2012, students: 42, group: "HIS" },
+          { year: 2013, students: 48, group: "HIS" },
+          { year: 2014, students: 45, group: "HIS" },
 
-      return (
-        <StackedAreaChart
-          data={data}
-          dataKey={dataKey}
-          dataKeyLabel={dataKeyLabel}
-          dataValue={dataValue}
-          dataValueLabel={dataValueLabel}
-          dataSeries={dataSeries}
-          dataSeriesLabel={dataSeriesLabel}
-          domain={domain}
-          size={size}
-          subtitle={subtitle}
-          title={title}
-          xLabel={xLabel}
-          yLabel={yLabel}
-          legendComponent={customLegend}
-        />
-      );
-    })
+          { year: 2005, students: 0, group: "MULTI" },
+          { year: 2006, students: 0, group: "MULTI" },
+          { year: 2007, students: 28, group: "MULTI" },
+          { year: 2008, students: 41, group: "MULTI" },
+          { year: 2009, students: 23, group: "MULTI" },
+          { year: 2010, students: 42, group: "MULTI" },
+          { year: 2011, students: 54, group: "MULTI" },
+          { year: 2012, students: 55, group: "MULTI" },
+          { year: 2013, students: 56, group: "MULTI" },
+          { year: 2014, students: 59, group: "MULTI" }
+        ];
+        const enrollmentDataSeries = "group";
+        const enrollmentDataSeriesLabels = [
+          { category: "BAA", label: "Black/African American" },
+          { category: "HIS", label: "Hispanic/Latino" },
+          { category: "MULTI", label: "Multi-Ethnic" }
+        ];
+        const sampleDomain = { x: [2005, 2014], y: [0, 125] };
+        // const sampleSize = { key: "y" };
+
+        const title = text(
+          "Title:",
+          "Students from Historically Underrepresented Groups",
+          GROUP_IDS.LABELS
+        );
+        const subtitle = text(
+          "Subtitle",
+          "Fall enrollment in Portland Public Schools - Buckman",
+          GROUP_IDS.LABELS
+        );
+        const xLabel = text("X-axis label:", "Year", GROUP_IDS.LABELS);
+        const optionSelectX = options(
+          "X-axis value format",
+          xFormatterOptions,
+          "year",
+          { display: "select" },
+          GROUP_IDS.LABELS
+        );
+        const yLabel = text("Y-axis label:", "Students", GROUP_IDS.LABELS);
+        const optionSelectY = options(
+          "Y-axis value format",
+          yFormatterOptions,
+          "numeric",
+          { display: "select" },
+          GROUP_IDS.LABELS
+        );
+
+        const dataKey = text("Data key", "year", GROUP_IDS.DATA);
+        // const dataKeyLabel = text("Data key label", "Year", GROUP_IDS.CUSTOM);
+        const dataKeyLabel = array(
+          "Data key label",
+          ["Year"],
+          ",",
+          GROUP_IDS.CUSTOM
+        );
+        const dataValue = text("Data value", "students", GROUP_IDS.DATA);
+        // const dataValueLabel = text(
+        //   "Data value label",
+        //   "Enrolled students",
+        //   GROUP_IDS.CUSTOM
+        // );
+        const dataValueLabel = array(
+          "Data value label",
+          ["Enrolled students"],
+          ",",
+          GROUP_IDS.CUSTOM
+        );
+        const dataSeries = text(
+          "Data series",
+          enrollmentDataSeries,
+          GROUP_IDS.DATA
+        );
+        const dataSeriesLabel = object(
+          "Data series labels:",
+          enrollmentDataSeriesLabels,
+          GROUP_IDS.DATA
+        );
+        const data = object("Data", sampleEnrollmentData, GROUP_IDS.DATA);
+
+        const domain = object("Domain", sampleDomain, GROUP_IDS.CUSTOM);
+        // A separate issue will be created for the size knob.
+        // const size = object("Size", sampleSize, GROUP_IDS.CUSTOM);
+
+        return (
+          <StackedAreaChart
+            data={data}
+            dataKey={dataKey}
+            dataKeyLabel={dataKeyLabel}
+            dataValue={dataValue}
+            dataValueLabel={dataValueLabel}
+            dataSeries={dataSeries}
+            dataSeriesLabel={dataSeriesLabel}
+            domain={domain}
+            // size={size}
+            subtitle={subtitle}
+            title={title}
+            xLabel={xLabel}
+            yLabel={yLabel}
+            xNumberFormatter={x => civicFormat[optionSelectX](x)}
+            yNumberFormatter={y => civicFormat[optionSelectY](y)}
+            legendComponent={customLegend}
+          />
+        );
+      },
+      { notes }
+    )
     .add(
       "Example: Simple",
       () => {
@@ -246,7 +313,7 @@ export default () =>
         ];
         const data = object("Data", sampleSimpleData, GROUP_IDS.DATA);
 
-        return <StackedAreaChart data={data} />;
+        return <StackedAreaChart data={data} xLabel={xLabel} yLabel={yLabel} />;
       },
       { notes }
     );

--- a/packages/component-library/stories/StackedAreaChart.story.js
+++ b/packages/component-library/stories/StackedAreaChart.story.js
@@ -119,7 +119,7 @@ export default () =>
         );
         const subtitle = text(
           "Subtitle",
-          "Fall enrollment in Portland Public Schools - Buckman",
+          "Fall enrollment in Portland Public Schools - Buckman, using selected Census categories",
           GROUP_IDS.LABELS
         );
         const xLabel = text("X-axis label:", "Year", GROUP_IDS.LABELS);
@@ -224,7 +224,7 @@ export default () =>
         );
         const subtitle = text(
           "Subtitle",
-          "Fall enrollment in Portland Public Schools - Buckman",
+          "Fall enrollment in Portland Public Schools - Buckman, using selected Census categories",
           GROUP_IDS.LABELS
         );
         const xLabel = text("X-axis label:", "Year", GROUP_IDS.LABELS);

--- a/packages/component-library/stories/StackedAreaChart.story.js
+++ b/packages/component-library/stories/StackedAreaChart.story.js
@@ -69,104 +69,108 @@ const customLegend = legendData => {
 export default () =>
   storiesOf("Component Lib|Charts/Stacked Area Chart", module)
     .addDecorator(withKnobs)
-    .add("Standard", () => {
-      const sampleEnrollmentData = [
-        { year: 2005, students: 34, group: "BAA" },
-        { year: 2006, students: 28, group: "BAA" },
-        { year: 2007, students: 17, group: "BAA" },
-        { year: 2008, students: 18, group: "BAA" },
-        { year: 2009, students: 14, group: "BAA" },
-        { year: 2010, students: 23, group: "BAA" },
-        { year: 2011, students: 21, group: "BAA" },
-        { year: 2012, students: 17, group: "BAA" },
-        { year: 2013, students: 19, group: "BAA" },
-        { year: 2014, students: 16, group: "BAA" },
+    .add(
+      "Standard",
+      () => {
+        const sampleEnrollmentData = [
+          { year: 2005, students: 34, group: "BAA" },
+          { year: 2006, students: 28, group: "BAA" },
+          { year: 2007, students: 17, group: "BAA" },
+          { year: 2008, students: 18, group: "BAA" },
+          { year: 2009, students: 14, group: "BAA" },
+          { year: 2010, students: 23, group: "BAA" },
+          { year: 2011, students: 21, group: "BAA" },
+          { year: 2012, students: 17, group: "BAA" },
+          { year: 2013, students: 19, group: "BAA" },
+          { year: 2014, students: 16, group: "BAA" },
 
-        { year: 2005, students: 34, group: "HIS" },
-        { year: 2006, students: 28, group: "HIS" },
-        { year: 2007, students: 24, group: "HIS" },
-        { year: 2008, students: 24, group: "HIS" },
-        { year: 2009, students: 37, group: "HIS" },
-        { year: 2010, students: 37, group: "HIS" },
-        { year: 2011, students: 44, group: "HIS" },
-        { year: 2012, students: 42, group: "HIS" },
-        { year: 2013, students: 48, group: "HIS" },
-        { year: 2014, students: 45, group: "HIS" },
+          { year: 2005, students: 34, group: "HIS" },
+          { year: 2006, students: 28, group: "HIS" },
+          { year: 2007, students: 24, group: "HIS" },
+          { year: 2008, students: 24, group: "HIS" },
+          { year: 2009, students: 37, group: "HIS" },
+          { year: 2010, students: 37, group: "HIS" },
+          { year: 2011, students: 44, group: "HIS" },
+          { year: 2012, students: 42, group: "HIS" },
+          { year: 2013, students: 48, group: "HIS" },
+          { year: 2014, students: 45, group: "HIS" },
 
-        { year: 2005, students: 0, group: "MULTI" },
-        { year: 2006, students: 0, group: "MULTI" },
-        { year: 2007, students: 28, group: "MULTI" },
-        { year: 2008, students: 41, group: "MULTI" },
-        { year: 2009, students: 23, group: "MULTI" },
-        { year: 2010, students: 42, group: "MULTI" },
-        { year: 2011, students: 54, group: "MULTI" },
-        { year: 2012, students: 55, group: "MULTI" },
-        { year: 2013, students: 56, group: "MULTI" },
-        { year: 2014, students: 59, group: "MULTI" }
-      ];
-      const enrollmentDataSeries = "group";
-      const enrollmentDataSeriesLabels = [
-        { category: "BAA", label: "Black/African American" },
-        { category: "HIS", label: "Hispanic/Latino" },
-        { category: "MULTI", label: "Multi-Ethnic" }
-      ];
-      const title = text(
-        "Title:",
-        "Students from Historically Underrepresented Groups",
-        GROUP_IDS.LABELS
-      );
-      const subtitle = text(
-        "Subtitle",
-        "Fall enrollment in Portland Public Schools - Buckman",
-        GROUP_IDS.LABELS
-      );
-      const xLabel = text("X-axis label:", "Year", GROUP_IDS.LABELS);
-      const optionSelectX = options(
-        "X-axis value format",
-        xFormatterOptions,
-        "year",
-        { display: "select" },
-        GROUP_IDS.LABELS
-      );
-      const yLabel = text("Y-axis label:", "Students", GROUP_IDS.LABELS);
-      const optionSelectY = options(
-        "Y-axis value format",
-        yFormatterOptions,
-        "numeric",
-        { display: "select" },
-        GROUP_IDS.LABELS
-      );
+          { year: 2005, students: 0, group: "MULTI" },
+          { year: 2006, students: 0, group: "MULTI" },
+          { year: 2007, students: 28, group: "MULTI" },
+          { year: 2008, students: 41, group: "MULTI" },
+          { year: 2009, students: 23, group: "MULTI" },
+          { year: 2010, students: 42, group: "MULTI" },
+          { year: 2011, students: 54, group: "MULTI" },
+          { year: 2012, students: 55, group: "MULTI" },
+          { year: 2013, students: 56, group: "MULTI" },
+          { year: 2014, students: 59, group: "MULTI" }
+        ];
+        const enrollmentDataSeries = "group";
+        const enrollmentDataSeriesLabels = [
+          { category: "BAA", label: "Black/African American" },
+          { category: "HIS", label: "Hispanic/Latino" },
+          { category: "MULTI", label: "Multi-Ethnic" }
+        ];
+        const title = text(
+          "Title:",
+          "Students from Historically Underrepresented Groups",
+          GROUP_IDS.LABELS
+        );
+        const subtitle = text(
+          "Subtitle",
+          "Fall enrollment in Portland Public Schools - Buckman",
+          GROUP_IDS.LABELS
+        );
+        const xLabel = text("X-axis label:", "Year", GROUP_IDS.LABELS);
+        const optionSelectX = options(
+          "X-axis value format",
+          xFormatterOptions,
+          "year",
+          { display: "select" },
+          GROUP_IDS.LABELS
+        );
+        const yLabel = text("Y-axis label:", "Students", GROUP_IDS.LABELS);
+        const optionSelectY = options(
+          "Y-axis value format",
+          yFormatterOptions,
+          "numeric",
+          { display: "select" },
+          GROUP_IDS.LABELS
+        );
 
-      const dataKey = text("Data key", "year", GROUP_IDS.DATA);
-      const dataValue = text("Data value", "students", GROUP_IDS.DATA);
-      const dataSeries = text(
-        "Data series",
-        enrollmentDataSeries,
-        GROUP_IDS.DATA
-      );
-      const dataSeriesLabel = object(
-        "Data series labels:",
-        enrollmentDataSeriesLabels,
-        GROUP_IDS.DATA
-      );
-      const data = object("Data", sampleEnrollmentData, GROUP_IDS.DATA);
+        const dataKey = text("Data key", "year", GROUP_IDS.DATA);
+        const dataValue = text("Data value", "students", GROUP_IDS.DATA);
+        const dataSeries = text(
+          "Data series",
+          enrollmentDataSeries,
+          GROUP_IDS.DATA
+        );
+        const dataSeriesLabel = object(
+          "Data series labels:",
+          enrollmentDataSeriesLabels,
+          GROUP_IDS.DATA
+        );
+        const data = object("Data", sampleEnrollmentData, GROUP_IDS.DATA);
 
-      return (
-        <StackedAreaChart
-          data={data}
-          dataKey={dataKey}
-          dataValue={dataValue}
-          dataSeries={dataSeries}
-          dataSeriesLabel={dataSeriesLabel}
-          subtitle={subtitle}
-          title={title}
-          xLabel={xLabel}
-          yLabel={yLabel}
-          xNumberFormatter={x => civicFormat[optionSelectX](x)}
-          yNumberFormatter={y => civicFormat[optionSelectY](y)}
-        />
-      );
-    })
+        return (
+          <StackedAreaChart
+            data={data}
+            dataKey={dataKey}
+            dataValue={dataValue}
+            dataSeries={dataSeries}
+            dataSeriesLabel={dataSeriesLabel}
+            subtitle={subtitle}
+            title={title}
+            xLabel={xLabel}
+            yLabel={yLabel}
+            xNumberFormatter={x => civicFormat[optionSelectX](x)}
+            yNumberFormatter={y => civicFormat[optionSelectY](y)}
+          />
+        );
+      },
+      { notes }
+    )
     .add(
       "Custom",
       () => {

--- a/packages/component-library/stories/StackedAreaChart.story.js
+++ b/packages/component-library/stories/StackedAreaChart.story.js
@@ -241,13 +241,7 @@ export default () =>
         );
 
         const dataKey = text("Data key", "year", GROUP_IDS.DATA);
-        const dataKeyLabel = text("Data key label", "Year", GROUP_IDS.CUSTOM);
         const dataValue = text("Data value", "students", GROUP_IDS.DATA);
-        const dataValueLabel = text(
-          "Data value label",
-          "Enrolled students",
-          GROUP_IDS.CUSTOM
-        );
         const dataSeries = text(
           "Data series",
           enrollmentDataSeries,
@@ -261,20 +255,15 @@ export default () =>
         const data = object("Data", sampleEnrollmentData, GROUP_IDS.DATA);
 
         const domain = object("Domain", sampleDomain, GROUP_IDS.CUSTOM);
-        // A separate issue will be created for the size knob.
-        // const size = object("Size", sampleSize, GROUP_IDS.CUSTOM);
 
         return (
           <StackedAreaChart
             data={data}
             dataKey={dataKey}
-            dataKeyLabel={dataKeyLabel}
             dataValue={dataValue}
-            dataValueLabel={dataValueLabel}
             dataSeries={dataSeries}
             dataSeriesLabel={dataSeriesLabel}
             domain={domain}
-            // size={size}
             subtitle={subtitle}
             title={title}
             xLabel={xLabel}

--- a/packages/component-library/stories/StackedAreaChart.story.js
+++ b/packages/component-library/stories/StackedAreaChart.story.js
@@ -2,15 +2,23 @@ import React from "react";
 import { css } from "emotion";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-import { object, text, withKnobs } from "@storybook/addon-knobs";
-import { StackedAreaChart, SimpleLegend } from "../src";
+import {
+  object,
+  text,
+  withKnobs,
+  optionsKnob as options
+} from "@storybook/addon-knobs";
+import { StackedAreaChart, SimpleLegend, civicFormat } from "../src";
+import notes from "./stackedAreaChart.notes.md";
 
-const sampleSimpleData = [
-  { x: 0, y: 20 },
-  { x: 10, y: 30 },
-  { x: 20, y: 50 },
-  { x: 30, y: 40 }
-];
+const GROUP_IDS = {
+  LABELS: "Labels",
+  DATA: "Data",
+  CUSTOM: "Custom"
+};
+
+const xFormatterOptions = getKeyNames(civicFormat);
+const yFormatterOptions = getKeyNames(civicFormat);
 
 const sampleData = [
   { x: 0, y: 2, series: "cat" },
@@ -41,19 +49,19 @@ const sampleDataKeyLabel = "Animals";
 const sampleDataValueLabel = "Cuteness";
 
 const sampleUnstructuredData = [
-  { size: 0, age: 2000000, type: "cat" },
-  { size: 5, age: 3000000, type: "cat" },
-  { size: 10, age: 7000000, type: "cat" },
-  { size: 0, age: 5000320, type: "fish" },
-  { size: 5, age: 40002300, type: "fish" },
-  { size: 10, age: 5007000, type: "fish" },
-  { size: 0, age: 3000000, type: "dog" },
-  { size: 5, age: 3000500, type: "dog" },
-  { size: 10, age: 3000000.5, type: "dog" }
+  { size: 0, age: 2000000, group: "cat" },
+  { size: 5, age: 3000000, group: "cat" },
+  { size: 10, age: 7000000, group: "cat" },
+  { size: 0, age: 5000320, group: "fish" },
+  { size: 5, age: 40002300, group: "fish" },
+  { size: 10, age: 5007000, group: "fish" },
+  { size: 0, age: 3000000, group: "dog" },
+  { size: 5, age: 3000500, group: "dog" },
+  { size: 10, age: 3000000.5, group: "dog" }
 ];
-const sampleUnstructuredXKey = "size";
-const sampleUnstructuredYKey = "age";
-const sampleUnstructuredDataSeries = "type";
+const sampleUnstructuredXKey = "year";
+const sampleUnstructuredYKey = "students";
+const sampleUnstructuredDataSeries = "group";
 const sampleUnstructuredXLabel = "Size (ft)";
 const sampleUnstructuredYLabel = "Age (yrs)";
 
@@ -104,16 +112,51 @@ const customLegend = legendData => {
 export default () =>
   storiesOf("Component Lib|Charts/Stacked Area Chart", module)
     .addDecorator(withKnobs)
-    .add("Simple usage", () => <StackedAreaChart data={sampleSimpleData} />)
-    .add("With some props", () => {
-      const data = object("Data", sampleData);
-      const dataKey = text("dataKey", sampleXKey);
-      const dataValue = text("dataValue", sampleYKey);
-      const dataSeries = text("dataSeries", sampleDataSeries);
-      const subtitle = text("Subtitle", sampleSubtitle);
-      const title = text("Title", sampleTitle);
-      const xLabel = text("xLabel", sampleXLabel);
-      const yLabel = text("yLabel", sampleYLabel);
+    .add("Standard", () => {
+      const title = text(
+        "Title:",
+        "Students from Historically Underrepresented Groups",
+        GROUP_IDS.LABELS
+      );
+      const subtitle = text(
+        "Subtitle",
+        "Fall enrollment in Portland Public Schools - Buckman",
+        GROUP_IDS.LABELS
+      );
+      const xLabel = text("X-axis label:", "Year", GROUP_IDS.LABELS);
+      const optionSelectX = options(
+        "X-axis value format",
+        xFormatterOptions,
+        "year",
+        { display: "select" },
+        GROUP_IDS.LABELS
+      );
+      const yLabel = text("Y-axis label:", "Students", GROUP_IDS.LABELS);
+      const optionSelectY = options(
+        "Y-axis value format",
+        yFormatterOptions,
+        "students",
+        { display: "select" },
+        GROUP_IDS.LABELS
+      );
+      const sampleEnrollmentData = [
+        { year: 0, students: 2000000, group: "cat" },
+        { year: 5, students: 3000000, group: "cat" },
+        { year: 10, students: 7000000, group: "cat" },
+        { year: 0, students: 5000320, group: "fish" },
+        { year: 5, students: 40002300, group: "fish" },
+        { year: 10, students: 5007000, group: "fish" },
+        { year: 0, students: 3000000, group: "dog" },
+        { year: 5, students: 3000500, group: "dog" },
+        { year: 10, students: 3000000.5, group: "dog" }
+      ];
+      // const sampleUnstructuredXKey = "year";
+      // const sampleUnstructuredYKey = "students";
+      // const sampleUnstructuredDataSeries = "group";
+      const dataKey = text("dataKey", "year", GROUP_IDS.DATA);
+      const dataValue = text("dataValue", "students", GROUP_IDS.DATA);
+      const dataSeries = text("dataSeries", "group", GROUP_IDS.DATA);
+      const data = object("Data", sampleEnrollmentData, GROUP_IDS.DATA);
 
       return (
         <StackedAreaChart
@@ -125,6 +168,8 @@ export default () =>
           title={title}
           xLabel={xLabel}
           yLabel={yLabel}
+          xNumberFormatter={x => civicFormat[optionSelectX](x)}
+          yNumberFormatter={y => civicFormat[optionSelectY](y)}
         />
       );
     })
@@ -187,4 +232,21 @@ export default () =>
           legendComponent={customLegend}
         />
       );
-    });
+    })
+    .add(
+      "Example: Simple",
+      () => {
+        const xLabel = text("X-axis label:", "X", GROUP_IDS.LABELS);
+        const yLabel = text("Y-axis label:", "Y", GROUP_IDS.LABELS);
+        const sampleSimpleData = [
+          { x: 0, y: 20 },
+          { x: 10, y: 30 },
+          { x: 20, y: 50 },
+          { x: 30, y: 40 }
+        ];
+        const data = object("Data", sampleSimpleData, GROUP_IDS.DATA);
+
+        return <StackedAreaChart data={data} />;
+      },
+      { notes }
+    );

--- a/packages/component-library/stories/stackedAreaChart.notes.md
+++ b/packages/component-library/stories/stackedAreaChart.notes.md
@@ -1,0 +1,17 @@
+# StackedAreaChart Component
+
+## Standard
+
+The Standard story shows the standard usage of the StackedAreaChart for the CIVIC platform. StackedAreaChart includes standard styling.
+
+These properties can be set in the Standard story:
+
+- Title
+
+## Custom
+
+The Custom story shows all possible properties that can be passed to the StackedAreaChart component for customization. Three additional properties are added to the properties listed in the Standard story.
+
+## Simple
+
+The example Simple story shows the minimal properties needed for the LineChart.

--- a/packages/component-library/stories/stackedAreaChart.notes.md
+++ b/packages/component-library/stories/stackedAreaChart.notes.md
@@ -7,11 +7,28 @@ The Standard story shows the standard usage of the StackedAreaChart for the CIVI
 These properties can be set in the Standard story:
 
 - Title
+- Subtitle
+- X-axis label
+- X-axis value format
+- Y-axis label
+- Y-axis value format
+- Data key
+- Data value
+- Data series
+- Data series labels
 
 ## Custom
 
 The Custom story shows all possible properties that can be passed to the StackedAreaChart component for customization. Three additional properties are added to the properties listed in the Standard story.
 
+- Data key label
+- Data value label
+- Domain
+
 ## Simple
 
 The example Simple story shows the minimal properties needed for the LineChart.
+
+- X-axis label
+- Y-axis label
+- Data

--- a/packages/component-library/stories/stackedAreaChart.notes.md
+++ b/packages/component-library/stories/stackedAreaChart.notes.md
@@ -21,8 +21,6 @@ These properties can be set in the Standard story:
 
 The Custom story shows all possible properties that can be passed to the StackedAreaChart component for customization. Three additional properties are added to the properties listed in the Standard story.
 
-- Data key label
-- Data value label
 - Domain
 
 ## Simple


### PR DESCRIPTION
This update to the Scatterplot component follows the Civic design system pattern established in #508, #553, and #565.

Working with the existing stories the following stories were created:

Standard - the common, default use of the StackedAreaChart component in the CIVIC platform
Custom - add knobs for all props of the StackedAreaChart component
Examples - examples of the component that show non-standard, but useful, configurations of the component:
The simple story shows only the most basic props.

A notes file was added; it describes each story and list the props/knobs that can be changed.