### PR TITLE
Added CivicCardLayoutVisualizationOnly component

### DIFF
--- a/packages/2019-template/src/components/App/index.js
+++ b/packages/2019-template/src/components/App/index.js
@@ -5,7 +5,8 @@ import { cx, css } from "emotion"; // eslint-disable-line emotion/no-vanilla
 import {
   PageLayout,
   PullQuote,
-  CivicCardLayoutClassic
+  CivicCardLayoutClassic,
+  CivicCardLayoutVisualizationOnly
 } from "@hackoregon/component-library";
 
 import TemplateCard from "../TemplateCard";
@@ -44,6 +45,18 @@ const App = () => (
   >
     <section className={cx(sectionBodyHeading, sectionMaxWidthSmall)}>
       <h2>Ullamcorper dignissim cras tincidunt?</h2>
+    </section>
+    <section className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
+      <p className={paragraphStyle}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Elementum curabitur
+        vitae nunc sed. Nisl condimentum id venenatis a condimentum vitae sapien
+        pellentesque. Sapien eget mi proin sed libero enim sed faucibus turpis.
+        Fermentum leo vel orci porta.
+      </p>
+    </section>
+    <section className={sectionMarginMedium}>
+      <DemoCard Layout={CivicCardLayoutVisualizationOnly} />
     </section>
     <section className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
       <p className={paragraphStyle}>

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -73,6 +73,7 @@
     "webpack-cli": "^3.2.3"
   },
   "dependencies": {
+    "@emotion/core": "^10.0.15",
     "@material-ui/core": "^4.1.3",
     "chai-enzyme": "^1.0.0-beta.1",
     "cheerio": "^1.0.0-rc.2",

--- a/packages/component-library/src/CivicCard/CivicCardLayoutVisualizationOnly.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutVisualizationOnly.js
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import PropTypes from "prop-types";
+import CivicCardLink from "./CivicCardLink";
+
+function CivicCardLayoutVisualizationOnly({ isLoading, data, cardMeta }) {
+  return (
+    <div
+      css={css`
+        text-align: center;
+      `}
+    >
+      <cardMeta.visualization isLoading={isLoading} data={data} />
+      <CivicCardLink slug={cardMeta.slug}>Learn more</CivicCardLink>
+    </div>
+  );
+}
+
+CivicCardLayoutVisualizationOnly.propTypes = {
+  isLoading: PropTypes.bool,
+  data: PropTypes.arrayOf(PropTypes.object),
+  cardMeta: PropTypes.shape({
+    /* TODO: Add shape */
+  })
+};
+
+export default CivicCardLayoutVisualizationOnly;

--- a/packages/component-library/src/CivicCard/CivicCardLink.js
+++ b/packages/component-library/src/CivicCard/CivicCardLink.js
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { Link } from "react-router";
+
+import PropTypes from "prop-types";
+
+const CardLink = ({ children, slug }) => (
+  <div>
+    <Link to={`cards/${slug}`}>
+      <span>{children}</span>
+    </Link>
+  </div>
+);
+
+CardLink.displayName = "CardLink";
+CardLink.propTypes = {
+  children: PropTypes.node,
+  slug: PropTypes.string
+};
+
+export default CardLink;

--- a/packages/component-library/src/index.js
+++ b/packages/component-library/src/index.js
@@ -62,6 +62,9 @@ export {
 export {
   default as CivicCardLayoutClassic
 } from "./CivicCard/CivicCardLayoutClassic";
+export {
+  default as CivicCardLayoutVisualizationOnly
+} from "./CivicCard/CivicCardLayoutVisualizationOnly";
 
 export { default as civicFormat } from "./utils/civicFormat";
 export { default as ungroupBy } from "./utils/ungroupBy";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,6 +1171,16 @@
     find-root "^1.1.0"
     source-map "^0.7.2"
 
+"@emotion/cache@^10.0.15":
+  version "10.0.15"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.15.tgz#b81767b48015aae2689c60373992145c67b8de02"
+  integrity sha512-8VthgeKhlGeTXSW1JN7I14AnAaiFPbOrqNqg3dPoGCZ3bnMjkrmRU0zrx0BtBw9esBaPaQgDB9y0tVgAGT2Mrg==
+  dependencies:
+    "@emotion/sheet" "0.9.3"
+    "@emotion/stylis" "0.8.4"
+    "@emotion/utils" "0.11.2"
+    "@emotion/weak-memoize" "0.2.3"
+
 "@emotion/cache@^10.0.9":
   version "10.0.9"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.9.tgz#e0c7b7a289f7530edcfad4dcf3858bd2e5700a6f"
@@ -1189,6 +1199,27 @@
     "@emotion/serialize" "^0.11.6"
     "@emotion/sheet" "0.9.2"
     "@emotion/utils" "0.11.1"
+
+"@emotion/core@^10.0.15":
+  version "10.0.15"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.15.tgz#b8489d85d64b45bd03abdb8a3d9639ba8a0328d0"
+  integrity sha512-VHwwl3k/ddMfQOHYgOJryXOs2rGJ5AfKLQGm5AVolNonnr6tkmDI4nzIMNaPpveoXVs7sP0OrF24UunIPxveQw==
+  dependencies:
+    "@babel/runtime" "^7.4.3"
+    "@emotion/cache" "^10.0.15"
+    "@emotion/css" "^10.0.14"
+    "@emotion/serialize" "^0.11.9"
+    "@emotion/sheet" "0.9.3"
+    "@emotion/utils" "0.11.2"
+
+"@emotion/css@^10.0.14":
+  version "10.0.14"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.14.tgz#95dacabdd0e22845d1a1b0b5968d9afa34011139"
+  integrity sha512-MozgPkBEWvorcdpqHZE5x1D/PLEHUitALQCQYt2wayf4UNhpgQs2tN0UwHYS4FMy5ROBH+0ALyCFVYJ/ywmwlg==
+  dependencies:
+    "@emotion/serialize" "^0.11.8"
+    "@emotion/utils" "0.11.2"
+    babel-plugin-emotion "^10.0.14"
 
 "@emotion/css@^10.0.9":
   version "10.0.9"
@@ -1258,6 +1289,17 @@
     "@emotion/utils" "0.11.2"
     csstype "^2.5.7"
 
+"@emotion/serialize@^0.11.9":
+  version "0.11.9"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.9.tgz#123e0f51d2dee9693fae1057bd7fc27b021d6868"
+  integrity sha512-/Cn4V81z3ZyFiDQRw8nhGFaHkxHtmCSSBUit4vgTuLA1BqxfJUYiqSq97tq/vV8z9LfIoqs6a9v6QrUFWZpK7A==
+  dependencies:
+    "@emotion/hash" "0.7.2"
+    "@emotion/memoize" "0.7.2"
+    "@emotion/unitless" "0.7.4"
+    "@emotion/utils" "0.11.2"
+    csstype "^2.5.7"
+
 "@emotion/serialize@^0.9.1":
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.9.1.tgz#a494982a6920730dba6303eb018220a2b629c145"
@@ -1270,6 +1312,11 @@
 "@emotion/sheet@0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.2.tgz#74e5c6b5e489a1ba30ab246ab5eedd96916487c4"
+
+"@emotion/sheet@0.9.3":
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.3.tgz#689f135ecf87d3c650ed0c4f5ddcbe579883564a"
+  integrity sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A==
 
 "@emotion/styled-base@^10.0.10":
   version "10.0.10"
@@ -1309,6 +1356,11 @@
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.3.tgz#3ca7e9bcb31b3cb4afbaeb66156d86ee85e23246"
 
+"@emotion/stylis@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.4.tgz#6c51afdf1dd0d73666ba09d2eb6c25c220d6fe4c"
+  integrity sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==
+
 "@emotion/stylis@^0.7.0":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.7.1.tgz#50f63225e712d99e2b2b39c19c70fff023793ca5"
@@ -1342,6 +1394,11 @@
 "@emotion/weak-memoize@0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
+
+"@emotion/weak-memoize@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.3.tgz#dfa0c92efe44a1d1a7974fb49ffeb40ef2da5a27"
+  integrity sha512-zVgvPwGK7c1aVdUVc9Qv7SqepOGRDrqCw7KZPSZziWGxSlbII3gmvGLPzLX4d0n0BMbamBacUrN22zOMyFFEkQ==
 
 "@icons/material@^0.2.4":
   version "0.2.4"


### PR DESCRIPTION
This layout for CivicCard just shows the visualization with a link to "Learn more" to show the whole card.

The "Learn more" could use some design work but figured it'd be useful to have this component as an option.

<img width="476" alt="image" src="https://user-images.githubusercontent.com/7065695/62418925-f7ded100-b629-11e9-8ae7-72ac131869b6.png">

I also added @emotion/core to the component-library.
