### PR TITLE
Fix CivicFullCardLayout Collapsable bug

### DIFF
--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -99,13 +99,13 @@ MetadataQuestion.propTypes = {
 function CollapsableSection({ items, collapseAfter }) {
   const beforeFold = _.slice(items, 0, collapseAfter);
   const afterFold = _.slice(items, collapseAfter);
-  return (
+  return (afterFold && afterFold.length) > 0 ? (
     <Collapsable>
       <Collapsable.Section>{beforeFold}</Collapsable.Section>
-      {afterFold.length > 0 && (
-        <Collapsable.Section hidden>{afterFold}</Collapsable.Section>
-      )}
+      <Collapsable.Section hidden>{afterFold}</Collapsable.Section>
     </Collapsable>
+  ) : (
+    <Fragment>{beforeFold}</Fragment>
   );
 }
 


### PR DESCRIPTION
This fixes an undocumented bug -- the full view of the `template-card` in the 2019-template package throws a type error, because of an unhandled case in CivicFullCardLayout.