### PR TITLE
Update Icon Map to use Material Design Icons

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -76,6 +76,8 @@
   "dependencies": {
     "@emotion/core": "^10.0.15",
     "@material-ui/core": "^4.1.3",
+    "@mdi/js": "^3.9.97",
+    "@mdi/react": "^1.2.1",
     "copy-to-clipboard": "^3.0.5",
     "create-react-ref": "^0.1.0",
     "d3": "^4.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,6 +2259,16 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
+"@mdi/js@^3.9.97":
+  version "3.9.97"
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-3.9.97.tgz#8bf012999b9f6898692b854a32f6f17c344b125a"
+  integrity sha512-JzX6rDlUcNZHaoUg9sAzdg5Js287tvgRbNmMIyKoJK2ZCP9JupeWTYlpbX4oNJ9Zg9v8YH76WuWLALKOospQgw==
+
+"@mdi/react@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@mdi/react/-/react-1.2.1.tgz#24279784e080728e953f3c1a71f49c64031dee47"
+  integrity sha512-1IRIVCT07vlLmaZjVtGfyfwCMivg/tCtPj0+r1BKrkoh9z4xLf+M1TD0LhjJPO+4+O0ibW+xrNRvf+boRRtX9A==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -3752,20 +3762,20 @@ axe-core@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.2.2.tgz#b06d6e9ae4636d706068843272bfaeed3fe97362"
 
-axios@0.19.0, axios@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
-  dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
-
 axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
   dependencies:
     follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
+
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 axobject-query@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
This PR updates the Icon Map to use Material Design Icons.

However, I ran into an issue with using svg icons created as a component with `@mdi/react`. Instead, I used the path data from `@mdi/js` to create a data URI for each svg icon and passed that as the url property for the `getIcon` prop.

Since the [disaster resilience API endpoint](https://service.civicpdx.org/disaster-resilience/sandbox/slides/poi/) from last year we used for the icon map is returning an internal server error, I had to improvise. Ideally the `iconSet` object would contain the name of each icon and then within the `getIcon` function use the `d.properties.type` from the GeoJSON to set the url. I had to use numbers and create it randomly.

I opened this PR as a draft because even though this works I'm not sure this couldn't be improved. So I'm open to any suggestions, comments, or questions.

