### PR TITLE
Feature/task state

### DIFF
--- a/packages/project-disaster-trail/src/components/Game/TaskScreen.js
+++ b/packages/project-disaster-trail/src/components/Game/TaskScreen.js
@@ -1,0 +1,121 @@
+import React from "react";
+import { PropTypes } from "prop-types";
+import { connect } from "react-redux";
+import { map } from "lodash";
+import {
+  getTaskOrder,
+  getActiveTask,
+  getActiveEnvironment,
+  getTasksForEnvironment,
+  doNextTask,
+  changeEnvironment
+} from "../../state/tasks";
+
+const TaskScreen = ({
+  taskOrder,
+  activeTask,
+  activeEnvironment,
+  tasksForEnvironment,
+  addTask,
+  updateEnvironment
+}) => {
+  const possibleTasks = [];
+  map(tasksForEnvironment[activeEnvironment], tasks => {
+    for (let i = 0; i < tasks.length; i += 1) {
+      const taskOption = tasks[i];
+      possibleTasks.push(
+        <button
+          key={taskOption}
+          type="button"
+          onClick={() => {
+            addTask(taskOption);
+          }}
+        >
+          {taskOption}
+        </button>
+      );
+    }
+  });
+
+  const environments = Object.keys(tasksForEnvironment);
+  const envButtons = [];
+  for (let i = 0; i < environments.length; i += 1) {
+    envButtons.push(
+      <button
+        key={environments[i]}
+        type="button"
+        onClick={() => {
+          updateEnvironment(environments[i]);
+        }}
+      >
+        {environments[i]}
+      </button>
+    );
+  }
+
+  return (
+    <div style={{ flexDirection: "column" }}>
+      <h1>Task Screen</h1>
+      <h2>activeEnvironment: {activeEnvironment}</h2>
+      <div>
+        <h2>tasksForEnvironment</h2>
+        <p>
+          saveYourself: [
+          {map(
+            tasksForEnvironment[activeEnvironment].saveYourself,
+            task => ` ${task}, `
+          )}
+          ]
+        </p>
+        <p>
+          saveOthers: [
+          {map(
+            tasksForEnvironment[activeEnvironment].saveOthers,
+            task => ` ${task}, `
+          )}
+          ]
+        </p>
+      </div>
+
+      <h2>taskOrder: [{map(taskOrder, task => ` ${task}, `)}]</h2>
+
+      <h2>activeTask: {taskOrder[activeTask]}</h2>
+      <h3>Change activeTask</h3>
+      {possibleTasks}
+      <h3>Change activeEnvironment</h3>
+      {envButtons}
+    </div>
+  );
+};
+
+TaskScreen.propTypes = {
+  taskOrder: PropTypes.arrayOf(PropTypes.string),
+  activeTask: PropTypes.number,
+  activeEnvironment: PropTypes.string,
+  tasksForEnvironment: PropTypes.shape({}),
+  addTask: PropTypes.func,
+  updateEnvironment: PropTypes.func
+};
+
+// export default TaskScreen;
+
+const mapStateToProps = state => ({
+  taskOrder: getTaskOrder(state),
+  activeTask: getActiveTask(state),
+  activeEnvironment: getActiveEnvironment(state),
+  tasksForEnvironment: getTasksForEnvironment(state)
+});
+
+const mapDispatchToProps = dispatch => ({
+  addTask(chosenTask) {
+    dispatch(doNextTask(chosenTask));
+  },
+  updateEnvironment(chosenEnv) {
+    dispatch(changeEnvironment(chosenEnv));
+  }
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TaskScreen);

--- a/packages/project-disaster-trail/src/components/Game/TaskScreen.js
+++ b/packages/project-disaster-trail/src/components/Game/TaskScreen.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { PropTypes } from "prop-types";
 import { connect } from "react-redux";
-import { map } from "lodash";
 import {
   getTaskOrder,
   getActiveTask,
@@ -19,39 +18,40 @@ const TaskScreen = ({
   addTask,
   updateEnvironment
 }) => {
-  const possibleTasks = [];
-  map(tasksForEnvironment[activeEnvironment], tasks => {
-    for (let i = 0; i < tasks.length; i += 1) {
-      const taskOption = tasks[i];
-      possibleTasks.push(
-        <button
-          key={taskOption}
-          type="button"
-          onClick={() => {
-            addTask(taskOption);
-          }}
-        >
-          {taskOption}
-        </button>
-      );
-    }
-  });
+  const mapTasksToButton = task => (
+    <button
+      key={task}
+      type="button"
+      onClick={() => {
+        addTask(task);
+      }}
+    >
+      {task}
+    </button>
+  );
 
+  // All possible tasks for the game environment
+  const saveYourselfTasks = tasksForEnvironment[
+    activeEnvironment
+  ].saveYourself.map(mapTasksToButton);
+  const saveOthersTasks = tasksForEnvironment[activeEnvironment].saveOthers.map(
+    mapTasksToButton
+  );
+  const possibleTasks = [].concat(saveYourselfTasks, saveOthersTasks);
+
+  // All types of environment
   const environments = Object.keys(tasksForEnvironment);
-  const envButtons = [];
-  for (let i = 0; i < environments.length; i += 1) {
-    envButtons.push(
-      <button
-        key={environments[i]}
-        type="button"
-        onClick={() => {
-          updateEnvironment(environments[i]);
-        }}
-      >
-        {environments[i]}
-      </button>
-    );
-  }
+  const envButtons = environments.map(environment => (
+    <button
+      key={environment}
+      type="button"
+      onClick={() => {
+        updateEnvironment(environment);
+      }}
+    >
+      {environment}
+    </button>
+  ));
 
   return (
     <div style={{ flexDirection: "column" }}>
@@ -61,23 +61,21 @@ const TaskScreen = ({
         <h2>tasksForEnvironment</h2>
         <p>
           saveYourself: [
-          {map(
-            tasksForEnvironment[activeEnvironment].saveYourself,
+          {tasksForEnvironment[activeEnvironment].saveYourself.map(
             task => ` ${task}, `
           )}
           ]
         </p>
         <p>
           saveOthers: [
-          {map(
-            tasksForEnvironment[activeEnvironment].saveOthers,
+          {tasksForEnvironment[activeEnvironment].saveOthers.map(
             task => ` ${task}, `
           )}
           ]
         </p>
       </div>
 
-      <h2>taskOrder: [{map(taskOrder, task => ` ${task}, `)}]</h2>
+      <h2>taskOrder: [{taskOrder.map(task => ` ${task}, `)}]</h2>
 
       <h2>activeTask: {taskOrder[activeTask]}</h2>
       <h3>Change activeTask</h3>
@@ -96,8 +94,6 @@ TaskScreen.propTypes = {
   addTask: PropTypes.func,
   updateEnvironment: PropTypes.func
 };
-
-// export default TaskScreen;
 
 const mapStateToProps = state => ({
   taskOrder: getTaskOrder(state),

--- a/packages/project-disaster-trail/src/components/Game/index.js
+++ b/packages/project-disaster-trail/src/components/Game/index.js
@@ -8,6 +8,7 @@ import * as SCREENS from "../../constants/screens";
 import { getActiveChapter, setActiveChapter } from "../../state/chapters";
 
 import KitScreen from "./KitScreen";
+import TaskScreen from "./TaskScreen";
 // import Orb from "./Orb";
 import OrbManager from "./OrbManager";
 import PointsView from "../atoms/PointsView";
@@ -40,6 +41,14 @@ const Game = ({ settings, activeChapter, goToChapter }) => {
     </Fragment>
   );
 
+  const taskScreen = (
+    <Fragment>
+      <MapStyle>
+        <TaskScreen />
+      </MapStyle>
+    </Fragment>
+  );
+
   const chapterButtons = (
     <ChapterButtonsStyle>
       <button
@@ -65,7 +74,10 @@ const Game = ({ settings, activeChapter, goToChapter }) => {
     <GameContainerStyle screen={screen}>
       {chapterButtons}
       {activeChapter.id === 2 && kitScreen}
-      {activeChapter.id !== 2 && defaultScreen(activeChapter.title)}
+      {activeChapter.id === 6 && taskScreen}
+      {activeChapter.id !== 2 &&
+        activeChapter.id !== 6 &&
+        defaultScreen(activeChapter.title)}
     </GameContainerStyle>
   );
 };

--- a/packages/project-disaster-trail/src/constants/items.js
+++ b/packages/project-disaster-trail/src/constants/items.js
@@ -1,55 +1,74 @@
-import Corn from "../../assets/corn.svg";
+import CornEmpty from "../../assets/corn.svg";
 import CornColor from "../../assets/corn-color.svg";
-import Water from "../../assets/water.svg";
+import WaterEmpty from "../../assets/water.svg";
 import WaterColor from "../../assets/water-color.svg";
-import FireExtinguisher from "../../assets/fire-extinguisher.svg";
+import FireExtinguisherEmpty from "../../assets/fire-extinguisher.svg";
 import FireExtinguisherColor from "../../assets/fire-extinguisher-color.svg";
-import FirstAid from "../../assets/first-aid-kit.svg";
+import FirstAidEmpty from "../../assets/first-aid-kit.svg";
 import FirstAidColor from "../../assets/first-aid-kit-color.svg";
-import Flashlight from "../../assets/flashlight.svg";
+import FlashlightEmpty from "../../assets/flashlight.svg";
 import FlashlightColor from "../../assets/flashlight-color.svg";
-import WalkieTalkie from "../../assets/walkie-talkie.svg";
+import WalkieTalkieEmpty from "../../assets/walkie-talkie.svg";
 import WalkieTalkieColor from "../../assets/walkie-talkie-color.svg";
 
+export const food = "FOOD";
+export const water = "WATER";
+export const fireExtinguisher = "FIRE_EXTINGUISHER";
+export const firstAidKit = "FIRST_AID_KIT";
+export const flashlight = "FLASHLIGHT";
+export const walkieTalkie = "WALKIE_TALKIE";
+
+// No current svgs
+export const protectiveGear = "PROTECTIVE_GEAR";
+
 export const FOOD = {
-  id: "FOOD",
-  emptySvg: Corn,
+  id: food,
+  emptySvg: CornEmpty,
   fullSvg: CornColor,
   quantity: 0,
   kitsFilledByItem: 0
 };
 export const WATER = {
-  id: "WATER",
-  emptySvg: Water,
+  id: water,
+  emptySvg: WaterEmpty,
   fullSvg: WaterColor,
   quantity: 0,
   kitsFilledByItem: 0
 };
 export const FIRE_EXTINGUISHER = {
-  id: "FIRE_EXTINGUISHER",
-  emptySvg: FireExtinguisher,
+  id: fireExtinguisher,
+  emptySvg: FireExtinguisherEmpty,
   fullSvg: FireExtinguisherColor,
   quantity: 0,
   kitsFilledByItem: 0
 };
 export const FIRST_AID_KIT = {
-  id: "FIRST_AID_KIT",
-  emptySvg: FirstAid,
+  id: firstAidKit,
+  emptySvg: FirstAidEmpty,
   fullSvg: FirstAidColor,
   quantity: 0,
   kitsFilledByItem: 0
 };
 export const FLASHLIGHT = {
-  id: "FLASHLIGHT",
-  emptySvg: Flashlight,
+  id: flashlight,
+  emptySvg: FlashlightEmpty,
   fullSvg: FlashlightColor,
   quantity: 0,
   kitsFilledByItem: 0
 };
 export const WALKIE_TALKIE = {
-  id: "WALKIE_TALKIE",
-  emptySvg: WalkieTalkie,
+  id: walkieTalkie,
+  emptySvg: WalkieTalkieEmpty,
   fullSvg: WalkieTalkieColor,
+  quantity: 0,
+  kitsFilledByItem: 0
+};
+
+// TODO: update items
+export const PROTECTIVE_GEAR = {
+  id: protectiveGear,
+  emptySvg: "https://image.flaticon.com/icons/svg/1705/1705460.svg",
+  fullSvg: "https://image.flaticon.com/icons/svg/1705/1705463.svg",
   quantity: 0,
   kitsFilledByItem: 0
 };
@@ -60,7 +79,8 @@ export const MINIMUM_KIT = {
   FIRE_EXTINGUISHER: { ...FIRE_EXTINGUISHER, quantity: 1 },
   FIRST_AID_KIT: { ...FIRST_AID_KIT, quantity: 1 },
   FLASHLIGHT: { ...FLASHLIGHT, quantity: 1 },
-  WALKIE_TALKIE: { ...WALKIE_TALKIE, quantity: 1 }
+  WALKIE_TALKIE: { ...WALKIE_TALKIE, quantity: 1 },
+  PROTECTIVE_GEAR: { ...PROTECTIVE_GEAR, quantity: 1 }
 };
 
 export default {
@@ -69,5 +89,6 @@ export default {
   FIRE_EXTINGUISHER,
   FIRST_AID_KIT,
   FLASHLIGHT,
-  WALKIE_TALKIE
+  WALKIE_TALKIE,
+  PROTECTIVE_GEAR
 };

--- a/packages/project-disaster-trail/src/constants/tasks.js
+++ b/packages/project-disaster-trail/src/constants/tasks.js
@@ -1,0 +1,71 @@
+import {
+  protectiveGear,
+  fireExtinguisher,
+  firstAidKit,
+  food,
+  water
+} from "./items";
+
+// Save yourself ids
+const protection = "PROTECTION";
+// Save others ids
+const fire = "FIRE";
+const injury = "INJURY";
+const hunger = "HUNGER";
+const thirst = "THIRST";
+
+const tasks = {
+  // Save Yourself
+  protection: {
+    id: protection,
+    time: 10,
+    requiredItems: [protectiveGear],
+    points: 3,
+    text: "I'm afraid I'll fall over the rubble."
+  },
+  // Save Others
+  fire: {
+    id: fire,
+    time: 20,
+    requiredItems: [fireExtinguisher],
+    points: 5,
+    text: "Uh oh! This fire could spread!"
+  },
+  injury: {
+    id: injury,
+    time: 20,
+    requiredItems: [firstAidKit],
+    points: 7,
+    text: "That person looks hurt."
+  },
+  hunger: {
+    id: hunger,
+    time: 20,
+    requiredItems: [food],
+    points: 5,
+    text: "That person looks hurt."
+  },
+  thirst: {
+    id: thirst,
+    time: 20,
+    requiredItems: [water],
+    points: 5,
+    text: "That person looks hurt."
+  }
+};
+
+const tasksForEnvironment = {
+  suburban: {
+    saveYourself: [protection],
+    saveOthers: [hunger, thirst]
+  },
+  urban: {
+    saveYourself: [protection],
+    saveOthers: [fire, injury]
+  }
+};
+
+export default {
+  tasks,
+  tasksForEnvironment
+};

--- a/packages/project-disaster-trail/src/constants/tasks.js
+++ b/packages/project-disaster-trail/src/constants/tasks.js
@@ -7,46 +7,50 @@ import {
 } from "./items";
 
 // Save yourself ids
-const protection = "PROTECTION";
+export const PROTECTION = "protection";
 // Save others ids
-const fire = "FIRE";
-const injury = "INJURY";
-const hunger = "HUNGER";
-const thirst = "THIRST";
+export const FIRE = "fire";
+export const INJURY = "injury";
+export const HUNGER = "hunger";
+export const THIRST = "thirst";
 
-const tasks = {
+// environments
+export const URBAN = "urban";
+export const SUBURBAN = "suburban";
+
+export const tasks = {
   // Save Yourself
-  protection: {
-    id: protection,
+  [PROTECTION]: {
+    id: PROTECTION,
     time: 10,
     requiredItems: [protectiveGear],
     points: 3,
     text: "I'm afraid I'll fall over the rubble."
   },
   // Save Others
-  fire: {
-    id: fire,
+  [FIRE]: {
+    id: FIRE,
     time: 20,
     requiredItems: [fireExtinguisher],
     points: 5,
     text: "Uh oh! This fire could spread!"
   },
-  injury: {
-    id: injury,
+  [INJURY]: {
+    id: INJURY,
     time: 20,
     requiredItems: [firstAidKit],
     points: 7,
     text: "That person looks hurt."
   },
-  hunger: {
-    id: hunger,
+  [HUNGER]: {
+    id: HUNGER,
     time: 20,
     requiredItems: [food],
     points: 5,
     text: "That person looks hurt."
   },
-  thirst: {
-    id: thirst,
+  [THIRST]: {
+    id: THIRST,
     time: 20,
     requiredItems: [water],
     points: 5,
@@ -54,18 +58,13 @@ const tasks = {
   }
 };
 
-const tasksForEnvironment = {
-  suburban: {
-    saveYourself: [protection],
-    saveOthers: [hunger, thirst]
+export const tasksForEnvironment = {
+  [SUBURBAN]: {
+    saveYourself: [PROTECTION],
+    saveOthers: [HUNGER, THIRST]
   },
-  urban: {
-    saveYourself: [protection],
-    saveOthers: [fire, injury]
+  [URBAN]: {
+    saveYourself: [PROTECTION],
+    saveOthers: [FIRE, INJURY]
   }
-};
-
-export default {
-  tasks,
-  tasksForEnvironment
 };

--- a/packages/project-disaster-trail/src/state/chapters.js
+++ b/packages/project-disaster-trail/src/state/chapters.js
@@ -46,6 +46,8 @@ export const chapters = createReducer(initialState, {
     if (action.chapterId < 1) return;
     // eslint-disable-next-line no-param-reassign
     state.activeChapter = action.chapterId;
+
+    // TODO: change chapter model enabled prop
   }
 });
 

--- a/packages/project-disaster-trail/src/state/index.js
+++ b/packages/project-disaster-trail/src/state/index.js
@@ -5,6 +5,7 @@ import chapters from "./chapters";
 import kit from "./kit";
 import user from "./user";
 import settings from "./settings";
+import tasks from "./tasks";
 
 export default function createReducer(asyncReducers) {
   return combineReducers({
@@ -13,6 +14,7 @@ export default function createReducer(asyncReducers) {
     kit,
     user,
     settings,
+    tasks,
     ...asyncReducers
   });
 }

--- a/packages/project-disaster-trail/src/state/tasks.js
+++ b/packages/project-disaster-trail/src/state/tasks.js
@@ -1,27 +1,55 @@
 import { createReducer } from "redux-starter-kit";
+import { shuffle } from "lodash";
 
-import TASKS from "../constants/tasks";
+import { tasks, tasksForEnvironment, URBAN } from "../constants/tasks";
 
-const defaultEnv = "urban";
-const defaultSaveYourself = [
-  TASKS.tasksForEnvironment[defaultEnv].saveYourself
-];
+const defaultEnv = URBAN;
+const defaultSaveYourself = [tasksForEnvironment[defaultEnv].saveYourself];
 
 // INITIAL STATE
 const initialState = {
-  ...TASKS,
+  tasks,
+  tasksForEnvironment,
   activeEnvironment: defaultEnv,
-  taskOrder: defaultSaveYourself,
+  taskOrder: shuffle(defaultSaveYourself),
   activeTask: 0
 };
 
 // CONSTANTS
+const actionTypes = {
+  CHANGE_ENVIRONMENT: "CHANGE_ENVIRONMENT",
+  DO_NEXT_TASK: "DO_NEXT_TASK"
+};
 
 // ACTIONS
+export const changeEnvironment = nextEnvironmentId => dispatch => {
+  dispatch({ type: actionTypes.CHANGE_ENVIRONMENT, nextEnvironmentId });
+};
+export const doNextTask = taskChoice => dispatch => {
+  dispatch({ type: actionTypes.DO_NEXT_TASK, taskChoice });
+};
 
 // REDUCERS
-export const settings = createReducer(initialState, {});
+/* eslint-disable no-param-reassign */
+export const tasksReducer = createReducer(initialState, {
+  [actionTypes.CHANGE_ENVIRONMENT]: (state, action) => {
+    const newTasks = tasksForEnvironment[action.nextEnvironmentId];
 
-export default settings;
+    state.activeEnvironment = action.nextEnvironmentId;
+    state.taskOrder = shuffle(newTasks);
+    state.activeTask = 0;
+  },
+  [actionTypes.DO_NEXT_TASK]: (state, action) => {
+    state.activeTask += 1;
+    const noNextTask = state.taskOrder[state.activeTask];
+
+    if (noNextTask) {
+      state.taskOrder.push(action.taskChoice);
+    }
+  }
+});
+/* eslint-enable no-param-reassign */
+
+export default tasksReducer;
 
 // SELECTORS

--- a/packages/project-disaster-trail/src/state/tasks.js
+++ b/packages/project-disaster-trail/src/state/tasks.js
@@ -1,0 +1,27 @@
+import { createReducer } from "redux-starter-kit";
+
+import TASKS from "../constants/tasks";
+
+const defaultEnv = "urban";
+const defaultSaveYourself = [
+  TASKS.tasksForEnvironment[defaultEnv].saveYourself
+];
+
+// INITIAL STATE
+const initialState = {
+  ...TASKS,
+  activeEnvironment: defaultEnv,
+  taskOrder: defaultSaveYourself,
+  activeTask: 0
+};
+
+// CONSTANTS
+
+// ACTIONS
+
+// REDUCERS
+export const settings = createReducer(initialState, {});
+
+export default settings;
+
+// SELECTORS

--- a/packages/project-disaster-trail/src/state/tasks.js
+++ b/packages/project-disaster-trail/src/state/tasks.js
@@ -1,10 +1,10 @@
-import { createReducer } from "redux-starter-kit";
+import { createReducer, createSelector } from "redux-starter-kit";
 import { shuffle } from "lodash";
 
 import { tasks, tasksForEnvironment, URBAN } from "../constants/tasks";
 
 const defaultEnv = URBAN;
-const defaultSaveYourself = [tasksForEnvironment[defaultEnv].saveYourself];
+const defaultSaveYourself = tasksForEnvironment[defaultEnv].saveYourself;
 
 // INITIAL STATE
 const initialState = {
@@ -33,7 +33,7 @@ export const doNextTask = taskChoice => dispatch => {
 /* eslint-disable no-param-reassign */
 export const tasksReducer = createReducer(initialState, {
   [actionTypes.CHANGE_ENVIRONMENT]: (state, action) => {
-    const newTasks = tasksForEnvironment[action.nextEnvironmentId];
+    const newTasks = tasksForEnvironment[action.nextEnvironmentId].saveYourself;
 
     state.activeEnvironment = action.nextEnvironmentId;
     state.taskOrder = shuffle(newTasks);
@@ -41,7 +41,7 @@ export const tasksReducer = createReducer(initialState, {
   },
   [actionTypes.DO_NEXT_TASK]: (state, action) => {
     state.activeTask += 1;
-    const noNextTask = state.taskOrder[state.activeTask];
+    const noNextTask = !state.taskOrder[state.activeTask];
 
     if (noNextTask) {
       state.taskOrder.push(action.taskChoice);
@@ -53,3 +53,23 @@ export const tasksReducer = createReducer(initialState, {
 export default tasksReducer;
 
 // SELECTORS
+
+export const getTaskOrder = createSelector(
+  ["tasks.taskOrder"],
+  taskOrder => taskOrder
+);
+
+export const getActiveTask = createSelector(
+  ["tasks.activeTask"],
+  activeTask => activeTask
+);
+
+export const getActiveEnvironment = createSelector(
+  ["tasks.activeEnvironment"],
+  activeEnvironment => activeEnvironment
+);
+
+export const getTasksForEnvironment = createSelector(
+  ["tasks.tasksForEnvironment"],
+  foundTasks => foundTasks
+);


### PR DESCRIPTION
Adds `tasks` to the application's state. Includes some example tasks, environments where tasks are applicable, and enables adding tasks (like we would on a vote) and changing the environment (like we would at the end of the game)

You can check out the tasks by clicking to the tasks chapter OR you can go to `project-disaster-trail/src/constants/chapters.js` and update CHAPTERS.2.enabled to `false` and CHAPTERS.6.enabled to `true` if you'll be refreshing much.

![tasks](https://user-images.githubusercontent.com/10056079/61986727-05f77680-afc6-11e9-97ec-8db16da0b457.gif)
