### PR TITLE
Design system - PieChart stories

### DIFF
--- a/packages/component-library/stories/LineChart.story.js
+++ b/packages/component-library/stories/LineChart.story.js
@@ -277,7 +277,7 @@ export default () =>
       "Example: Many data points",
       () => {
         const scale = 0.25;
-        const value = number("Number of data points", 100, GROUP_IDS.DATA);
+        const value = number("Number of data points", 100, {}, GROUP_IDS.DATA);
         return (
           <LineChart
             data={Array(value)

--- a/packages/component-library/stories/PieChart.story.js
+++ b/packages/component-library/stories/PieChart.story.js
@@ -1,66 +1,148 @@
 import React from "react";
 /* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from "@storybook/react";
-
 import {
   withKnobs,
   text,
   number,
+  object,
   array,
   boolean
 } from "@storybook/addon-knobs";
 import { PieChart } from "../src";
-import { colors, getRandomValuesArray, objectRandomizer } from "./shared";
+import notes from "./pieChart.notes.md";
+
+const GROUP_IDS = {
+  LABELS: "Labels",
+  DESIGN: "Design",
+  DATA: "Data",
+  CUSTOM: "Custom"
+};
 
 export default () =>
-  storiesOf("Component Lib|Charts/Pie/Donut Visualization", module)
+  storiesOf("Component Lib|Charts/Pie Chart", module)
     .addDecorator(withKnobs)
     .add(
-      "Basic usage",
-      // 'edit this visual in the knobs tab below and check click events in the actions tab',
+      "Standard",
       () => {
-        const numberOfData = number("Amount of data values", 2);
-        const values = getRandomValuesArray(numberOfData, objectRandomizer);
+        const title = text("Title", "Contributor Breakdown", GROUP_IDS.LABELS);
+        const subtitle = text(
+          "Subtitle",
+          "Contributions reported to ORESTAR by category",
+          GROUP_IDS.LABELS
+        );
+        const useLegend = boolean("Use legend", true, GROUP_IDS.LABELS);
+        const chartHeight = number("Chart height", 400, GROUP_IDS.DESIGN);
+        const innerRadius = number("Inner radius", 100, GROUP_IDS.DESIGN);
+        const halfDoughnut = boolean("Half doughnut", true, GROUP_IDS.DESIGN);
+        const categoricalColors = [
+          "#DC4556",
+          "#1E62BD",
+          "#19B7AA",
+          "#721D7C",
+          "#FFB226"
+        ];
+        const colors = array(
+          "Colors",
+          categoricalColors,
+          ",",
+          GROUP_IDS.DESIGN
+        );
+        const sampleData = [
+          { x: "Business entity", y: 35 },
+          { x: "Individual", y: 40 },
+          { x: "Labor organization", y: 55 },
+          { x: "Other", y: 75 }
+        ];
+        const data = object("Data", sampleData, GROUP_IDS.DATA);
 
         return (
-          <div style={{ display: "flex", justifyContent: "space-around" }}>
-            <PieChart data={values} />
-          </div>
+          <PieChart
+            title={title}
+            subtitle={subtitle}
+            data={data}
+            colors={colors}
+            height={chartHeight}
+            innerRadius={innerRadius}
+            halfDoughnut={halfDoughnut}
+            useLegend={useLegend}
+          />
         );
-      }
+      },
+      { notes }
     )
     .add(
-      "Simple usage",
-      // 'edit this visual in the knobs tab below and check click events in the actions tab',
+      "Custom",
       () => {
-        const sampleTitle = text("Title", "Sample Title");
-        const sampleSubtitle = text("Subtitle", "Sample Subtitle");
-        const numberOfData = number("Amount of data values", 3);
-        const getRandomColors = array(
-          "Array of colors",
-          colors.slice(0, numberOfData)
+        const title = text("Title", "Contributor Breakdown", GROUP_IDS.LABELS);
+        const subtitle = text(
+          "Subtitle",
+          "Contributions reported to ORESTAR by category",
+          GROUP_IDS.LABELS
         );
-        const values = getRandomValuesArray(numberOfData, objectRandomizer);
-        const chartHeight = number("Chart height", 450);
-        const chartWidth = number("Chart width", 450);
-        const innerRadius = number("Inner radius", 100);
-        const halfDoughnut = boolean("halfDoughnut", true);
-        const useLegend = boolean("useLegend", false);
+        const useLegend = boolean("Use legend", true, GROUP_IDS.LABELS);
+        const chartHeight = number("Chart height", 400, GROUP_IDS.DESIGN);
+        const chartWidth = number("Chart width", 400, GROUP_IDS.DESIGN);
+        const innerRadius = number("Inner radius", 100, GROUP_IDS.DESIGN);
+        const halfDoughnut = boolean("Half doughnut", true, GROUP_IDS.DESIGN);
+        const categoricalColors = [
+          "#DC4556",
+          "#1E62BD",
+          "#19B7AA",
+          "#721D7C",
+          "#FFB226"
+        ];
+        const colors = array(
+          "Colors",
+          categoricalColors,
+          ",",
+          GROUP_IDS.DESIGN
+        );
+        const startAngle = number("Start angle", 90, GROUP_IDS.DESIGN);
+        const endAngle = number("End angle", -90, GROUP_IDS.DESIGN);
+        const sampleData = [
+          { contributor: "Business entity", amount: 35 },
+          { contributor: "Individual", amount: 40 },
+          { contributor: "Labor organization", amount: 55 },
+          { contributor: "Other", amount: 75 }
+        ];
+        const dataLabel = text("Data label", "contributor", GROUP_IDS.DATA);
+        const dataValue = text("Data value", "amount", GROUP_IDS.DATA);
+        const data = object("Data", sampleData, GROUP_IDS.DATA);
 
         return (
-          <div style={{ display: "flex", justifyContent: "space-around" }}>
-            <PieChart
-              title={sampleTitle}
-              subtitle={sampleSubtitle}
-              data={values}
-              colors={getRandomColors}
-              width={chartWidth}
-              height={chartHeight}
-              innerRadius={innerRadius}
-              halfDoughnut={halfDoughnut}
-              useLegend={useLegend}
-            />
-          </div>
+          <PieChart
+            title={title}
+            subtitle={subtitle}
+            dataLabel={dataLabel}
+            dataValue={dataValue}
+            data={data}
+            colors={colors}
+            // animate={animate}
+            width={chartWidth}
+            height={chartHeight}
+            innerRadius={innerRadius}
+            startAngle={startAngle}
+            endAngle={endAngle}
+            halfDoughnut={halfDoughnut}
+            useLegend={useLegend}
+          />
         );
-      }
+      },
+      { notes }
+    )
+    .add(
+      "Example: Simple",
+      () => {
+        const sampleSimpleData = [
+          { x: "Business entity", y: 35 },
+          { x: "Individual", y: 40 },
+          { x: "Labor organization", y: 55 },
+          { x: "Other", y: 75 }
+        ];
+        const data = object("Data", sampleSimpleData, GROUP_IDS.DATA);
+
+        return <PieChart data={data} />;
+      },
+      { notes }
     );

--- a/packages/component-library/stories/PieChart.story.js
+++ b/packages/component-library/stories/PieChart.story.js
@@ -32,22 +32,7 @@ export default () =>
           GROUP_IDS.LABELS
         );
         const useLegend = boolean("Use legend", true, GROUP_IDS.LABELS);
-        const chartHeight = number("Chart height", 400, GROUP_IDS.DESIGN);
-        const innerRadius = number("Inner radius", 100, GROUP_IDS.DESIGN);
         const halfDoughnut = boolean("Half doughnut", true, GROUP_IDS.DESIGN);
-        const categoricalColors = [
-          "#DC4556",
-          "#1E62BD",
-          "#19B7AA",
-          "#721D7C",
-          "#FFB226"
-        ];
-        const colors = array(
-          "Colors",
-          categoricalColors,
-          ",",
-          GROUP_IDS.DESIGN
-        );
         const sampleData = [
           { x: "Business entity", y: 35 },
           { x: "Individual", y: 40 },
@@ -61,9 +46,6 @@ export default () =>
             title={title}
             subtitle={subtitle}
             data={data}
-            colors={colors}
-            height={chartHeight}
-            innerRadius={innerRadius}
             halfDoughnut={halfDoughnut}
             useLegend={useLegend}
           />
@@ -81,10 +63,19 @@ export default () =>
           GROUP_IDS.LABELS
         );
         const useLegend = boolean("Use legend", true, GROUP_IDS.LABELS);
-        const chartHeight = number("Chart height", 400, GROUP_IDS.DESIGN);
-        const chartWidth = number("Chart width", 400, GROUP_IDS.DESIGN);
-        const innerRadius = number("Inner radius", 100, GROUP_IDS.DESIGN);
         const halfDoughnut = boolean("Half doughnut", true, GROUP_IDS.DESIGN);
+        const sampleData = [
+          { contributor: "Business entity", amount: 35 },
+          { contributor: "Individual", amount: 40 },
+          { contributor: "Labor organization", amount: 55 },
+          { contributor: "Other", amount: 75 }
+        ];
+        const data = object("Data", sampleData, GROUP_IDS.DATA);
+        const dataLabel = text("Data label", "contributor", GROUP_IDS.CUSTOM);
+        const dataValue = text("Data value", "amount", GROUP_IDS.CUSTOM);
+        const chartHeight = number("Chart height", 100, {}, GROUP_IDS.CUSTOM);
+        const chartWidth = number("Chart width", 100, {}, GROUP_IDS.CUSTOM);
+        const innerRadius = number("Inner radius", 50, {}, GROUP_IDS.CUSTOM);
         const categoricalColors = [
           "#DC4556",
           "#1E62BD",
@@ -96,19 +87,10 @@ export default () =>
           "Colors",
           categoricalColors,
           ",",
-          GROUP_IDS.DESIGN
+          GROUP_IDS.CUSTOM
         );
-        const startAngle = number("Start angle", 90, GROUP_IDS.DESIGN);
-        const endAngle = number("End angle", -90, GROUP_IDS.DESIGN);
-        const sampleData = [
-          { contributor: "Business entity", amount: 35 },
-          { contributor: "Individual", amount: 40 },
-          { contributor: "Labor organization", amount: 55 },
-          { contributor: "Other", amount: 75 }
-        ];
-        const dataLabel = text("Data label", "contributor", GROUP_IDS.DATA);
-        const dataValue = text("Data value", "amount", GROUP_IDS.DATA);
-        const data = object("Data", sampleData, GROUP_IDS.DATA);
+        const startAngle = number("Start angle", 90, {}, GROUP_IDS.CUSTOM);
+        const endAngle = number("End angle", -90, {}, GROUP_IDS.CUSTOM);
 
         return (
           <PieChart
@@ -118,7 +100,6 @@ export default () =>
             dataValue={dataValue}
             data={data}
             colors={colors}
-            // animate={animate}
             width={chartWidth}
             height={chartHeight}
             innerRadius={innerRadius}

--- a/packages/component-library/stories/PieChart.story.js
+++ b/packages/component-library/stories/PieChart.story.js
@@ -93,9 +93,6 @@ export default () =>
           ",",
           GROUP_IDS.CUSTOM
         );
-        // const startAngle = number("Start angle", 90, {}, GROUP_IDS.CUSTOM);
-        // const endAngle = number("End angle", -90, {}, GROUP_IDS.CUSTOM);
-
         return (
           <PieChart
             title={title}
@@ -107,8 +104,6 @@ export default () =>
             width={chartWidth}
             height={chartHeight}
             innerRadius={innerRadius}
-            // startAngle={startAngle}
-            // endAngle={endAngle}
             halfDoughnut={halfDoughnut}
             useLegend={useLegend}
           />

--- a/packages/component-library/stories/PieChart.story.js
+++ b/packages/component-library/stories/PieChart.story.js
@@ -31,8 +31,10 @@ export default () =>
           "Contributions reported to ORESTAR by category",
           GROUP_IDS.LABELS
         );
-        const useLegend = boolean("Use legend", true, GROUP_IDS.LABELS);
         const halfDoughnut = boolean("Half doughnut", true, GROUP_IDS.DESIGN);
+        const useLegend = boolean("Use legend", true, GROUP_IDS.DESIGN);
+        const dataLabel = text("Data label", "x", GROUP_IDS.DATA);
+        const dataValue = text("Data value", "y", GROUP_IDS.DATA);
         const sampleData = [
           { x: "Business entity", y: 35 },
           { x: "Individual", y: 40 },
@@ -45,6 +47,8 @@ export default () =>
           <PieChart
             title={title}
             subtitle={subtitle}
+            dataLabel={dataLabel}
+            dataValue={dataValue}
             data={data}
             halfDoughnut={halfDoughnut}
             useLegend={useLegend}
@@ -62,7 +66,7 @@ export default () =>
           "Contributions reported to ORESTAR by category",
           GROUP_IDS.LABELS
         );
-        const useLegend = boolean("Use legend", true, GROUP_IDS.LABELS);
+        const useLegend = boolean("Use legend", true, GROUP_IDS.DESIGN);
         const halfDoughnut = boolean("Half doughnut", true, GROUP_IDS.DESIGN);
         const sampleData = [
           { contributor: "Business entity", amount: 35 },
@@ -70,11 +74,11 @@ export default () =>
           { contributor: "Labor organization", amount: 55 },
           { contributor: "Other", amount: 75 }
         ];
+        const dataLabel = text("Data label", "contributor", GROUP_IDS.DATA);
+        const dataValue = text("Data value", "amount", GROUP_IDS.DATA);
         const data = object("Data", sampleData, GROUP_IDS.DATA);
-        const dataLabel = text("Data label", "contributor", GROUP_IDS.CUSTOM);
-        const dataValue = text("Data value", "amount", GROUP_IDS.CUSTOM);
-        const chartHeight = number("Chart height", 100, {}, GROUP_IDS.CUSTOM);
-        const chartWidth = number("Chart width", 100, {}, GROUP_IDS.CUSTOM);
+        const chartHeight = number("Chart height", 350, {}, GROUP_IDS.CUSTOM);
+        const chartWidth = number("Chart width", 650, {}, GROUP_IDS.CUSTOM);
         const innerRadius = number("Inner radius", 50, {}, GROUP_IDS.CUSTOM);
         const categoricalColors = [
           "#DC4556",

--- a/packages/component-library/stories/PieChart.story.js
+++ b/packages/component-library/stories/PieChart.story.js
@@ -93,8 +93,8 @@ export default () =>
           ",",
           GROUP_IDS.CUSTOM
         );
-        const startAngle = number("Start angle", 90, {}, GROUP_IDS.CUSTOM);
-        const endAngle = number("End angle", -90, {}, GROUP_IDS.CUSTOM);
+        // const startAngle = number("Start angle", 90, {}, GROUP_IDS.CUSTOM);
+        // const endAngle = number("End angle", -90, {}, GROUP_IDS.CUSTOM);
 
         return (
           <PieChart
@@ -107,8 +107,8 @@ export default () =>
             width={chartWidth}
             height={chartHeight}
             innerRadius={innerRadius}
-            startAngle={startAngle}
-            endAngle={endAngle}
+            // startAngle={startAngle}
+            // endAngle={endAngle}
             halfDoughnut={halfDoughnut}
             useLegend={useLegend}
           />

--- a/packages/component-library/stories/pieChart.notes.md
+++ b/packages/component-library/stories/pieChart.notes.md
@@ -1,0 +1,31 @@
+# PieChart Component
+
+## Standard
+
+The Standard story shows the standard usage of the PieChart for the CIVIC platform. PieChart includes standard styling.
+
+These properties can be set in the Standard story:
+
+- Title
+- Subtitle
+- X-axis label
+- X-axis value format
+- Y-axis label
+- Y-axis value format
+- Data key
+- Data value
+- Data series
+- Data series labels
+- Data
+
+## Custom
+
+The Custom story shows all possible properties that can be passed to the PieChart component for customization. Three additional properties are added to the properties listed in the Standard story.
+
+The Custom story also shows the use of a custom legend, which is a separate component.
+
+## Simple
+
+The example Simple story shows the minimal properties needed for the PieChart.
+
+- Data

--- a/packages/component-library/stories/pieChart.notes.md
+++ b/packages/component-library/stories/pieChart.notes.md
@@ -22,8 +22,6 @@ The Custom story shows all possible properties that can be passed to the PieChar
 - Chart width
 - Inner radius
 - Colors
-- Start angle
-- End angle
 
 ## Simple
 

--- a/packages/component-library/stories/pieChart.notes.md
+++ b/packages/component-library/stories/pieChart.notes.md
@@ -8,21 +8,22 @@ These properties can be set in the Standard story:
 
 - Title
 - Subtitle
-- X-axis label
-- X-axis value format
-- Y-axis label
-- Y-axis value format
-- Data key
-- Data value
-- Data series
-- Data series labels
+- Use legend
+- Half doughnut
 - Data
 
 ## Custom
 
 The Custom story shows all possible properties that can be passed to the PieChart component for customization. Three additional properties are added to the properties listed in the Standard story.
 
-The Custom story also shows the use of a custom legend, which is a separate component.
+- Data label
+- Data value
+- Chart height
+- Chart width
+- Inner radius
+- Colors
+- Start angle
+- End angle
 
 ## Simple
 

--- a/packages/component-library/stories/pieChart.notes.md
+++ b/packages/component-library/stories/pieChart.notes.md
@@ -10,14 +10,14 @@ These properties can be set in the Standard story:
 - Subtitle
 - Use legend
 - Half doughnut
+- Data label
+- Data value
 - Data
 
 ## Custom
 
 The Custom story shows all possible properties that can be passed to the PieChart component for customization. Three additional properties are added to the properties listed in the Standard story.
 
-- Data label
-- Data value
 - Chart height
 - Chart width
 - Inner radius


### PR DESCRIPTION
This update to the PieChart component follows the Civic design system pattern established in #508, #553, and #565.

Working with the existing stories the following stories were created:

Standard - the common, default use of the PieChart component in the CIVIC platform
Custom - add knobs for all props of the PieChart component
Example: Simple - the simple story shows only the most basic props.

A notes file was added; it describes each story and list the props/knobs that can be changed.