### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ lib-cov
 .DS_Store
 *.sw[onp]
 civic.iml
+.vscode


### PR DESCRIPTION
Until we intentionally want to add shared .vscode settings, I'm removing .vscode from source control so that people's individual settings don't clutter up PRs

https://stackoverflow.com/questions/32964920/should-i-commit-the-vscode-folder-to-source-control