### PR TITLE
MultiLayer Map Story Bug Fixes

### DIFF
--- a/packages/component-library/stories/MultiLayerMap.story.js
+++ b/packages/component-library/stories/MultiLayerMap.story.js
@@ -6,11 +6,11 @@ import {
   text,
   number,
   select,
-  object
+  object,
+  optionsKnob as options
 } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
-import { extent } from "d3";
 import { BaseMap, MultiLayerMap, DemoJSONLoader } from "../src";
 
 import notes from "./multiLayerMap.notes";
@@ -80,16 +80,19 @@ export default () =>
         );
 
         const PATH_MAP_SCALE_TYPE_COLOR_OPTIONS = {
-          "(none)": "",
+          none: "",
           threshold: "threshold",
           ordinal: "ordinal",
           equal: "equal"
         };
 
-        const scaleTypeColor = select(
+        const scaleTypeColor = options(
           "Scale Type:",
           PATH_MAP_SCALE_TYPE_COLOR_OPTIONS,
           "",
+          {
+            display: "inline-radio"
+          },
           GROUP_IDS.CUSTOM
         );
 
@@ -105,10 +108,6 @@ export default () =>
             CIVIC_CATEGORICAL_COLORS.civicGreen,
             GROUP_IDS.STANDARD
           );
-
-          fieldName = text("Field Name:", "", GROUP_IDS.CUSTOM);
-          dataRange = object("Data Range:", [], GROUP_IDS.CUSTOM);
-          colorRange = object("Color Range:", [], GROUP_IDS.CUSTOM);
         } else if (scaleTypeColor === "threshold") {
           lineColor = select(
             "Civic Color:",
@@ -212,7 +211,7 @@ export default () =>
         );
       },
       {
-        notes
+        notes: notes.pathNotes
       }
     )
     .add(
@@ -228,14 +227,17 @@ export default () =>
         );
 
         const SCATTERPLOT_SCALE_TYPE_COLOR_OPTIONS = {
-          "(none)": "",
+          none: "",
           ordinal: "ordinal"
         };
 
-        const scaleTypeColor = select(
+        const scaleTypeColor = options(
           "Scale Type (color):",
           SCATTERPLOT_SCALE_TYPE_COLOR_OPTIONS,
           "",
+          {
+            display: "inline-radio"
+          },
           GROUP_IDS.CUSTOM
         );
 
@@ -251,10 +253,6 @@ export default () =>
             CIVIC_CATEGORICAL_COLORS.civicGreen,
             GROUP_IDS.STANDARD
           );
-
-          fieldNameColor = text("Field Name (color):", "", GROUP_IDS.CUSTOM);
-          dataRange = object("Data Range:", [], GROUP_IDS.CUSTOM);
-          colorRange = object("Color Range:", [], GROUP_IDS.CUSTOM);
         } else if (scaleTypeColor === "ordinal") {
           fieldNameColor = text(
             "Field Name (color):",
@@ -276,14 +274,17 @@ export default () =>
         }
 
         const SCATTERPLOT_SCALE_TYPE_AREA_OPTIONS = {
-          "(none)": "",
+          none: "",
           "circle area": "circle area"
         };
 
-        const scaleTypeArea = select(
+        const scaleTypeArea = options(
           "Scale Type (area):",
           SCATTERPLOT_SCALE_TYPE_AREA_OPTIONS,
           "",
+          {
+            display: "inline-radio"
+          },
           GROUP_IDS.CUSTOM
         );
 
@@ -366,7 +367,7 @@ export default () =>
         );
       },
       {
-        notes
+        notes: notes.scatterPlotNotes
       }
     )
     .add(
@@ -434,7 +435,7 @@ export default () =>
         );
       },
       {
-        notes
+        notes: notes.screenGridNotes
       }
     )
     .add(
@@ -513,10 +514,13 @@ export default () =>
           ordinal: "ordinal"
         };
 
-        const scaleType = select(
+        const scaleType = options(
           "Scale Type:",
           ICON_SCALE_TYPE_COLOR_OPTIONS,
-          ICON_SCALE_TYPE_COLOR_OPTIONS.ordinal,
+          "ordinal",
+          {
+            display: "inline-radio"
+          },
           GROUP_IDS.STANDARD
         );
 
@@ -597,7 +601,7 @@ export default () =>
         );
       },
       {
-        notes
+        notes: notes.iconNotes
       }
     )
     .add(
@@ -611,15 +615,18 @@ export default () =>
         );
 
         const POLYGON_SCALE_TYPE_COLOR_OPTIONS = {
-          "(none)": "",
+          none: "",
           threshold: "threshold",
           ordinal: "ordinal"
         };
 
-        const scaleTypeSelection = select(
+        const scaleTypeSelection = options(
           "Scale Type:",
           POLYGON_SCALE_TYPE_COLOR_OPTIONS,
           "",
+          {
+            display: "inline-radio"
+          },
           GROUP_IDS.CUSTOM
         );
 
@@ -635,14 +642,7 @@ export default () =>
             CIVIC_CATEGORICAL_COLORS.civicGreen,
             GROUP_IDS.STANDARD
           );
-
-          fieldName = text("Field Name:", "", GROUP_IDS.CUSTOM);
-          dataRange = object("Data Range:", [], GROUP_IDS.CUSTOM);
-          colorRange = object("Color Range:", [], GROUP_IDS.CUSTOM);
         } else if (scaleTypeSelection === "threshold") {
-          // eslint-disable-next-line no-unused-expressions
-          polygonColor;
-
           fieldName = text("Field Name:", "acres", GROUP_IDS.CUSTOM);
 
           dataRange = object("Data Range:", [10], GROUP_IDS.CUSTOM);
@@ -653,9 +653,6 @@ export default () =>
             GROUP_IDS.CUSTOM
           );
         } else if (scaleTypeSelection === "ordinal") {
-          // eslint-disable-next-line no-unused-expressions
-          polygonColor;
-
           fieldName = text("Field Name:", "name", GROUP_IDS.CUSTOM);
 
           dataRange = object(
@@ -727,7 +724,7 @@ export default () =>
         );
       },
       {
-        notes
+        notes: notes.smallPolygonNotes
       }
     )
     .add(
@@ -746,10 +743,13 @@ export default () =>
           ordinal: "ordinal"
         };
 
-        const scaleTypeSelection = select(
+        const scaleTypeSelection = options(
           "Scale Type:",
           CHOROPLETH_SCALE_TYPE_COLOR_OPTIONS,
           "equal",
+          {
+            display: "inline-radio"
+          },
           GROUP_IDS.STANDARD
         );
 
@@ -771,7 +771,6 @@ export default () =>
                 GROUP_IDS.DATA
               );
 
-              let minMax;
               let polygonColor;
               let fieldName;
               let dataRange;
@@ -791,12 +790,7 @@ export default () =>
                   GROUP_IDS.STANDARD
                 );
 
-                minMax = extent(
-                  data.results.features,
-                  d => +d.properties[fieldName]
-                );
-
-                dataRange = object("Data Range:", minMax, GROUP_IDS.STANDARD);
+                dataRange = object("Data Range:", [], GROUP_IDS.STANDARD);
 
                 colorRange = object("Color Range:", [], GROUP_IDS.STANDARD);
               } else if (scaleTypeSelection === "threshold") {
@@ -880,6 +874,6 @@ export default () =>
         );
       },
       {
-        notes
+        notes: notes.choroplethNotes
       }
     );

--- a/packages/component-library/stories/multiLayerMap.notes.js
+++ b/packages/component-library/stories/multiLayerMap.notes.js
@@ -79,25 +79,23 @@ const createCustomColorProp = (
   ${
     threshold
       ? `- This property requires one of these diverging color schemes as a string if the \`scaleType\` is set to \`threshold\`:
-    - purpleGreen
-    - purpleOrange`
+        - purpleGreen
+        - purpleOrange`
       : ""
   }
   ${
     equal
       ? `- This property requires one of these sequential color schemes as a string if the \`scaleType\` is set to \`equal\`:
-    - thermal
-    - planet
-    - space
-    - earth
-    - ocean`
+        - thermal
+        - planet
+        - space
+        - earth
+        - ocean`
       : ""
   }
   ${
     ordinal
-      ? `
-  - This property requires no value if \`scaleType\` is set to \`ordinal\`
-  `
+      ? `- This property requires no value if \`scaleType\` is set to \`ordinal\``
       : ""
   }
 `;
@@ -114,7 +112,7 @@ const createOnClickProp = geometryType => `
   - This property expects a function
 `;
 
-const notes = `
+const baseNotes = `
 # MultiLayer Map Component
 
 The MultiLayer Map component is a more convenient way to display multiple map layers on the same Base Map.
@@ -125,21 +123,14 @@ These props can be passed to the MultiLayer Map component:
   - This prop expects an array of objects
   - Each object has a collection of properties made up of the values described below each map type.
 
-The MultiLayer Map component can display these map types:
-
-- [Path Map](#path-map)
-- [ScatterPlot Map](#scatterplot-map)
-- [Screen Grid Map](#screen-grid-map)
-- [Icon Map](#icon-map)
-- [Small Polygon Map](#small-polygon-map)
-- [Choropleth Map](#choropleth-map)
-
-
 ----
 
+`;
+
+const pathNotes = `
+${baseNotes}
 
 ## Path Map
-[Back to top](#multilayer-map-component)
 
 The Standard tab shows the basic implementation of a Path Map for the MultiLayer Map component.
 
@@ -204,12 +195,12 @@ ${fieldNameProp}
       - Thus the value at index 0 in the \`dataRange\` will have the color at index 0 of the \`colorRange\`
 
 ${createOnClickProp("a line")}
+`;
 
-
-
+const scatterPlotNotes = `
+${baseNotes}
 
 ## ScatterPlot Map
-[Back to top](#multilayer-map-component)
 
 The Standard tab shows the basic implementation of a ScatterPlot Map for the MultiLayer Map component.
 
@@ -277,12 +268,12 @@ ${createCustomColorProp("lines", {
   - This property requires a number greater than 1
 
 ${createOnClickProp("a line")}
+`;
 
-
-
+const screenGridNotes = `
+${baseNotes}
 
 ## Screen Grid Map
-[Back to top](#multilayer-map-component)
 
 The Standard tab shows the basic implementation of a Screen Grid Map for the MultiLayer Map component.
 
@@ -294,11 +285,13 @@ ${createDataProp("squares", "Point")}
 ${createSizeProp("square", "Size")}
 ${createOpacityProp("squares")}
 ${createColorProp("squares", civicSequentialColorOptions)}
+`;
 
-
-
+const iconNotes = `
+${baseNotes}
 
 ## Icon Map
+
 The Standard tab shows the basic implementation of an Icon Map for the MultiLayer Map component.
 
 These properties can be used to create a standard icon map layer object:
@@ -402,12 +395,12 @@ ${createOpacityProp("icons")}
     - And so on...
 
 ${createOnClickProp("an icon")}
+`;
 
-
-
+const smallPolygonNotes = `
+${baseNotes}
 
 ## Small Polygon Map
-[Back to top](#multilayer-map-component)
 
 The Standard tab shows the basic implementation of a Small Polygon Map for the MultiLayer Map component.
 
@@ -424,7 +417,7 @@ ${createColorProp("polygons", civicCategoricalColorOptions)}
 The Custom tab shows additional properties that can be used to create a custom small polygon map layer object:
 
 ${createScaleTypeProp({ threshold: true, equal: false, ordinal: true })}
-${createCustomColorProp("lines", {
+${createCustomColorProp("polygons", {
   threshold: true,
   equal: false,
   ordinal: true
@@ -465,12 +458,12 @@ ${fieldNameProp}
         - \`colorRange\`: \`[[0,0,255], [255,165,0], [0,255,0]]\`
     - The index of each value in \`dataRange\` will determine which color from the \`colorRange\` it's assigned
       - Thus the value at index 0 in the \`dataRange\` will have the color at index 0 of the \`colorRange\`
+`;
 
-
-
+const choroplethNotes = `
+${baseNotes}
 
 ## Choropleth Map
-[Back to top](#multilayer-map-component)
 
 The Standard tab shows the basic implementation of a Choropleth Map for the MultiLayer Map component.
 
@@ -533,5 +526,14 @@ ${createOnClickProp("a line")}
 
 
 `;
+
+const notes = {
+  pathNotes,
+  scatterPlotNotes,
+  screenGridNotes,
+  iconNotes,
+  smallPolygonNotes,
+  choroplethNotes
+};
 
 export default notes;


### PR DESCRIPTION
This fixes a couple of problems with the MultiLayer Map story.
- First, it updates the notes by only showing the props for each layer type. It's still 1 notes file but broken up into smaller parts. This also fixes the problem with the links not working.
- Second, the scale type knob has been switched from `select` to `optionsKnob`. This should fix the problem of the values not updating.