### PR TITLE
CIVIC Sandbox Style Improvements

### DIFF
--- a/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
+++ b/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
@@ -24,7 +24,11 @@ const container = css`
   display: flex;
   flex-direction: column;
   width: 575px;
-  background: rgba(243, 242, 243, 0.95);
+  background: rgba(243, 242, 243, 0.9);
+  color: rgb(85, 85, 85);
+  border: 1px solid #ddd;
+  border-radius: 2px;
+  box-shadow: 5px 5px 15px -3px rgba(0, 0, 0, 0.2);
   @media (max-width: 900px) {
     width: 92%;
     left: 1%;
@@ -35,7 +39,7 @@ const dashboardOpen = css`
   height: 45vh;
   overflow-y: auto;
   overflow-x: hidden;
-  opacity: 1;
+  opacity: 0.9;
   transition: height 750ms ease-out, opacity 1.5s ease-in;
 `;
 
@@ -59,10 +63,12 @@ const toggleContainer = css`
   flex-direction: row;
   height: 100%;
   width: 100%;
-  border: 1px solid rgb(170, 164, 171);
-  background-color: rgb(243, 242, 243);
   color: #dc4556;
   z-index: 4;
+  opacity: 0.9;
+  border: 1px solid #ddd;
+  border-radius: 2px;
+  box-shadow: 5px 5px 15px -3px rgba(0, 0, 0, 0.2);
 `;
 
 const toggleTitle = css`
@@ -235,7 +241,9 @@ const CivicDashboard = props => {
 
   const dashboardToggleButton = (
     <div className={toggleContainer} onClick={() => onClick()}>
-      <div className={toggleTitle}>Please select a polygon</div>
+      <div className={toggleTitle}>
+        {isDashboardOpen ? "" : "Please select a polygon"}
+      </div>
       <div className={toggleArrow}>
         <div className={isDashboardOpen ? ICONS.arrowDown : ICONS.arrowUp} />
       </div>

--- a/packages/component-library/src/Sandbox/SandboxBaseMapSelector.js
+++ b/packages/component-library/src/Sandbox/SandboxBaseMapSelector.js
@@ -1,9 +1,10 @@
+/* TODO: Fix linting errors */
+/* eslint-disable */
 import PropTypes from "prop-types";
 import React from "react";
 import { css } from "emotion";
 
 const baseMapMenu = css(`
-  background: #f3f2f3;
   padding: 10px;
   z-index: 2;
   font-family: "Roboto Condensed", sans-serif;

--- a/packages/component-library/src/Sandbox/SandboxDrawer.js
+++ b/packages/component-library/src/Sandbox/SandboxDrawer.js
@@ -87,10 +87,13 @@ const SandboxDrawer = ({
       {drawerVisible && (
         <div
           className={css(`
-          background: #F3F2F3;
+          background: rgba(243,242,243,0.9);
           overflow-y: auto;
           min-height: 550px;
           height: 74vh;
+          border: 1px solid #ddd;
+          border-radius: 2px;
+          box-shadow: -10px 5px 15px -3px rgba(0, 0, 0, 0.2);
           @media (max-width: 850px) {
             height: 60vh;
           }
@@ -231,7 +234,7 @@ const SandboxDrawer = ({
             const backgroundSlideColor = slide.color;
             const formatBackgroundColor = arr =>
               arr.reduce(
-                (acc, cur, i) => (i < 3 ? acc + cur + "," : acc + "1)"),
+                (acc, cur, i) => (i < 3 ? acc + cur + "," : acc + "0.9)"),
                 "rgba("
               );
             const slideBackGroundColor = formatBackgroundColor(


### PR DESCRIPTION
Per Jaron:
1. Match side menu and dashboard `border` and `box-shadow` properties with CivicStoryCard (reverse x-offset for side menu)
2. Match color and opacity of side menu and dashboard
3. Hide “Please select a polygon” when dashboard is open

