### PR TITLE
add in missed word for clarity

### DIFF
--- a/packages/2018/src/components/HomePage.js
+++ b/packages/2018/src/components/HomePage.js
@@ -687,7 +687,7 @@ class HomePage extends Component {
                   <div className={listSubTitle}>Vision</div>
                   <p className={listText}>
                     Empowering cities to create technology that is a reflection
-                    their ambition, their values, and their priorities.
+                    of their ambition, their values, and their priorities.
                   </p>
                   <div className={listSubTitle}>Workflow</div>
                   <p className={listText}>

--- a/packages/component-library/src/LandingPage/LandingPage.js
+++ b/packages/component-library/src/LandingPage/LandingPage.js
@@ -492,7 +492,7 @@ class LandingPage extends React.Component {
                 <div className={listTitle}>Supporting People</div>
                 <div className={listSubTitle}>Vision</div>
                 <p className={listText}>
-                  Empowering cities to create technology that is a reflection
+                  Empowering cities to create technology that is a reflection of
                   their ambition, their values, and their priorities.
                 </p>
                 <div className={listSubTitle}>Workflow</div>


### PR DESCRIPTION
A word was inadvertently left out ("of") on the landing page for the platform.