### PR TITLE
Fix chart animation issues and VictoryAnimate PropType warnings

### DIFF
--- a/packages/component-library/src/BarChart/BarChart.js
+++ b/packages/component-library/src/BarChart/BarChart.js
@@ -103,6 +103,7 @@ const BarChart = ({
             y="dataValue"
             title="Bar Chart"
             style={{ data: { width: barWidth } }}
+            animate
           />
         </VictoryChart>
       </DataChecker>

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
@@ -173,6 +173,7 @@ const HorizontalBarChart = ({
               x="sortOrder"
               y="dataValue"
               events={chartEvents}
+              animate
             />
           )}
           {!stacked && (
@@ -203,6 +204,7 @@ const HorizontalBarChart = ({
               x="sortOrder"
               y="dataValue"
               events={chartEvents}
+              animate
             />
           )}
           {stacked && (
@@ -235,6 +237,7 @@ const HorizontalBarChart = ({
                         theme={CivicVictoryTheme.civic}
                       />
                     }
+                    animate
                   />
                 );
               })}

--- a/packages/component-library/src/LineChart/LineChart.js
+++ b/packages/component-library/src/LineChart/LineChart.js
@@ -75,7 +75,7 @@ const LineChart = ({
           // line animations when the animate properties are derived from the VictoryChart
           // wrapping component. Remove this direct animate after the bug is fixed.
           // https://github.com/FormidableLabs/victory/issues/1282
-          animate={100}
+          animate
         />
       ))
     : null;

--- a/packages/component-library/src/StackedAreaChart/StackedAreaChart.js
+++ b/packages/component-library/src/StackedAreaChart/StackedAreaChart.js
@@ -75,6 +75,7 @@ const StackedAreaChart = ({
           y="dataValue"
           style={getDefaultAreaStyle(index)}
           standalone={false}
+          animate
         />
       ))
     : null;
@@ -111,6 +112,7 @@ const StackedAreaChart = ({
               theme={CivicVictoryTheme.civic}
             />
           }
+          animate
         />
       ))
     : null;

--- a/packages/component-library/src/VictoryTheme/CivicVictoryTheme.js
+++ b/packages/component-library/src/VictoryTheme/CivicVictoryTheme.js
@@ -186,7 +186,7 @@ export default {
   ),
   chart: assign(
     {
-      animate: 100
+      animate: { duration: 1000 }
     },
     baseProps
   ),


### PR DESCRIPTION
We were using the animate prop on Victory improperly, and it was clouding the console with errors as well as causing issues with animations not completing. This simple PR solves those issues.

Before:
![Screen Recording 2019-08-10 at 9 10 04 PM](https://user-images.githubusercontent.com/7065695/62829498-e8283500-bbb3-11e9-9064-a882e243ec83.gif)

After:
![Screen Recording 2019-08-10 at 9 08 11 PM](https://user-images.githubusercontent.com/7065695/62829496-cf1f8400-bbb3-11e9-9b9f-14afea25754f.gif)
