### PR TITLE
Base Map Scale Bar

### DIFF
--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -12,7 +12,7 @@ import createRef from "create-react-ref/lib/createRef";
 import Geocoder from "react-map-gl-geocoder";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { isEqual } from "lodash";
-import { ScaleControl } from "mapbox-gl/dist/mapbox-gl";
+import mapboxgl from "./mapboxgl";
 
 const MAPBOX_TOKEN =
   "pk.eyJ1IjoiaGFja29yZWdvbiIsImEiOiJjamk0MGZhc2cwNDl4M3FsdHAwaG54a3BnIn0.Fq1KA0IUwpeKQlFIoaEn_Q";
@@ -171,7 +171,7 @@ class BaseMap extends Component {
 
       if (scaleBar) {
         map.addControl(
-          new ScaleControl({
+          new mapboxgl.ScaleControl({
             maxWidth: scaleBarOptions.maxWidth,
             unit: scaleBarOptions.units
           })

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -10,6 +10,7 @@ import { css } from "emotion";
 import PropTypes from "prop-types";
 import createRef from "create-react-ref/lib/createRef";
 import Geocoder from "react-map-gl-geocoder";
+import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { isEqual } from "lodash";
 
@@ -147,7 +148,9 @@ class BaseMap extends Component {
       mapboxLayerId,
       locationMarkerCoord,
       animate,
-      animationDuration
+      animationDuration,
+      scaleBar,
+      scaleBarOptions
     } = this.props;
 
     viewport.width = containerWidth || 500;
@@ -164,8 +167,18 @@ class BaseMap extends Component {
     });
 
     const onMapLoad = () => {
-      if (!mapboxData || !mapboxLayerType || !mapboxLayerOptions) return;
       const map = this.mapRef.current.getMap();
+
+      if (scaleBar) {
+        map.addControl(
+          new mapboxgl.ScaleControl({
+            maxWidth: scaleBarOptions.maxWidth,
+            unit: scaleBarOptions.units
+          })
+        );
+      }
+
+      if (!mapboxData || !mapboxLayerType || !mapboxLayerOptions) return;
       map.addSource(mapboxDataId, {
         type: "geojson",
         data: mapboxData
@@ -283,7 +296,12 @@ BaseMap.propTypes = {
   }),
   mapboxLayerType: PropTypes.string,
   mapboxLayerId: PropTypes.string,
-  mapboxLayerOptions: PropTypes.shape({})
+  mapboxLayerOptions: PropTypes.shape({}),
+  scaleBar: PropTypes.bool,
+  scaleBarOptions: PropTypes.shape({
+    maxWidth: PropTypes.number,
+    units: PropTypes.string
+  })
 };
 
 BaseMap.defaultProps = {
@@ -302,7 +320,8 @@ BaseMap.defaultProps = {
     latitude: 0,
     longitude: 0
   },
-  animationDuration: 1000
+  animationDuration: 1000,
+  scaleBar: false
 };
 
 export default Dimensions()(BaseMap);

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -10,7 +10,7 @@ import { css } from "emotion";
 import PropTypes from "prop-types";
 import createRef from "create-react-ref/lib/createRef";
 import Geocoder from "react-map-gl-geocoder";
-import mapboxgl from "mapbox-gl";
+import mapboxgl from "mapbox-gl/dist/mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { isEqual } from "lodash";
 

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -10,9 +10,9 @@ import { css } from "emotion";
 import PropTypes from "prop-types";
 import createRef from "create-react-ref/lib/createRef";
 import Geocoder from "react-map-gl-geocoder";
-import mapboxgl from "mapbox-gl/dist/mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { isEqual } from "lodash";
+import { ScaleControl } from "mapbox-gl/dist/mapbox-gl";
 
 const MAPBOX_TOKEN =
   "pk.eyJ1IjoiaGFja29yZWdvbiIsImEiOiJjamk0MGZhc2cwNDl4M3FsdHAwaG54a3BnIn0.Fq1KA0IUwpeKQlFIoaEn_Q";
@@ -171,7 +171,7 @@ class BaseMap extends Component {
 
       if (scaleBar) {
         map.addControl(
-          new mapboxgl.ScaleControl({
+          new ScaleControl({
             maxWidth: scaleBarOptions.maxWidth,
             unit: scaleBarOptions.units
           })

--- a/packages/component-library/src/BaseMap/mapboxgl.js
+++ b/packages/component-library/src/BaseMap/mapboxgl.js
@@ -1,0 +1,8 @@
+const isBrowser = !(
+  Object.prototype.toString.call(global.process) === "[object process]" &&
+  !global.process.browser
+);
+
+const mapboxgl = isBrowser ? require("mapbox-gl") : null;
+
+export default mapboxgl;

--- a/packages/component-library/stories/BaseMap.story.js
+++ b/packages/component-library/stories/BaseMap.story.js
@@ -51,6 +51,11 @@ const animatedMapProps = {
   lat: 45.5
 };
 
+const containerWrapper = css`
+  height: 100vh;
+  min-height: 500px;
+`;
+
 export default () =>
   storiesOf("Component Lib|Maps/Base Map", module)
     .addDecorator(withKnobs)
@@ -273,11 +278,6 @@ export default () =>
     .add(
       "Example: Use Container Height",
       () => {
-        const containerWrapper = css`
-          height: 100vh;
-          min-height: 500px;
-        `;
-
         const useContainerHeight = boolean(
           "Use Container Height:",
           true,
@@ -287,6 +287,25 @@ export default () =>
         return (
           <div className={containerWrapper}>
             <BaseMap useContainerHeight={useContainerHeight} />
+          </div>
+        );
+      },
+      {
+        notes
+      }
+    )
+    .add(
+      "Example: With Scale Bar",
+      () => {
+        return (
+          <div className={containerWrapper}>
+            <BaseMap
+              scaleBar
+              scaleBarOptions={{
+                maxWidth: 200,
+                units: "imperial"
+              }}
+            />
           </div>
         );
       },

--- a/packages/component-library/stories/baseMap.notes.md
+++ b/packages/component-library/stories/baseMap.notes.md
@@ -108,3 +108,19 @@ This prop can be set in this story:
 
 - **useContainerHeight:** whether the Base Map should adjust according to the height of its parent container
   - This prop expects a boolean
+
+## Example: With Scale Bar
+
+This story shows how to include a scale bar on the Base Map.
+
+- **scaleBar:** whether the Base Map should include a scale bar
+  - This prop expects a boolean
+- **scaleBarOptions:** options for the scale bar
+  - The scaleBarOptions prop expects an object and must include the following properties:
+  - **maxWidth:** the maximum length of the scale bar
+    - This property expects a number
+  - **units:** distance units displayed by the scale bar
+    - This property expects 1 of the following strings:
+      - `"imperial"`
+      - `"metric"`
+      - `"nautical"`


### PR DESCRIPTION
This PR addresses #660. 

It adds the ability to include a scale bar to the Base Map. This is achieved by adding two new props: `scaleBar` and `scaleBarOptions` which sets the maximum width and the units used by the scale bar (e.g., imperial, metric, nautical).

It also updates the Base Map story and notes to include an example of it in use.
![SCALE_BAR](https://user-images.githubusercontent.com/9361258/63139504-59d8f800-bf93-11e9-8d9e-1e9d875cb002.png)



