### PR TITLE
Accessibility landmarks

### DIFF
--- a/packages/2019-template/src/components/DemoCard/demoCardMeta.js
+++ b/packages/2019-template/src/components/DemoCard/demoCardMeta.js
@@ -19,12 +19,12 @@ const demoCardMeta = (/* data */) => ({
       <p>
         TriMet, the transit agency serving the Portland, OR, metro area, has
         seen recent declines in bus ridership, similar to other agencies across
-        the country. TriMet has{" "}
+        the country.{" "}
         <a href="http://transitcenter.org/2017/11/14/in-portland-economic-displacement-may-be-a-driver-of-transit-ridership-loss/">
-          cited
+          TriMet has cited economic displacement as a main driver of ridership
+          loss
         </a>{" "}
-        economic displacement as a main driver of ridership loss. Portland is
-        one of the most{" "}
+        . Portland is one of the most{" "}
         <a href="http://www.oregonlive.com/hg/index.ssf/2017/02/portland_gentrification_4_real.html">
           rapidly gentrifying cities
         </a>{" "}

--- a/packages/component-library/src/Footer/Footer.js
+++ b/packages/component-library/src/Footer/Footer.js
@@ -76,7 +76,7 @@ const scrollToTopClass = css`
 const defaultAttribution = `\u00A9 Copyright ${new Date().getFullYear()}`;
 
 const Footer = ({ attribution }) => (
-  <div className={footerClass}>
+  <footer className={footerClass}>
     <div className={copyrightClass}>{attribution}</div>
     <div className={logoClass}>
       <Link to="/" className={logoLinkStyle}>
@@ -86,7 +86,7 @@ const Footer = ({ attribution }) => (
     <div className={scrollToTopClass}>
       <ScrollToTop iconStyle="fa fa-angle-up" />
     </div>
-  </div>
+  </footer>
 );
 
 Footer.displayName = "Footer";

--- a/packages/component-library/src/Navigation/Header.js
+++ b/packages/component-library/src/Navigation/Header.js
@@ -94,7 +94,10 @@ class Header extends Component {
   render() {
     const { children, menu, title, overlay, mainProjectColor } = this.props;
     return (
-      <header className={overlay ? overlayContainerClass : containerClass}>
+      <header
+        className={overlay ? overlayContainerClass : containerClass}
+        id="site-header"
+      >
         <nav
           className={overlay ? overlayHeaderClass : headerClass}
           style={{ backgroundColor: mainProjectColor || primaryColor }}

--- a/packages/component-library/src/Navigation/Header.js
+++ b/packages/component-library/src/Navigation/Header.js
@@ -94,7 +94,7 @@ class Header extends Component {
   render() {
     const { children, menu, title, overlay, mainProjectColor } = this.props;
     return (
-      <div className={overlay ? overlayContainerClass : containerClass}>
+      <header className={overlay ? overlayContainerClass : containerClass}>
         <nav
           className={overlay ? overlayHeaderClass : headerClass}
           style={{ backgroundColor: mainProjectColor || primaryColor }}
@@ -126,7 +126,7 @@ class Header extends Component {
             />
           </a>
         </nav>
-      </div>
+      </header>
     );
   }
 }

--- a/packages/component-library/src/PageLayout/PageLayout.js
+++ b/packages/component-library/src/PageLayout/PageLayout.js
@@ -54,7 +54,7 @@ const PageLayout = ({
   <div>
     {header && (
       <Header
-        title="Civic"
+        title="Civic homepage"
         mainProjectColor={mainProjectColor}
         overlay={overlay || false}
       />

--- a/packages/component-library/src/ScrollToTop/ScrollToTop.js
+++ b/packages/component-library/src/ScrollToTop/ScrollToTop.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import Icon from "../Icon/Icon";
 
-const hashToGoToTop = "#";
+const hashToGoToTop = "#site-header";
 const styles = {
   display: "flex",
   flexDirection: "column",
@@ -11,7 +11,7 @@ const styles = {
 
 const ScrollToTop = ({ iconStyle = null }) => (
   <div>
-    <a style={styles} aria-label="scroll to top" href={hashToGoToTop}>
+    <a style={styles} href={hashToGoToTop}>
       {iconStyle && <Icon className={iconStyle} />}
       <span>Back to Top</span>
     </a>


### PR DESCRIPTION
Added semantic HTML elements for the site header and footer to create [landmark areas](https://www.scottohara.me/blog/2018/03/03/landmarks.html) to improve navigation for some assistive technology users.

Removed an `aria-label` attribute from the "back to top" link and connected that link to the site header to improve the experience for some assistive technology users and also keyboard users.

Updated `alt` text for Civic logo in the header to better describe the destination of the parent link. Screen reader users will hear "Civic homepage" instead of "Civic".