### PR TITLE
Magnitude of Urban Campsite Sweeps

### DIFF
--- a/packages/2018-neighborhood-development/src/state/magnitude-of-urban-campsite-sweeps/selectors.js
+++ b/packages/2018-neighborhood-development/src/state/magnitude-of-urban-campsite-sweeps/selectors.js
@@ -8,7 +8,7 @@ export const getMagnitudeOfUrbanCampsiteSweepsRequest = createSelector(
 
 const formatData = arr =>
   arr.map(obj => ({
-    date: new Date(obj.report_time),
+    date: new Date(`${obj.report_time.slice(0, -1)  }-08:00`),
     count: obj.count
   }));
 


### PR DESCRIPTION
This addresses #386.

The original data included a `Z` at the end of the date string, which means it's set to Coordinated Universal Time (UTC). So when the strings were used to create a Date instance, it gets converted to local time or Pacific Standard Time, which is 8 hours behind UTC. This created dates that were 1 day behind the intended date.

Instead of ending the date strings with a `Z`, I replaced it in the selector with the PST timezone offset. 
