### PR TITLE
Introduce a directive for skipping hygen rules

### DIFF
--- a/_templates/api-story-card/with-prompt/src/index-import.ejs.t
+++ b/_templates/api-story-card/with-prompt/src/index-import.ejs.t
@@ -3,6 +3,7 @@ to: packages/<%=package%>/src/index.js
 inject: true
 # This regex will inject this after the the last occurrence of a new line that begins with "import" (i.e. right after the other import statements)
 after: \nimport(?![\s\S]*\nimport).*
-skip_if: import <%=StoryCardName%> from
+# Skip if the story card is already imported OR if the hygen:skip directive is found
+skip_if: "(import <%=StoryCardName%> from|hygen:skip)"
 ---
 import <%=StoryCardName%> from './components/<%=StoryCardName%>'

--- a/_templates/api-story-card/with-prompt/src/index-registry.ejs.t
+++ b/_templates/api-story-card/with-prompt/src/index-registry.ejs.t
@@ -2,7 +2,8 @@
 to: packages/<%=package%>/src/index.js
 inject: true
 after: \[
-skip_if: <%=slug%>
+# Skip if the slug is found OR if the hygen:skip directive is found
+skip_if: "(<%=slug%>|hygen:skip)"
 ---
   {
     slug: "<%=slug%>",

--- a/packages/project-disaster-trail/src/index.js
+++ b/packages/project-disaster-trail/src/index.js
@@ -1,3 +1,4 @@
+// hygen:skip
 import App from "./components/App";
 import Routes from "./routes";
 import Reducers from "./state";


### PR DESCRIPTION
Since hygen only supports regular expressions for skipping injections, which is particularly bad for matching the absence of text.

I hereby declare a new `// hygen:skip` pattern to make it easier to write hygen skip rules.

The origin of this work was #737, which details how an errant insertion can cause a syntax error.