### PR TITLE
Fix Location Marker Position on Change

### DIFF
--- a/packages/2018-disaster-resilience/src/components/YouAndYourNeighbors/index.js
+++ b/packages/2018-disaster-resilience/src/components/YouAndYourNeighbors/index.js
@@ -122,7 +122,8 @@ export class YouAndYourNeighbors extends React.Component {
               initialLatitude={selectedCoords.latitude}
               initialZoom={ZOOM}
               navigation={false}
-              locationMarker={coordsProperties}
+              locationMarker
+              locationMarkerCoord={selectedCoords}
               geocoder
               geocoderOptions={geocoderOptions}
               geocoderOnChange={geocoderChange}
@@ -140,7 +141,7 @@ export class YouAndYourNeighbors extends React.Component {
                     f.geometry === null ? [0, 0] : f.geometry.coordinates
                   }
                   getIcon={f => f.properties.type}
-                  getSize={f => 7}
+                  getSize={() => 7}
                   getColor={poiGetIconColor}
                   autoHighlight={false}
                   highlightColor={[0, 0, 0, 0]}
@@ -150,7 +151,7 @@ export class YouAndYourNeighbors extends React.Component {
           </div>
           {noCoordsData && (
             <p>
-              We don't have complete information for your address.{" "}
+              We don&apos;t have complete information for your address.{" "}
               <a href="https://civicplatform.org/">
                 Learn more about how your city can work to get their data in
                 Civic.

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -127,9 +127,9 @@ class BaseMap extends Component {
       containerWidth,
       civicMapStyle,
       mapboxToken,
+      navigation,
       geocoder,
       locationMarker,
-      navigation,
       geocoderOptions,
       geocoderOnChange,
       mapGLOptions,
@@ -140,7 +140,8 @@ class BaseMap extends Component {
       mapboxDataId,
       mapboxLayerType,
       mapboxLayerOptions,
-      mapboxLayerId
+      mapboxLayerId,
+      locationMarkerCoord
     } = this.props;
 
     viewport.width = containerWidth || 500;
@@ -206,8 +207,8 @@ class BaseMap extends Component {
           </div>
           {locationMarker && (
             <Marker
-              latitude={viewport.latitude}
-              longitude={viewport.longitude}
+              latitude={locationMarkerCoord.latitude}
+              longitude={locationMarkerCoord.longitude}
               offsetLeft={-20}
               offsetTop={-10}
             >
@@ -222,7 +223,7 @@ class BaseMap extends Component {
               mapboxApiAccessToken={mapboxToken}
               onViewportChange={newViewport => {
                 this.onViewportChange(newViewport);
-                // eslint-disable-next-line
+                // eslint-disable-next-line no-unused-expressions
                 !!geocoderOnChange && geocoderOnChange(newViewport);
               }}
               options={{ ...geocoderOptions }}
@@ -245,9 +246,13 @@ BaseMap.propTypes = {
   containerWidth: PropTypes.number,
   mapboxToken: PropTypes.string,
   civicMapStyle: PropTypes.string,
-  locationMarker: PropTypes.bool,
-  geocoder: PropTypes.bool,
   navigation: PropTypes.bool,
+  locationMarker: PropTypes.bool,
+  locationMarkerCoord: PropTypes.shape({
+    latitude: PropTypes.number,
+    longitude: PropTypes.number
+  }),
+  geocoder: PropTypes.bool,
   geocoderOptions: PropTypes.shape({}),
   geocoderOnChange: PropTypes.func,
   mapGLOptions: PropTypes.shape({}),
@@ -275,7 +280,11 @@ BaseMap.defaultProps = {
   initialLatitude: 45.5231,
   initialZoom: 9.5,
   initialPitch: 0,
-  height: 500
+  height: 500,
+  locationMarkerCoord: {
+    latitude: 0,
+    longitude: 0
+  }
 };
 
 export default Dimensions()(BaseMap);

--- a/packages/component-library/stories/BaseMap.story.js
+++ b/packages/component-library/stories/BaseMap.story.js
@@ -12,6 +12,7 @@ import { action } from "@storybook/addon-actions";
 import { css } from "emotion";
 import { BaseMap } from "../src";
 import notes from "./baseMap.notes.md";
+import StatefulWrapper from "../src/utils/StatefulWrapper";
 
 const GROUP_IDS = {
   DESIGN: "Design",
@@ -146,12 +147,24 @@ export default () =>
         );
 
         return (
-          <BaseMap
-            geocoder={geocoder}
-            geocoderOptions={geocoderOptions}
-            locationMarker={locationMarker}
-            mapGLOptions={mapGLOptions}
-          />
+          <StatefulWrapper
+            initialState={{ coord: { latitude: 0, longitude: 0 } }}
+          >
+            {({ get, set }) => {
+              return (
+                <BaseMap
+                  geocoder={geocoder}
+                  geocoderOnChange={coord => {
+                    set({ coord });
+                  }}
+                  geocoderOptions={geocoderOptions}
+                  locationMarker={locationMarker}
+                  locationMarkerCoord={get("coord")}
+                  mapGLOptions={mapGLOptions}
+                />
+              );
+            }}
+          </StatefulWrapper>
         );
       },
       {

--- a/packages/component-library/stories/baseMap.notes.md
+++ b/packages/component-library/stories/baseMap.notes.md
@@ -37,7 +37,7 @@ This story shows how to use a geocoder with the Base Map.
 These props can be set in this story:
 
 - **geocoder:** whether the Base Map should include the geocoder
-  - This property expects a boolean
+  - This prop expects a boolean
 - **geocoderOptions:** options for the geocoder search input
   - The geocoderOptions prop expects an object and may include the following properties:
   - **placeholder:** the text that appears in the geocoder search input
@@ -48,8 +48,16 @@ These props can be set in this story:
     - This property expects an array in the format:
       `[minLongitude, minLatitude, maxLongitude, maxLatitude]`
   - [Additional geocoder options can be found here.](https://github.com/mapbox/mapbox-gl-geocoder/blob/master/API.md)
-- **locationMarker:** whether to include a ❌ marker at the result location
-  - This property expects a boolean
+- **geocoderOnChange:** a function that updates the coordinates of the location marker
+  - This prop expects a function
+- **locationMarker:** whether to include an ❌ marker at the location of the geocoder results
+  - This prop expects a boolean
+- **locationMarkerCoord:** the coordinates of the location marker
+  - The locationMarkerCoord prop expects an object and must include the following properties:
+  - **latitude:** the latitude of the location marker
+    - This prop expects a decimal between -90 and 90
+  - **longitude:** the longitude of the location marker
+    - This prop expects a decimal between -120 and 120
 - **mapGLOptions:** interaction properties for the Base Map
   - Please refer to the "Example: No Interactivity" story for more information
 


### PR DESCRIPTION
This addresses #664.

The latitude and longitude in the viewport prop are always located in the center of the map. That's why when the map changes/zooms the location marker remains in the center and not at the coordinates returned by the geocoder. 

I added a `locationMarkerCoord` prop and used that to position of the marker. Now if the map moves/zooms the marker stays in place.

I updated the geocoder Base Map story and made it stateful so that it can keep track of the location marker coordinates. And added the `locationMarkerCoord` and `geocoderOnChange` props to the notes file.

I also updated the You and Your Neighbors story card by adding the `locationMarkerCoord` prop and fixed an error with the `locationMarker` prop. It seems it was being passed an object and not a boolean.

