### PR TITLE
Donut Chart Size

### DIFF
--- a/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
+++ b/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
@@ -1,5 +1,4 @@
-/* TODO: Fix linting errors */
-/* eslint-disable */
+/* eslint-disable no-nested-ternary */
 import React, { useState } from "react";
 import {
   arrayOf,
@@ -23,7 +22,7 @@ const container = css`
   left: 25px;
   display: flex;
   flex-direction: column;
-  width: 575px;
+  width: 500px;
   background: rgba(243, 242, 243, 0.9);
   color: rgb(85, 85, 85);
   border: 1px solid #ddd;
@@ -36,7 +35,7 @@ const container = css`
 `;
 
 const dashboardOpen = css`
-  height: 45vh;
+  height: 400px;
   overflow-y: auto;
   overflow-x: hidden;
   opacity: 0.9;
@@ -46,7 +45,7 @@ const dashboardOpen = css`
 const dashboardClosed = css`
   height: 0;
   opacity: 0;
-  transition: height 750ms ease-out, opacity 0.25s linear;
+  transition: height 750ms ease-out, opacity 0s linear;
 `;
 
 const contentContainer = css`
@@ -122,12 +121,13 @@ const iconActive = css`
 const viz = css`
   width: 90%;
   margin: 2% 2% 2% 8%;
+  padding-bottom: 25px;
   overflow-y: hidden;
 `;
 
 const donutPercent = css`
   position: absolute;
-  bottom: 43%;
+  bottom: 35px;
   left: 28%;
   width: 50%;
   margin: auto;
@@ -156,9 +156,9 @@ const createDonutViz = (donut, index) => {
       <PieChart
         data={donut.data}
         colors={[salmon, gray]}
-        width={475}
-        height={350}
-        innerRadius={90}
+        width={400}
+        height={400}
+        innerRadius={110}
         halfDoughnut
       />
     </div>
@@ -227,12 +227,18 @@ const CivicDashboard = props => {
       <div
         className={display === "description" ? iconActive : icon}
         onClick={() => setDisplay("description")}
+        onKeyPress={() => setDisplay("description")}
+        tabIndex={0}
+        role="button"
       >
         <div className={ICONS.info} />
       </div>
       <div
         className={display === "visualizations" ? iconActive : icon}
         onClick={() => setDisplay("visualizations")}
+        onKeyPress={() => setDisplay("visualizations")}
+        tabIndex={0}
+        role="button"
       >
         <div className={ICONS.eye} />
       </div>
@@ -240,7 +246,13 @@ const CivicDashboard = props => {
   );
 
   const dashboardToggleButton = (
-    <div className={toggleContainer} onClick={() => onClick()}>
+    <div
+      className={toggleContainer}
+      onClick={() => onClick()}
+      onKeyPress={() => onClick()}
+      tabIndex={0}
+      role="button"
+    >
       <div className={toggleTitle}>
         {isDashboardOpen ? "" : "Please select a polygon"}
       </div>

--- a/packages/component-library/src/PieChart/PieChart.js
+++ b/packages/component-library/src/PieChart/PieChart.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { VictoryPie, VictoryLabel } from "victory";
+import { VictoryPie, VictoryLabel, VictoryContainer } from "victory";
 import ChartContainer from "../ChartContainer";
 import civicTheme from "../VictoryTheme/CivicVictoryTheme";
 import SimpleLegend from "../SimpleLegend";
@@ -25,6 +25,7 @@ const PieChart = props => {
 
   const startAngle = halfDoughnut ? -90 : 0;
   const endAngle = halfDoughnut ? 90 : 360;
+  const adjustedHeight = halfDoughnut ? height / 2 : height;
   const legendLabels = data.map(value => ({ name: value[dataLabel] }));
   const legendProps = {};
 
@@ -66,6 +67,9 @@ const PieChart = props => {
             <VictoryLabel style={{ ...civicTheme.pieLabel.style }} />
           }
           {...legendProps}
+          containerComponent={
+            <VictoryContainer height={adjustedHeight} width={width} />
+          }
         />
       </DataChecker>
     </ChartContainer>

--- a/packages/component-library/stories/CivicSandboxDashboard.story.js
+++ b/packages/component-library/stories/CivicSandboxDashboard.story.js
@@ -57,10 +57,11 @@ class DashboardStory extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (
-      prevState.selectedFoundationDatumID !==
-      this.state.selectedFoundationDatumID
-    ) {
+    const {
+      selectedFoundationDatumID: prevSelectedFoundationDatumID
+    } = prevState;
+    const { selectedFoundationDatumID } = this.state;
+    if (prevSelectedFoundationDatumID !== selectedFoundationDatumID) {
       this.toggleDashboardOpen();
     }
   }
@@ -83,9 +84,19 @@ class DashboardStory extends React.Component {
   };
 
   render() {
-    if (this.props.data === null) return null;
+    // eslint-disable-next-line react/prop-types
+    const { data } = this.props;
 
-    const populationData = this.props.data;
+    if (data === null) return null;
+
+    const {
+      dashboardIsOpen,
+      selectedFoundationDatum,
+      selectedFoundationDatumID
+    } = this.state;
+
+    // eslint-disable-next-line react/prop-types
+    const populationData = data;
 
     const planetColorScheme = [
       [247, 244, 249, 155],
@@ -105,23 +116,23 @@ class DashboardStory extends React.Component {
       opacity: 1,
       data: populationData.slide_data.features,
       getLineColor: f => {
-        return f.id === this.state.selectedFoundationDatumID
+        return f.id === selectedFoundationDatumID
           ? [30, 144, 255, 255]
           : [0, 0, 0, 55];
       },
       getLineWidth: f => {
-        return f.id === this.state.selectedFoundationDatumID ? 175 : 1;
+        return f.id === selectedFoundationDatumID ? 175 : 1;
       },
       scaleType: "equal",
       color: planetColorScheme,
       getPropValue: f => f.properties.total_population,
       propName: "total_population",
       highlightColor: [30, 144, 255, 100],
-      onLayerClick: selectedFoundationDatum =>
-        this.setselectedFoundationDatum(selectedFoundationDatum),
+      onLayerClick: foundationDatum =>
+        this.setselectedFoundationDatum(foundationDatum),
       updateTriggers: {
-        getLineColor: this.state.selectedFoundationDatumID,
-        getLineWidth: this.state.selectedFoundationDatumID
+        getLineColor: selectedFoundationDatumID,
+        getLineWidth: selectedFoundationDatumID
       }
     };
 
@@ -134,25 +145,25 @@ class DashboardStory extends React.Component {
 
     // Dashboard Visualization
     let textData = {};
-    if (this.state.selectedFoundationDatum.properties) {
+    if (selectedFoundationDatum.properties) {
       textData = createTextViz(
-        this.state.selectedFoundationDatum,
+        selectedFoundationDatum,
         "Neighborhood Population",
         "total_population"
       );
     }
 
     let donutData = {};
-    if (this.state.selectedFoundationDatum.properties) {
+    if (selectedFoundationDatum.properties) {
       donutData = createDonutViz(
-        this.state.selectedFoundationDatum,
+        selectedFoundationDatum,
         "Neighborhood Population",
         "total_population"
       );
     }
 
-    const textVisible = boolean("Text:", true);
-    const donutVisible = boolean("Percent Donut:", false);
+    const textVisible = boolean("Text:", false);
+    const donutVisible = boolean("Percent Donut:", true);
 
     const dashboardArray = [
       {
@@ -173,7 +184,9 @@ class DashboardStory extends React.Component {
     const dashboardInformation = (
       <div className={dashboardDescription}>
         <h2>
-          How has ridership changed throughout Tri-Met's service area over time?
+          {
+            "How has ridership changed throughout Tri-Met's service area over time?"
+          }
         </h2>
         <p>{wallOfText}</p>
         <p>{wallOfText}</p>
@@ -201,13 +214,13 @@ class DashboardStory extends React.Component {
           >
             <CivicSandboxMap
               mapLayers={mapLayers}
-              selectedFoundationDatum={[this.state.selectedFoundationDatum]}
+              selectedFoundationDatum={[selectedFoundationDatum]}
             />
           </BaseMap>
           <CivicSandboxDashboard
             data={dashboardData}
             onClick={this.toggleDashboard}
-            isDashboardOpen={this.state.dashboardIsOpen}
+            isDashboardOpen={dashboardIsOpen}
           >
             {dashboardDescriptionVisible ? dashboardInformation : null}
           </CivicSandboxDashboard>

--- a/packages/component-library/stories/PieChart.story.js
+++ b/packages/component-library/stories/PieChart.story.js
@@ -50,6 +50,8 @@ export default () =>
             dataLabel={dataLabel}
             dataValue={dataValue}
             data={data}
+            width={650}
+            height={350}
             halfDoughnut={halfDoughnut}
             useLegend={useLegend}
           />


### PR DESCRIPTION
This PR addresses #396.
- The donut chart now only takes half the height of the normal pie chart. These changes are the same ones made in PR #404, which were not merged in.
- It adjusts the sandbox dashboard to fit the updated donut chart
- It also fixes some linting errors
