### PR TITLE
Remove redux logger from 2018 and convenience packages

### DIFF
--- a/packages/2018-disaster-resilience/package.json
+++ b/packages/2018-disaster-resilience/package.json
@@ -50,7 +50,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.0"
   },

--- a/packages/2018-example-farmers-markets/package.json
+++ b/packages/2018-example-farmers-markets/package.json
@@ -47,7 +47,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.0"
   },

--- a/packages/2018-housing-affordability/package.json
+++ b/packages/2018-housing-affordability/package.json
@@ -50,7 +50,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.0"
   },

--- a/packages/2018-local-elections/package.json
+++ b/packages/2018-local-elections/package.json
@@ -50,7 +50,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.0"
   },

--- a/packages/2018-neighborhood-development/package.json
+++ b/packages/2018-neighborhood-development/package.json
@@ -51,7 +51,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.0"
   },

--- a/packages/2018-transportation-systems/package.json
+++ b/packages/2018-transportation-systems/package.json
@@ -49,7 +49,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.0"
   },

--- a/packages/2018/package.json
+++ b/packages/2018/package.json
@@ -50,7 +50,6 @@
     "redux": "^4.0.1",
     "redux-devtools-extension": "^2.13.8",
     "redux-form": "^8.1.0",
-    "redux-logger": "^3.0.6",
     "redux-thunk": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/2018/src/App.js
+++ b/packages/2018/src/App.js
@@ -9,7 +9,6 @@ import {
   routerMiddleware,
   syncHistoryWithStore
 } from "react-router-redux";
-import { createLogger } from "redux-logger";
 import { reducer as reduxFormReducer } from "redux-form";
 import { composeWithDevTools } from "redux-devtools-extension";
 
@@ -84,9 +83,6 @@ import CardDetailPageEmbed from "./components/CardDetailPageEmbed";
 // Create a store by combining all project reducers and the routing reducer
 const configureStore = (initialState, history) => {
   const middlewares = [thunk, routerMiddleware(history)];
-  if (process.env.NODE_ENV !== "production") {
-    middlewares.push(createLogger());
-  }
 
   const store = createStore(
     combineReducers({

--- a/packages/2019-housing/package.json
+++ b/packages/2019-housing/package.json
@@ -47,7 +47,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.0"
   },

--- a/packages/2019-template/package.json
+++ b/packages/2019-template/package.json
@@ -51,7 +51,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-thunk": "^2.1.0",
     "reduxful": "^1.2.2",
     "reselect": "^3.0.0"

--- a/packages/2019-transportation/package.json
+++ b/packages/2019-transportation/package.json
@@ -51,7 +51,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.0"
   },

--- a/packages/civic-sandbox/package.json
+++ b/packages/civic-sandbox/package.json
@@ -47,7 +47,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.0"
   },

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -22,7 +22,6 @@
     "chalk": "^2.4.2",
     "compression": "^1.7.4",
     "express": "^4.17.1",
-    "redux-logger": "^3.0.6",
     "webpack": "^4.33.0",
     "webpack-dev-middleware": "^3.6.1",
     "webpack-hot-middleware": "^2.22.0",

--- a/packages/mock-wrapper/package.json
+++ b/packages/mock-wrapper/package.json
@@ -29,7 +29,6 @@
     "react-router": "^3.0.0",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
-    "redux-logger": "^3.0.6",
     "redux-thunk": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/mock-wrapper/src/index.js
+++ b/packages/mock-wrapper/src/index.js
@@ -5,12 +5,11 @@ import thunk from "redux-thunk";
 import { syncHistoryWithStore, routerMiddleware } from "react-router-redux";
 import { Provider } from "react-redux";
 import { Router, browserHistory } from "react-router";
-import { createLogger } from "redux-logger";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { composeWithDevTools } from "redux-devtools-extension";
 
 export default function MockWrapper(App, Reducers, Routes = () => []) {
-  const middlewares = [thunk, routerMiddleware(browserHistory), createLogger()];
+  const middlewares = [thunk, routerMiddleware(browserHistory)];
 
   const store = createStore(
     Reducers(),

--- a/packages/project-disaster-trail/package.json
+++ b/packages/project-disaster-trail/package.json
@@ -55,7 +55,6 @@
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",
-    "redux-logger": "^2.8.2",
     "redux-starter-kit": "^0.5.1",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3752,20 +3752,20 @@ axe-core@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.2.2.tgz#b06d6e9ae4636d706068843272bfaeed3fe97362"
 
-axios@0.19.0, axios@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
-  dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
-
 axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
   dependencies:
     follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
+
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 axobject-query@^2.0.2:
   version "2.0.2"
@@ -6152,10 +6152,6 @@ dedent@^0.7.0:
 deep-diff@0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.4.tgz#aac5c39952236abe5f037a2349060ba01b00ae48"
-
-deep-diff@^0.3.5:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
 
 deep-eql@^3.0.1:
   version "3.0.1"
@@ -13646,12 +13642,6 @@ redux-logger@^2.8.2:
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-2.10.2.tgz#3c5a5f0a6f32577c1deadf6655f257f82c6c3937"
   dependencies:
     deep-diff "0.3.4"
-
-redux-logger@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
-  dependencies:
-    deep-diff "^0.3.5"
 
 redux-mock-store@^1.2.1:
   version "1.5.3"


### PR DESCRIPTION
Now that #687 is complete, we can use the [Redux Dev Tools](https://github.com/reduxjs/redux-devtools) rather than Redux Logger. 

This will allow us to see other console messages much more clearly.

Note -- left 2017 packages alone for now