### PR TITLE
Fix Sandbox Data Collection/Package Loading Error

### DIFF
--- a/packages/civic-sandbox/package.json
+++ b/packages/civic-sandbox/package.json
@@ -39,6 +39,7 @@
     "cross-env": "^5.2.0",
     "express": "^4.14.1",
     "invariant": "^2.2.2",
+    "lodash": "4.17.11",
     "prop-types": "^15.7.2",
     "ramda": "^0.23.0",
     "react": "^16.8.4",

--- a/packages/civic-sandbox/src/state/sandbox/index.js
+++ b/packages/civic-sandbox/src/state/sandbox/index.js
@@ -121,18 +121,12 @@ const reducer = (state = INITIAL_STATE, action) => {
         foundationData: {},
         slidesData: [],
         selectedFoundation:
-          state.sandbox.packages[action.selectedPackage]
-            .default_foundation,
+          state.sandbox.packages[action.selectedPackage].default_foundation,
         selectedSlide: isArray(
-          state.sandbox.packages[action.selectedPackage]
-            .default_slide
+          state.sandbox.packages[action.selectedPackage].default_slide
         )
-          ? state.sandbox.packages[action.selectedPackage]
-              .default_slide
-          : [
-              state.sandbox.packages[action.selectedPackage]
-                .default_slide
-            ],
+          ? state.sandbox.packages[action.selectedPackage].default_slide
+          : [state.sandbox.packages[action.selectedPackage].default_slide],
         selectedFoundationDatum: null,
         selectedSlideDatum: null
       };
@@ -155,9 +149,8 @@ const reducer = (state = INITIAL_STATE, action) => {
         slidesPending: true,
         slidesError: null
       };
-    case SLIDE_SUCCESS:
-      let { foundationData } = state;
-      let { slidesData } = state;
+    case SLIDE_SUCCESS: {
+      let { foundationData, slidesData } = state;
       if (action.payload.type === "foundation") {
         foundationData = action.payload.data;
       }
@@ -181,6 +174,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         slidesData,
         foundationData
       };
+    }
     case SLIDE_FAILURE:
       return {
         ...state,

--- a/packages/civic-sandbox/src/state/sandbox/index.js
+++ b/packages/civic-sandbox/src/state/sandbox/index.js
@@ -110,7 +110,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         ...state,
         slidesPending: false,
         slidesError: action.payload,
-        slidesData: null,
+        slidesData: [],
         selectedFoundationDatum: null,
         selectedSlideDatum: null
       };
@@ -121,16 +121,16 @@ const reducer = (state = INITIAL_STATE, action) => {
         foundationData: {},
         slidesData: [],
         selectedFoundation:
-          state.packageCivicSandbox.packages[action.selectedPackage]
+          state.sandbox.packages[action.selectedPackage]
             .default_foundation,
         selectedSlide: isArray(
-          state.packageCivicSandbox.packages[action.selectedPackage]
+          state.sandbox.packages[action.selectedPackage]
             .default_slide
         )
-          ? state.packageCivicSandbox.packages[action.selectedPackage]
+          ? state.sandbox.packages[action.selectedPackage]
               .default_slide
           : [
-              state.packageCivicSandbox.packages[action.selectedPackage]
+              state.sandbox.packages[action.selectedPackage]
                 .default_slide
             ],
         selectedFoundationDatum: null,

--- a/packages/component-library/stories/MultiLayerMap.story.js
+++ b/packages/component-library/stories/MultiLayerMap.story.js
@@ -489,7 +489,7 @@ export default () =>
               );
 
               const featuresData = at(data, featuresArrayPath)[0];
-              const dataFilterNulls = featuresData.filter(d => d.geometry);
+              const dataFilterNulls = featuresData ? featuresData.filter(d => d.geometry) : [];
 
               const iconMapLayer = {
                 mapType: "IconMap",

--- a/packages/component-library/stories/MultiLayerMap.story.js
+++ b/packages/component-library/stories/MultiLayerMap.story.js
@@ -489,7 +489,9 @@ export default () =>
               );
 
               const featuresData = at(data, featuresArrayPath)[0];
-              const dataFilterNulls = featuresData ? featuresData.filter(d => d.geometry) : [];
+              const dataFilterNulls = featuresData
+                ? featuresData.filter(d => d.geometry)
+                : [];
 
               const iconMapLayer = {
                 mapType: "IconMap",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10461,7 +10461,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10:
+lodash@4.17.11, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 


### PR DESCRIPTION
This fixes #798.

There was a small naming error that was causing the data collections/packages not to load. The state property named `sandbox` got changed to `packageCivicSandbox` in the sandbox reducer. This didn't need to be updated and changing it back solves the problem. 

This also fixes some eslint errors.

