### PR TITLE
Add redux-devtools-extension to 2018 & mockwrapper

### DIFF
--- a/packages/2018/package.json
+++ b/packages/2018/package.json
@@ -33,7 +33,7 @@
     "@hackoregon/2018-transportation-systems": "^3.0.0",
     "@hackoregon/2019-housing": "^1.0.0",
     "@hackoregon/2019-template": "^1.0.0",
-    "@hackoregon/2019-transportation": "^1.0.0",    
+    "@hackoregon/2019-transportation": "^1.0.0",
     "@hackoregon/civic-sandbox": "^3.0.0",
     "@hackoregon/component-library": "^3.0.0",
     "chalk": "^1.1.3",
@@ -48,6 +48,7 @@
     "react-router-redux": "^4.0.8",
     "react-typekit": "^1.1.3",
     "redux": "^4.0.1",
+    "redux-devtools-extension": "^2.13.8",
     "redux-form": "^8.1.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.1.0"

--- a/packages/2018/src/App.js
+++ b/packages/2018/src/App.js
@@ -1,6 +1,6 @@
 /* eslint-disable global-require */
 import React from "react";
-import { createStore, compose, applyMiddleware, combineReducers } from "redux";
+import { createStore, applyMiddleware, combineReducers } from "redux";
 import thunk from "redux-thunk";
 import { Provider } from "react-redux";
 import { Router, browserHistory } from "react-router";
@@ -11,6 +11,7 @@ import {
 } from "react-router-redux";
 import { createLogger } from "redux-logger";
 import { reducer as reduxFormReducer } from "redux-form";
+import { composeWithDevTools } from "redux-devtools-extension";
 
 // Import routes, reducers, and root component from each project
 import {
@@ -87,8 +88,6 @@ const configureStore = (initialState, history) => {
     middlewares.push(createLogger());
   }
 
-  const composeEnhancers =
-    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE_ || compose;
   const store = createStore(
     combineReducers({
       routing: routerReducer,
@@ -106,7 +105,7 @@ const configureStore = (initialState, history) => {
       transportation2019: Transportation2019Reducers()
     }),
     initialState,
-    composeEnhancers(applyMiddleware(...middlewares))
+    composeWithDevTools(applyMiddleware(...middlewares))
   );
 
   store.asyncReducers = {};

--- a/packages/mock-wrapper/package.json
+++ b/packages/mock-wrapper/package.json
@@ -29,6 +29,7 @@
     "react-router": "^3.0.0",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
+    "redux-devtools-extension": "^2.13.8",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.1.0"
   },

--- a/packages/mock-wrapper/package.json
+++ b/packages/mock-wrapper/package.json
@@ -29,9 +29,11 @@
     "react-router": "^3.0.0",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
-    "redux-devtools-extension": "^2.13.8",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.1.0"
+  },
+  "devDependencies": {
+    "redux-devtools-extension": "^2.13.8"
   },
   "gitHead": "b50f7a7fca617964ade5a3ecb5225fee17b20fe4"
 }

--- a/packages/mock-wrapper/src/index.js
+++ b/packages/mock-wrapper/src/index.js
@@ -1,21 +1,20 @@
 import React from "react";
 import { render } from "react-dom";
-import { createStore, compose, applyMiddleware } from "redux";
+import { createStore, applyMiddleware } from "redux";
 import thunk from "redux-thunk";
 import { syncHistoryWithStore, routerMiddleware } from "react-router-redux";
 import { Provider } from "react-redux";
 import { Router, browserHistory } from "react-router";
 import { createLogger } from "redux-logger";
+import { composeWithDevTools } from "redux-devtools-extension";
 
 export default function MockWrapper(App, Reducers, Routes = () => []) {
   const middlewares = [thunk, routerMiddleware(browserHistory), createLogger()];
 
-  const composeEnhancers =
-    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE_ || compose;
   const store = createStore(
     Reducers(),
     {},
-    composeEnhancers(applyMiddleware(...middlewares))
+    composeWithDevTools(applyMiddleware(...middlewares))
   );
 
   store.asyncReducers = {};

--- a/packages/mock-wrapper/src/index.js
+++ b/packages/mock-wrapper/src/index.js
@@ -6,6 +6,7 @@ import { syncHistoryWithStore, routerMiddleware } from "react-router-redux";
 import { Provider } from "react-redux";
 import { Router, browserHistory } from "react-router";
 import { createLogger } from "redux-logger";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { composeWithDevTools } from "redux-devtools-extension";
 
 export default function MockWrapper(App, Reducers, Routes = () => []) {


### PR DESCRIPTION
Our previous method of applying the redux-dev-tools extension wasn't working. It works now in project packages and year packages!

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/7065695/62208020-89102800-b34a-11e9-8648-85471a7af54b.png">
