### PR TITLE
Add Card Layout with descriptions

### DIFF
--- a/packages/component-library/src/ChartContainer/ChartContainer.js
+++ b/packages/component-library/src/ChartContainer/ChartContainer.js
@@ -39,10 +39,10 @@ const ChartContainer = ({
   `;
 
   let content = (
-    <div>
+    <figure>
       <ChartTitle title={title} subtitle={subtitle} />
       <div className={wrapperStyle}>{children}</div>
-    </div>
+    </figure>
   );
 
   if (loading) {

--- a/packages/component-library/src/ChartTitle/ChartTitle.js
+++ b/packages/component-library/src/ChartTitle/ChartTitle.js
@@ -29,10 +29,10 @@ const subtitleStyle = css`
 
 const ChartTitle = ({ title, subtitle }) =>
   title || subtitle ? (
-    <div>
-      {title ? <h3 className={titleStyle}>{title}</h3> : null}
-      {subtitle ? <span className={subtitleStyle}>{subtitle}</span> : null}
-    </div>
+    <figcaption>
+      {title ? <h2 className={titleStyle}>{title}</h2> : null}
+      {subtitle ? <h3 className={subtitleStyle}>{subtitle}</h3> : null}
+    </figcaption>
   ) : null;
 
 ChartTitle.propTypes = {

--- a/packages/component-library/src/ChartTitle/ChartTitle.test.js
+++ b/packages/component-library/src/ChartTitle/ChartTitle.test.js
@@ -9,14 +9,14 @@ describe("ChartTitle", () => {
       <ChartTitle title="Fun title" subtitle="Fun subtitle" />
     );
 
-    expect(wrapper.find("h3").text()).to.eql("Fun title");
-    expect(wrapper.find("span").text()).to.eql("Fun subtitle");
+    expect(wrapper.find("h2").text()).to.eql("Fun title");
+    expect(wrapper.find("h3").text()).to.eql("Fun subtitle");
   });
 
   it("should neither render a title nor a subtitle when neither are provided", () => {
     const wrapper = shallow(<ChartTitle />);
 
+    expect(wrapper.find("h2").length).to.eql(0);
     expect(wrapper.find("h3").length).to.eql(0);
-    expect(wrapper.find("span").length).to.eql(0);
   });
 });

--- a/packages/component-library/src/CivicCard/CivicCardLayoutExample.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutExample.js
@@ -1,0 +1,221 @@
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import PropTypes from "prop-types";
+import _ from "lodash";
+import PullQuote from "../PullQuote/PullQuote";
+import Placeholder from "../Placeholder/Placeholder";
+import cardMetaTypes from "./cardMetaTypes";
+import cardMetaDescription from "./cardMetaDescriptions";
+import {
+  Chip,
+  Resource,
+  MetadataQuestion,
+  CollapsableSection
+} from "./LayoutComponents";
+
+const sectionMarginSmall = css`
+  display: block;
+  margin: 12px auto;
+`;
+
+const sectionMaxWidthSmall = css`
+  max-width: 700px;
+`;
+
+const sectionMarginMedium = css`
+  display: block;
+  margin: 64px auto;
+`;
+
+const sectionMaxWidthMedium = css`
+  max-width: 900px;
+`;
+
+const authorPhoto = css`
+  width: 50%;
+  filter: grayscale(100%);
+  cursor: pointer;
+`;
+
+const cardMetaItem = css`
+  border: 1px solid red;
+`;
+
+const platformItem = css`
+  border: 1px solid blue;
+`;
+
+const description = css`
+  max-width: 700px;
+  margin: auto;
+`;
+
+function Desc({ id }) {
+  return (
+    <div css={description}>
+      <b>{_.get(cardMetaDescription, [id, "title"])}</b>
+      <code>{` (${id}) `}</code>
+      <p>{_.get(cardMetaDescription, [id, "description"])}</p>
+    </div>
+  );
+}
+
+Desc.propTypes = {
+  id: PropTypes.string
+};
+
+function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
+  return (
+    <div>
+      <div>
+        <article>
+          <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
+            <header>
+              <h1 css={cardMetaItem} id="title">
+                {cardMeta.title}
+              </h1>
+              <Desc id="title" />
+            </header>
+            <hr />
+            <section css={cardMetaItem} id="tags">
+              {cardMeta.tags.map((tag, index) => (
+                <Chip tag={tag} index={index} />
+              ))}
+            </section>
+            <Desc id="tags" />
+            <hr />
+          </div>
+          <section>
+            <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
+              <div css={cardMetaItem} id="introText">
+                {cardMeta.introText}
+              </div>
+              <Desc id="introText" />
+            </div>
+            <figure
+              id="visualization"
+              css={[sectionMarginMedium, sectionMaxWidthMedium, cardMetaItem]}
+            >
+              {cardMeta.selector}
+              <cardMeta.visualization isLoading={isLoading} data={data} />
+            </figure>
+            <Desc id="visualization" />
+            <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
+              <div css={cardMetaItem} id="shareText">
+                <PullQuote quoteText={cardMeta.shareText} />
+              </div>
+              <Desc id="shareText" />
+              <div css={cardMetaItem} id="additionalText">
+                {cardMeta.additionalText}
+              </div>
+              <Desc id="additionalText" />
+            </div>
+          </section>
+          <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
+          <section css={[sectionMarginSmall, sectionMaxWidthSmall]}>
+            <div css={cardMetaItem} id="analysis">
+              <h2>About this analysis</h2>
+              {cardMeta.analysis}
+            </div>
+          </section>
+          <Desc id="analysis" />
+          <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
+          <section
+            css={[sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem]}
+            id="metadata"
+          >
+            <h2>About this data</h2>
+            {cardMeta.metadata}
+            {_.has(cardMeta, "metadataQA") && (
+              <CollapsableSection
+                items={cardMeta.metadataQA.map(item => (
+                  <MetadataQuestion item={item} />
+                ))}
+                collapseAfter={5}
+              />
+            )}
+          </section>
+          <Desc id="metadataQA" />
+          <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
+          <section
+            css={[sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem]}
+            id="resources"
+          >
+            <h2>Links and resources</h2>
+            <p>
+              Interested in learning more? The following links and resources are
+              useful in gaining a greater understanding of the context of this
+              data visualization.
+            </p>
+            <ul>
+              <CollapsableSection
+                items={cardMeta.resources.map(item => (
+                  <Resource item={item} />
+                ))}
+                collapseAfter={7}
+              />
+            </ul>
+          </section>
+          <Desc id="resources" />
+          <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
+          <section
+            css={[sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem]}
+            id="authors"
+          >
+            <h2>Who made this?</h2>
+            {cardMeta.authors.map(photo => (
+              <img
+                css={authorPhoto}
+                src={photo}
+                alt="Pictures of people who worked on this"
+              />
+            ))}
+          </section>
+          <Desc id="authors" />
+          <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
+          <section
+            css={[sectionMarginSmall, sectionMaxWidthSmall, platformItem]}
+            id="improve"
+          >
+            <h2>Help make this better</h2>
+            <p>
+              CIVIC is an open platform, so you can help make this better!
+              Whether you noticed a typo, want to suggest an improvement for our
+              data visualization, or have context to add about the dataset, we
+              want you to contribute.
+              <ul>
+                <li>
+                  <a href="https://civicsoftwarefoundation.org/#volunteers">
+                    Get Started!
+                  </a>
+                </li>
+              </ul>
+            </p>
+          </section>
+        </article>
+        <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
+        <section
+          css={[sectionMarginSmall, sectionMaxWidthSmall, platformItem]}
+          id="explore"
+        >
+          <h2>Explore related data</h2>
+          <Placeholder>
+            <h3>
+              <a href="https://civicsoftwarefoundation.org/#cities">
+                See your data here!
+              </a>
+            </h3>
+          </Placeholder>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+CivicCardLayoutFull.propTypes = {
+  isLoading: PropTypes.bool,
+  data: PropTypes.oneOfType([PropTypes.shape({}), PropTypes.array]),
+  cardMeta: cardMetaTypes
+};
+
+export default CivicCardLayoutFull;

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -37,26 +37,16 @@ const authorPhoto = css`
   cursor: pointer;
 `;
 
-const cardMetaItem = css`
-  border: 1px solid red;
-`;
-
-const platformItem = css`
-  border: 1px solid blue;
-`;
-
 function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
   return (
     <Fragment>
       <article>
         <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
           <header>
-            <h1 css={cardMetaItem} id="title">
-              {cardMeta.title}
-            </h1>
+            <h1 id="title">{cardMeta.title}</h1>
           </header>
           <hr />
-          <section css={cardMetaItem} id="tags">
+          <section id="tags">
             {cardMeta.tags.map((tag, index) => (
               <Chip tag={tag} index={index} />
             ))}
@@ -65,38 +55,31 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
         </div>
         <section>
           <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
-            <div css={cardMetaItem} id="introText">
-              {cardMeta.introText}
-            </div>
+            <div id="introText">{cardMeta.introText}</div>
           </div>
           <figure
             id="visualization"
-            css={[sectionMarginMedium, sectionMaxWidthMedium, cardMetaItem]}
+            css={[sectionMarginMedium, sectionMaxWidthMedium]}
           >
             {cardMeta.selector}
             <cardMeta.visualization isLoading={isLoading} data={data} />
           </figure>
           <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
-            <div css={cardMetaItem} id="shareText">
+            <div id="shareText">
               <PullQuote quoteText={cardMeta.shareText} />
             </div>
-            <div css={cardMetaItem} id="additionalText">
-              {cardMeta.additionalText}
-            </div>
+            <div id="additionalText">{cardMeta.additionalText}</div>
           </div>
         </section>
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section css={[sectionMarginSmall, sectionMaxWidthSmall]}>
-          <div css={cardMetaItem} id="analysis">
+          <div id="analysis">
             <h2>About this analysis</h2>
             {cardMeta.analysis}
           </div>
         </section>
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
-        <section
-          css={[sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem]}
-          id="metadata"
-        >
+        <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="metadata">
           <h2>About this data</h2>
           {cardMeta.metadata}
           {_.has(cardMeta, "metadataQA") && (
@@ -110,7 +93,7 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
         </section>
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section
-          css={[sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem]}
+          css={[sectionMarginSmall, sectionMaxWidthSmall]}
           id="resources"
         >
           <h2>Links and resources</h2>
@@ -129,10 +112,7 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
           </ul>
         </section>
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
-        <section
-          css={[sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem]}
-          id="authors"
-        >
+        <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="authors">
           <h2>Who made this?</h2>
           {cardMeta.authors.map(photo => (
             <img
@@ -143,10 +123,7 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
           ))}
         </section>
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
-        <section
-          css={[sectionMarginSmall, sectionMaxWidthSmall, platformItem]}
-          id="improve"
-        >
+        <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="improve">
           <h2>Help make this better</h2>
           <p>
             CIVIC is an open platform, so you can help make this better! Whether
@@ -164,10 +141,7 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
         </section>
       </article>
       <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
-      <section
-        css={[sectionMarginSmall, sectionMaxWidthSmall, platformItem]}
-        id="explore"
-      >
+      <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="explore">
         <h2>Explore related data</h2>
         <Placeholder>
           <h3>

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -58,13 +58,13 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
           <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
             <div id="introText">{cardMeta.introText}</div>
           </div>
-          <figure
+          <div
             id="visualization"
             css={[sectionMarginMedium, sectionMaxWidthMedium]}
           >
             {cardMeta.selector}
             <cardMeta.visualization isLoading={isLoading} data={data} />
-          </figure>
+          </div>
           <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
             <div id="shareText">
               <PullQuote quoteText={cardMeta.shareText} />

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -3,6 +3,7 @@ import { jsx, css } from "@emotion/core";
 import { Fragment } from "react";
 import PropTypes from "prop-types";
 import _ from "lodash";
+import { generate } from "shortid";
 import PullQuote from "../PullQuote/PullQuote";
 import Placeholder from "../Placeholder/Placeholder";
 import cardMetaTypes from "./cardMetaTypes";
@@ -48,7 +49,7 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
           <hr />
           <section id="tags">
             {cardMeta.tags.map((tag, index) => (
-              <Chip tag={tag} index={index} />
+              <Chip tag={tag} index={index} key={generate()} />
             ))}
           </section>
           <hr />
@@ -85,7 +86,7 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
           {_.has(cardMeta, "metadataQA") && (
             <CollapsableSection
               items={cardMeta.metadataQA.map(item => (
-                <MetadataQuestion item={item} />
+                <MetadataQuestion item={item} key={generate()} />
               ))}
               collapseAfter={5}
             />
@@ -102,14 +103,12 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
             useful in gaining a greater understanding of the context of this
             data visualization.
           </p>
-          <ul>
-            <CollapsableSection
-              items={cardMeta.resources.map(item => (
-                <Resource item={item} />
-              ))}
-              collapseAfter={7}
-            />
-          </ul>
+          <CollapsableSection
+            items={cardMeta.resources.map(item => (
+              <Resource item={item} key={generate()} />
+            ))}
+            collapseAfter={7}
+          />
         </section>
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="authors">
@@ -119,6 +118,7 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
               css={authorPhoto}
               src={photo}
               alt="Pictures of people who worked on this"
+              key={generate()}
             />
           ))}
         </section>
@@ -130,14 +130,14 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
             you noticed a typo, want to suggest an improvement for our data
             visualization, or have context to add about the dataset, we want you
             to contribute.
-            <ul>
-              <li>
-                <a href="https://civicsoftwarefoundation.org/#volunteers">
-                  Get Started!
-                </a>
-              </li>
-            </ul>
           </p>
+          <ul>
+            <li>
+              <a href="https://civicsoftwarefoundation.org/#volunteers">
+                Get Started!
+              </a>
+            </li>
+          </ul>
         </section>
       </article>
       <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -1,8 +1,8 @@
-import React, { Fragment } from "react";
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import { Fragment } from "react";
 import PropTypes from "prop-types";
 import _ from "lodash";
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { cx, css } from "emotion";
 import PullQuote from "../PullQuote/PullQuote";
 import Placeholder from "../Placeholder/Placeholder";
 import cardMetaTypes from "./cardMetaTypes";
@@ -49,14 +49,14 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
   return (
     <Fragment>
       <article>
-        <div className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
+        <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
           <header>
-            <h1 className={cardMetaItem} id="title">
+            <h1 css={cardMetaItem} id="title">
               {cardMeta.title}
             </h1>
           </header>
           <hr />
-          <section className={cardMetaItem} id="tags">
+          <section css={cardMetaItem} id="tags">
             {cardMeta.tags.map((tag, index) => (
               <Chip tag={tag} index={index} />
             ))}
@@ -64,41 +64,37 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
           <hr />
         </div>
         <section>
-          <div className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
-            <div className={cardMetaItem} id="introText">
+          <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
+            <div css={cardMetaItem} id="introText">
               {cardMeta.introText}
             </div>
           </div>
           <figure
             id="visualization"
-            className={cx(
-              sectionMarginMedium,
-              sectionMaxWidthMedium,
-              cardMetaItem
-            )}
+            css={[sectionMarginMedium, sectionMaxWidthMedium, cardMetaItem]}
           >
             {cardMeta.selector}
             <cardMeta.visualization isLoading={isLoading} data={data} />
           </figure>
-          <div className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
-            <div className={cardMetaItem} id="shareText">
+          <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
+            <div css={cardMetaItem} id="shareText">
               <PullQuote quoteText={cardMeta.shareText} />
             </div>
-            <div className={cardMetaItem} id="additionalText">
+            <div css={cardMetaItem} id="additionalText">
               {cardMeta.additionalText}
             </div>
           </div>
         </section>
-        <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
-        <section className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
-          <div className={cardMetaItem} id="analysis">
+        <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
+        <section css={[sectionMarginSmall, sectionMaxWidthSmall]}>
+          <div css={cardMetaItem} id="analysis">
             <h2>About this analysis</h2>
             {cardMeta.analysis}
           </div>
         </section>
-        <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+        <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section
-          className={cx(sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem)}
+          css={[sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem]}
           id="metadata"
         >
           <h2>About this data</h2>
@@ -112,9 +108,9 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
             />
           )}
         </section>
-        <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+        <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section
-          className={cx(sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem)}
+          css={[sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem]}
           id="resources"
         >
           <h2>Links and resources</h2>
@@ -132,23 +128,23 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
             />
           </ul>
         </section>
-        <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+        <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section
-          className={cx(sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem)}
+          css={[sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem]}
           id="authors"
         >
           <h2>Who made this?</h2>
           {cardMeta.authors.map(photo => (
             <img
-              className={authorPhoto}
+              css={authorPhoto}
               src={photo}
               alt="Pictures of people who worked on this"
             />
           ))}
         </section>
-        <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+        <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section
-          className={cx(sectionMarginSmall, sectionMaxWidthSmall, platformItem)}
+          css={[sectionMarginSmall, sectionMaxWidthSmall, platformItem]}
           id="improve"
         >
           <h2>Help make this better</h2>
@@ -167,9 +163,9 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
           </p>
         </section>
       </article>
-      <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+      <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
       <section
-        className={cx(sectionMarginSmall, sectionMaxWidthSmall, platformItem)}
+        css={[sectionMarginSmall, sectionMaxWidthSmall, platformItem]}
         id="explore"
       >
         <h2>Explore related data</h2>

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -1,13 +1,17 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
+import _ from "lodash";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { cx, css } from "emotion";
-import _ from "lodash";
 import PullQuote from "../PullQuote/PullQuote";
 import Placeholder from "../Placeholder/Placeholder";
-import CivicVictoryTheme from "../VictoryTheme/CivicVictoryTheme";
-import Collapsable from "../Collapsable/Collapsable";
 import cardMetaTypes from "./cardMetaTypes";
+import {
+  Chip,
+  Resource,
+  MetadataQuestion,
+  CollapsableSection
+} from "./LayoutComponents";
 
 const sectionMarginSmall = css`
   display: block;
@@ -33,161 +37,141 @@ const authorPhoto = css`
   cursor: pointer;
 `;
 
-function Chip({ tag, index }) {
-  return (
-    <span
-      className={css`
-        display: inline-block;
-        padding: 0 2em;
-        height: 2em;
-        line-height: 2em;
-        border-radius: 1em;
-        background-color: ${CivicVictoryTheme.group.colorScale[
-          index % CivicVictoryTheme.group.colorScale.length
-        ]};
-        margin: 0.5em 0.5em;
-        font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, sans-serif;
-        font-weight: bold;
-        color: white;
-        cursor: pointer;
-      `}
-    >{`#${tag}`}</span>
-  );
-}
+const cardMetaItem = css`
+  border: 1px solid red;
+`;
 
-Chip.propTypes = {
-  tag: PropTypes.string,
-  index: PropTypes.number
-};
-
-function Resource({ item }) {
-  return _.has(item, "section") ? (
-    <h3>{item.section}</h3>
-  ) : (
-    <li>
-      <a href={item.link}>{item.description}</a>
-    </li>
-  );
-}
-
-Resource.propTypes = {
-  item: PropTypes.shape({
-    link: PropTypes.string,
-    description: PropTypes.string
-  })
-};
-
-function MetadataQuestion({ item }) {
-  return _.has(item, "section") ? (
-    <h3>{item.section}</h3>
-  ) : (
-    item.answer.length > 0 && (
-      <Fragment>
-        <h4>{item.question}</h4>
-        <p>{item.answer}</p>
-      </Fragment>
-    )
-  );
-}
-
-MetadataQuestion.propTypes = {
-  item: PropTypes.shape({
-    question: PropTypes.string,
-    answer: PropTypes.string
-  })
-};
-
-function CollapsableSection({ items, collapseAfter }) {
-  const beforeFold = _.slice(items, 0, collapseAfter);
-  const afterFold = _.slice(items, collapseAfter);
-  return (afterFold && afterFold.length) > 0 ? (
-    <Collapsable>
-      <Collapsable.Section>{beforeFold}</Collapsable.Section>
-      <Collapsable.Section hidden>{afterFold}</Collapsable.Section>
-    </Collapsable>
-  ) : (
-    <Fragment>{beforeFold}</Fragment>
-  );
-}
-
-CollapsableSection.propTypes = {
-  items: PropTypes.arrayOf(PropTypes.node),
-  collapseAfter: PropTypes.number
-};
+const platformItem = css`
+  border: 1px solid blue;
+`;
 
 function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
   return (
-    <React.Fragment>
-      <div className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
-        <h1>{cardMeta.title}</h1>
-        <hr />
-        {cardMeta.tags.map((tag, index) => (
-          <Chip tag={tag} index={index} />
-        ))}
-        <hr />
-        {cardMeta.introText}
-        {cardMeta.selector}
-      </div>
-      <div className={cx(sectionMarginMedium, sectionMaxWidthMedium)}>
-        <cardMeta.visualization isLoading={isLoading} data={data} />
-      </div>
-      <div className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
-        <PullQuote quoteText={cardMeta.shareText} />
-        {cardMeta.additionalText}
-        <hr />
-        <h2>About this analysis</h2>
-        {cardMeta.analysis}
-        <hr />
-        <h2>About this data</h2>
-        {cardMeta.metadata}
-        {_.has(cardMeta, "metadataQA") && (
-          <CollapsableSection
-            items={cardMeta.metadataQA.map(item => (
-              <MetadataQuestion item={item} />
+    <Fragment>
+      <article>
+        <div className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
+          <header>
+            <h1 className={cardMetaItem} id="title">
+              {cardMeta.title}
+            </h1>
+          </header>
+          <hr />
+          <section className={cardMetaItem} id="tags">
+            {cardMeta.tags.map((tag, index) => (
+              <Chip tag={tag} index={index} />
             ))}
-            collapseAfter={5}
-          />
-        )}
-        <hr />
-        <h2>Links and resources</h2>
-        <p>
-          Interested in learning more? The following links and resources are
-          useful in gaining a greater understanding of the context of this data
-          visualization.
-        </p>
-        <ul>
-          <CollapsableSection
-            items={cardMeta.resources.map(item => (
-              <Resource item={item} />
-            ))}
-            collapseAfter={7}
-          />
-        </ul>
-        <hr />
-        <h2>Who made this?</h2>
-        {cardMeta.authors.map(photo => (
-          <img
-            className={authorPhoto}
-            src={photo}
-            alt="Pictures of people who worked on this"
-          />
-        ))}
-        <hr />
-        <h2>Help make this better</h2>
-        <p>
-          CIVIC is an open platform, so you can help make this better! Whether
-          you noticed a typo, want to suggest an improvement for our data
-          visualization, or have context to add about the dataset, we want you
-          to contribute.
+          </section>
+          <hr />
+        </div>
+        <section>
+          <div className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
+            <div className={cardMetaItem} id="introText">
+              {cardMeta.introText}
+            </div>
+          </div>
+          <figure
+            id="visualization"
+            className={cx(
+              sectionMarginMedium,
+              sectionMaxWidthMedium,
+              cardMetaItem
+            )}
+          >
+            {cardMeta.selector}
+            <cardMeta.visualization isLoading={isLoading} data={data} />
+          </figure>
+          <div className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
+            <div className={cardMetaItem} id="shareText">
+              <PullQuote quoteText={cardMeta.shareText} />
+            </div>
+            <div className={cardMetaItem} id="additionalText">
+              {cardMeta.additionalText}
+            </div>
+          </div>
+        </section>
+        <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+        <section className={cx(sectionMarginSmall, sectionMaxWidthSmall)}>
+          <div className={cardMetaItem} id="analysis">
+            <h2>About this analysis</h2>
+            {cardMeta.analysis}
+          </div>
+        </section>
+        <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+        <section
+          className={cx(sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem)}
+          id="metadata"
+        >
+          <h2>About this data</h2>
+          {cardMeta.metadata}
+          {_.has(cardMeta, "metadataQA") && (
+            <CollapsableSection
+              items={cardMeta.metadataQA.map(item => (
+                <MetadataQuestion item={item} />
+              ))}
+              collapseAfter={5}
+            />
+          )}
+        </section>
+        <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+        <section
+          className={cx(sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem)}
+          id="resources"
+        >
+          <h2>Links and resources</h2>
+          <p>
+            Interested in learning more? The following links and resources are
+            useful in gaining a greater understanding of the context of this
+            data visualization.
+          </p>
           <ul>
-            <li>
-              <a href="https://civicsoftwarefoundation.org/#volunteers">
-                Get Started!
-              </a>
-            </li>
+            <CollapsableSection
+              items={cardMeta.resources.map(item => (
+                <Resource item={item} />
+              ))}
+              collapseAfter={7}
+            />
           </ul>
-        </p>
-        <hr />
+        </section>
+        <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+        <section
+          className={cx(sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem)}
+          id="authors"
+        >
+          <h2>Who made this?</h2>
+          {cardMeta.authors.map(photo => (
+            <img
+              className={authorPhoto}
+              src={photo}
+              alt="Pictures of people who worked on this"
+            />
+          ))}
+        </section>
+        <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+        <section
+          className={cx(sectionMarginSmall, sectionMaxWidthSmall, platformItem)}
+          id="improve"
+        >
+          <h2>Help make this better</h2>
+          <p>
+            CIVIC is an open platform, so you can help make this better! Whether
+            you noticed a typo, want to suggest an improvement for our data
+            visualization, or have context to add about the dataset, we want you
+            to contribute.
+            <ul>
+              <li>
+                <a href="https://civicsoftwarefoundation.org/#volunteers">
+                  Get Started!
+                </a>
+              </li>
+            </ul>
+          </p>
+        </section>
+      </article>
+      <hr className={cx(sectionMarginSmall, sectionMaxWidthSmall)} />
+      <section
+        className={cx(sectionMarginSmall, sectionMaxWidthSmall, platformItem)}
+        id="explore"
+      >
         <h2>Explore related data</h2>
         <Placeholder>
           <h3>
@@ -196,8 +180,8 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
             </a>
           </h3>
         </Placeholder>
-      </div>
-    </React.Fragment>
+      </section>
+    </Fragment>
   );
 }
 

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
@@ -93,13 +93,13 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
               </div>
               <Desc id="introText" />
             </div>
-            <figure
+            <div
               id="visualization"
               css={[sectionMarginMedium, sectionMaxWidthMedium, cardMetaItem]}
             >
               {cardMeta.selector}
               <cardMeta.visualization isLoading={isLoading} data={data} />
-            </figure>
+            </div>
             <Desc id="visualization" />
             <div css={[sectionMarginSmall, sectionMaxWidthSmall]}>
               <div css={cardMetaItem} id="shareText">

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
@@ -2,6 +2,7 @@
 import { jsx, css } from "@emotion/core";
 import PropTypes from "prop-types";
 import _ from "lodash";
+import { generate } from "shortid";
 import PullQuote from "../PullQuote/PullQuote";
 import Placeholder from "../Placeholder/Placeholder";
 import cardMetaTypes from "./cardMetaTypes";
@@ -79,7 +80,7 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
             <hr />
             <section css={cardMetaItem} id="tags">
               {cardMeta.tags.map((tag, index) => (
-                <Chip tag={tag} index={index} />
+                <Chip tag={tag} index={index} key={generate()} />
               ))}
             </section>
             <Desc id="tags" />
@@ -129,7 +130,7 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
             {_.has(cardMeta, "metadataQA") && (
               <CollapsableSection
                 items={cardMeta.metadataQA.map(item => (
-                  <MetadataQuestion item={item} />
+                  <MetadataQuestion item={item} key={generate()} />
                 ))}
                 collapseAfter={5}
               />
@@ -147,14 +148,12 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
               useful in gaining a greater understanding of the context of this
               data visualization.
             </p>
-            <ul>
-              <CollapsableSection
-                items={cardMeta.resources.map(item => (
-                  <Resource item={item} />
-                ))}
-                collapseAfter={7}
-              />
-            </ul>
+            <CollapsableSection
+              items={cardMeta.resources.map(item => (
+                <Resource item={item} key={generate()} />
+              ))}
+              collapseAfter={7}
+            />
           </section>
           <Desc id="resources" />
           <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
@@ -168,6 +167,7 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
                 css={authorPhoto}
                 src={photo}
                 alt="Pictures of people who worked on this"
+                key={generate()}
               />
             ))}
           </section>
@@ -183,14 +183,14 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
               Whether you noticed a typo, want to suggest an improvement for our
               data visualization, or have context to add about the dataset, we
               want you to contribute.
-              <ul>
-                <li>
-                  <a href="https://civicsoftwarefoundation.org/#volunteers">
-                    Get Started!
-                  </a>
-                </li>
-              </ul>
             </p>
+            <ul>
+              <li>
+                <a href="https://civicsoftwarefoundation.org/#volunteers">
+                  Get Started!
+                </a>
+              </li>
+            </ul>
           </section>
         </article>
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
@@ -64,7 +64,7 @@ Desc.propTypes = {
   id: PropTypes.string
 };
 
-function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
+function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
   return (
     <div>
       <div>
@@ -212,10 +212,10 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
   );
 }
 
-CivicCardLayoutFull.propTypes = {
+CivicCardLayoutFullWithDescriptions.propTypes = {
   isLoading: PropTypes.bool,
   data: PropTypes.oneOfType([PropTypes.shape({}), PropTypes.array]),
   cardMeta: cardMetaTypes
 };
 
-export default CivicCardLayoutFull;
+export default CivicCardLayoutFullWithDescriptions;

--- a/packages/component-library/src/CivicCard/LayoutComponents.js
+++ b/packages/component-library/src/CivicCard/LayoutComponents.js
@@ -1,0 +1,88 @@
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import { Fragment } from "react";
+import PropTypes from "prop-types";
+import _ from "lodash";
+
+import Collapsable from "../Collapsable/Collapsable";
+import CivicVictoryTheme from "../VictoryTheme/CivicVictoryTheme";
+
+const chipStyle = index => css`
+  display: inline-block;
+  padding: 0 2em;
+  height: 2em;
+  line-height: 2em;
+  border-radius: 1em;
+  background-color: ${CivicVictoryTheme.group.colorScale[
+    index % CivicVictoryTheme.group.colorScale.length
+  ]};
+  margin: 0.5em 0.5em;
+  font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, sans-serif;
+  font-weight: bold;
+  color: white;
+  cursor: pointer;
+`;
+
+export function Chip({ tag, index }) {
+  return <span css={chipStyle(index)}>{`#${tag}`}</span>;
+}
+
+Chip.propTypes = {
+  tag: PropTypes.string,
+  index: PropTypes.number
+};
+
+export function Resource({ item }) {
+  return _.has(item, "section") ? (
+    <h3>{item.section}</h3>
+  ) : (
+    <li>
+      <a href={item.link}>{item.description}</a>
+    </li>
+  );
+}
+
+Resource.propTypes = {
+  item: PropTypes.shape({
+    link: PropTypes.string,
+    description: PropTypes.string
+  })
+};
+
+export function MetadataQuestion({ item }) {
+  return _.has(item, "section") ? (
+    <h3>{item.section}</h3>
+  ) : (
+    item.answer.length > 0 && (
+      <Fragment>
+        <h4>{item.question}</h4>
+        <p>{item.answer}</p>
+      </Fragment>
+    )
+  );
+}
+
+MetadataQuestion.propTypes = {
+  item: PropTypes.shape({
+    question: PropTypes.string,
+    answer: PropTypes.string
+  })
+};
+
+export function CollapsableSection({ items, collapseAfter }) {
+  const beforeFold = _.slice(items, 0, collapseAfter);
+  const afterFold = _.slice(items, collapseAfter);
+  return (afterFold && afterFold.length) > 0 ? (
+    <Collapsable>
+      <Collapsable.Section>{beforeFold}</Collapsable.Section>
+      <Collapsable.Section hidden>{afterFold}</Collapsable.Section>
+    </Collapsable>
+  ) : (
+    <Fragment>{beforeFold}</Fragment>
+  );
+}
+
+CollapsableSection.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.node),
+  collapseAfter: PropTypes.number
+};

--- a/packages/component-library/src/CivicCard/cardMetaDescriptions.js
+++ b/packages/component-library/src/CivicCard/cardMetaDescriptions.js
@@ -53,7 +53,8 @@ const cardMetaDescriptions = {
   },
   resources: {
     title: "Links and Resources",
-    description: "This section includes links and resources"
+    description:
+      "This section includes links and resources that provide additional context to the data visualization. Some recommended sections are: Studies and papers, Articles, Organizations"
   },
   authors: {
     title: "Authors",

--- a/packages/component-library/src/CivicCard/cardMetaDescriptions.js
+++ b/packages/component-library/src/CivicCard/cardMetaDescriptions.js
@@ -1,0 +1,65 @@
+const cardMetaDescriptions = {
+  title: {
+    title: "Title",
+    description:
+      "The title should summarize what the card is about, in 3-10 words"
+  },
+  slug: {
+    title: "Slug",
+    description: "The slug is used in the url and should be based on the title"
+  },
+  introText: {
+    title: "Intro Text",
+    description:
+      "The introduction text is 1-2 sentences providing some context for the visualization"
+  },
+  visualization: {
+    title: "Visualization",
+    description: "The visualization, including interactive elements"
+  },
+  additionalText: {
+    title: "Additional Text",
+    description:
+      "The additional text is 1-2 paragraphs providing additional insight into the data visualization"
+  },
+  shareText: {
+    title: "Share Text",
+    description:
+      "The share text is what will accompany the data visualization when it is shared"
+  },
+  tags: {
+    title: "Tags",
+    description: "Tags are used to categorize the card"
+  },
+  selector: {
+    title: "Selector",
+    description:
+      "NOT CURRENTLY USED - Could be split out the the visualization in the future"
+  },
+  analysis: {
+    title: "About This Analysis",
+    description:
+      "This section is a description of the analysis and includes a link to the data science notebooks and repository"
+  },
+  metadata: {
+    title: "About This Data",
+    description:
+      "REMOVE? REPLACED WITH METADATA QA - This section will point to the metadata API endpoint containing responses to the dataset metadata questionnaire"
+  },
+  metadataQA: {
+    title: "About This Data",
+    description:
+      "UNDER CONSTRUCTION - This section will point to the metadata API endpoint containing responses to the dataset metadata questionnaire"
+  },
+  resources: {
+    title: "Links and Resources",
+    description: "This section includes links and resources"
+  },
+  authors: {
+    title: "Authors",
+    description:
+      "This section shows all of the people who worked on the card that want to be shown"
+  }
+};
+
+export default cardMetaDescriptions;

--- a/packages/component-library/src/index.js
+++ b/packages/component-library/src/index.js
@@ -68,6 +68,9 @@ export {
 export {
   default as CivicCardLayoutVisualizationOnly
 } from "./CivicCard/CivicCardLayoutVisualizationOnly";
+export {
+  default as CivicCardLayoutExample
+} from "./CivicCard/CivicCardLayoutExample";
 
 export { default as civicFormat } from "./utils/civicFormat";
 export { default as ungroupBy } from "./utils/ungroupBy";

--- a/packages/component-library/src/index.js
+++ b/packages/component-library/src/index.js
@@ -69,8 +69,8 @@ export {
   default as CivicCardLayoutVisualizationOnly
 } from "./CivicCard/CivicCardLayoutVisualizationOnly";
 export {
-  default as CivicCardLayoutExample
-} from "./CivicCard/CivicCardLayoutExample";
+  default as CivicCardLayoutFullWithDescriptions
+} from "./CivicCard/CivicCardLayoutFullWithDescriptions";
 
 export { default as civicFormat } from "./utils/civicFormat";
 export { default as ungroupBy } from "./utils/ungroupBy";

--- a/packages/component-library/stories/CivicCard.story.js
+++ b/packages/component-library/stories/CivicCard.story.js
@@ -324,7 +324,7 @@ const demoCardMeta = (/* data */) => ({
 
 export default () =>
   storiesOf("Component Lib|Story Cards/CIVIC Card", module)
-    .add("Layout: Example (full)", () => (
+    .add("Layout: Full With Descriptions", () => (
       <CivicCard
         cardMeta={demoCardMeta}
         data={demoData}

--- a/packages/component-library/stories/CivicCard.story.js
+++ b/packages/component-library/stories/CivicCard.story.js
@@ -7,7 +7,8 @@ import {
   LineChart,
   Collapsable,
   CivicCardLayoutClassic,
-  CivicCardLayoutVisualizationOnly
+  CivicCardLayoutVisualizationOnly,
+  CivicCardLayoutExample
 } from "../src";
 import { civicFormat } from "../src/utils";
 
@@ -323,6 +324,14 @@ const demoCardMeta = (/* data */) => ({
 
 export default () =>
   storiesOf("Component Lib|Story Cards/CIVIC Card", module)
+    .add("Layout: Example (full)", () => (
+      <CivicCard
+        cardMeta={demoCardMeta}
+        data={demoData}
+        isLoading={false}
+        Layout={CivicCardLayoutExample}
+      />
+    ))
     .add("Layout: Default (full)", () => (
       <CivicCard cardMeta={demoCardMeta} data={demoData} isLoading={false} />
     ))

--- a/packages/component-library/stories/CivicCard.story.js
+++ b/packages/component-library/stories/CivicCard.story.js
@@ -8,7 +8,7 @@ import {
   Collapsable,
   CivicCardLayoutClassic,
   CivicCardLayoutVisualizationOnly,
-  CivicCardLayoutExample
+  CivicCardLayoutFullWithDescriptions
 } from "../src";
 import { civicFormat } from "../src/utils";
 
@@ -329,7 +329,7 @@ export default () =>
         cardMeta={demoCardMeta}
         data={demoData}
         isLoading={false}
-        Layout={CivicCardLayoutExample}
+        Layout={CivicCardLayoutFullWithDescriptions}
       />
     ))
     .add("Layout: Default (full)", () => (


### PR DESCRIPTION
- Refactored CivicCardLayoutFull semantic HTML structure, split other components to new file, and use Emotion 10.
- Added a new layout (`CivicCardLayoutFullWithDescriptions`) which uses a newly added `cardMetaDescriptions` file to provide an annotated view showing each of the sections of a card, shown below

![Screenshot_2019-08-17 Storybook](https://user-images.githubusercontent.com/7065695/63208000-01355800-c084-11e9-8d1b-cfbe65563f23.png)

Especially interested in comments on the descriptions.