### PR TITLE
Change default civic-card layout to full, simplify 2019-template index

### DIFF
--- a/packages/2019-template/src/index.js
+++ b/packages/2019-template/src/index.js
@@ -1,6 +1,3 @@
-import React from "react";
-import { CivicCardLayoutFull } from "@hackoregon/component-library";
-
 import App from "./components/App";
 import Routes from "./routes";
 import Reducers from "./state";
@@ -12,13 +9,11 @@ import DemoCard from "./components/DemoCard";
 const CardRegistry = [
   {
     slug: "template-card",
-    // this reflects the odd way that these components are composed
-    component: () => <TemplateCard Layout={CivicCardLayoutFull} />
+    component: TemplateCard
   },
   {
     slug: "demo-card",
-    // this reflects the odd way that these components are composed
-    component: () => <DemoCard Layout={CivicCardLayoutFull} />
+    component: DemoCard
   }
 ];
 

--- a/packages/component-library/src/CivicCard/CivicCard.js
+++ b/packages/component-library/src/CivicCard/CivicCard.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import CivicCardLayoutFull from "./CivicCardLayoutClassic";
+import CivicCardLayoutFull from "./CivicCardLayoutFull";
 
 const CivicCard = ({ cardMeta, data, isLoading, Layout }) => (
   <Layout cardMeta={cardMeta(data)} isLoading={isLoading} data={data} />


### PR DESCRIPTION
A couple of simple simplifying tweaks to `CivicCard` and our `2019-template`