### PR TITLE
Set figure margin 0 in ChartContainer

### DIFF
--- a/packages/component-library/src/ChartContainer/ChartContainer.js
+++ b/packages/component-library/src/ChartContainer/ChartContainer.js
@@ -31,6 +31,9 @@ const ChartContainer = ({
   children,
   className
 }) => {
+  const figureWrapper = css`
+    margin: 0;
+  `;
   const wrapperStyle = css`
     margin: 0 auto;
     max-width: 900px;
@@ -39,7 +42,7 @@ const ChartContainer = ({
   `;
 
   let content = (
-    <figure>
+    <figure className={figureWrapper}>
       <ChartTitle title={title} subtitle={subtitle} />
       <div className={wrapperStyle}>{children}</div>
     </figure>


### PR DESCRIPTION
While #791 improved accessibility, it messed up some styling. This quick fix gets the homepage back looking pretty 💅

😱
<img width="741" alt="image" src="https://user-images.githubusercontent.com/7065695/63240804-10441380-c206-11e9-831e-ff9e7f8e8079.png">

🤩
<img width="741" alt="image" src="https://user-images.githubusercontent.com/7065695/63240728-c6f3c400-c205-11e9-9149-ce1abc14750e.png">
