### PR TITLE
run yarn instead of yarn bootstrap after card and package generators

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "scripts": {
     "bootstrap": "yarn install --frozen-lockfile && yarn --cwd ./packages/component-library/ build && yarn --cwd ./packages/mock-wrapper/ build",
     "build": "lerna run build",
-    "new-package": "yarn hygen package-generator with-prompt && yarn bootstrap",
-    "card": "yarn hygen api-story-card with-prompt && yarn bootstrap",
-    "card:local-data": "yarn hygen local-data-story-card with-prompt && yarn bootstrap",
+    "new-package": "yarn hygen package-generator with-prompt && yarn",
+    "card": "yarn hygen api-story-card with-prompt && yarn",
+    "card:local-data": "yarn hygen local-data-story-card with-prompt && yarn",
     "configure": "lerna run configure",
     "publish-patch": "lerna publish bump patch --yes",
     "publish-minor": "lerna publish bump minor --yes",


### PR DESCRIPTION
We don't need to build the component-library or mock-wrapper packages after the card and package generator scripts. We do need to run yarn because the scripts can update dependencies.