### PR TITLE
Issue 789 - Links and Resources DOM nesting

### DIFF
--- a/_templates/api-story-card/with-prompt/src/components/App/templateAPICardMeta.ejs.t
+++ b/_templates/api-story-card/with-prompt/src/components/App/templateAPICardMeta.ejs.t
@@ -115,12 +115,17 @@ const <%=StoryCardName%>Meta = (/* data */) => ({
     </Collapsable>
   ),
   resources: [
-    { link: "http://www.hackoregon.org", description: "Hack Oregon" },
     {
-      link: "https://www.civicsoftwarefoundation.org",
-      description: "Civic Software Foundation"
-    },
-    { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      heading: "Organizations",
+      items: [
+        { link: "http://www.hackoregon.org", description: "Hack Oregon" },
+        {
+          link: "https://www.civicsoftwarefoundation.org",
+          description: "Civic Software Foundation"
+        },
+        { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      ]
+    }
   ],
   // authors likely an array of keys in the future
   authors: [

--- a/_templates/local-data-story-card/with-prompt/src/components/App/templateFileCardMeta.ejs.t
+++ b/_templates/local-data-story-card/with-prompt/src/components/App/templateFileCardMeta.ejs.t
@@ -114,12 +114,17 @@ const <%=StoryCardName%>Meta = (/* data */) => ({
     </Collapsable>
   ),
   resources: [
-    { link: "http://www.hackoregon.org", description: "Hack Oregon" },
     {
-      link: "https://www.civicsoftwarefoundation.org",
-      description: "Civic Software Foundation"
-    },
-    { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      heading: "Organizations",
+      items: [
+        { link: "http://www.hackoregon.org", description: "Hack Oregon" },
+        {
+          link: "https://www.civicsoftwarefoundation.org",
+          description: "Civic Software Foundation"
+        },
+        { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      ]
+    }
   ],
   // authors likely an array of keys in the future
   authors: [

--- a/packages/2019-template/src/components/DemoCard/demoCardMeta.js
+++ b/packages/2019-template/src/components/DemoCard/demoCardMeta.js
@@ -37,7 +37,9 @@ const demoCardMeta = (/* data */) => ({
         mortgage-lending practices, restrictive covenants and deeds, public
         works projects condemning entire Black neighborhoods, and zoning rules
         that reinforce segregation are only a few to be named."`}
-        {"("}<a href="https://www.portlandoregon.gov/bps/article/700970">Source</a>{")"}
+        {"("}
+        <a href="https://www.portlandoregon.gov/bps/article/700970">Source</a>
+        {")"}
       </p>
     </Fragment>
   ),
@@ -455,44 +457,56 @@ const demoCardMeta = (/* data */) => ({
     }
   ],
   resources: [
-    { section: "Studies and Papers" },
     {
-      link: "https://www.portlandoregon.gov/bps/62635",
-      description:
-        "Gentrification and Displacement Study - Portland Bureau of Planning and Sustainability"
+      heading: "Studies and Papers",
+      items: [
+        {
+          link: "https://www.portlandoregon.gov/bps/62635",
+          description:
+            "Gentrification and Displacement Study - Portland Bureau of Planning and Sustainability"
+        },
+        {
+          link:
+            "https://www.sciencedirect.com/science/article/abs/pii/S2213624X18300270",
+          description:
+            "Gentrification of station areas and its impact on transit ridership"
+        }
+      ]
     },
     {
-      link:
-        "https://www.sciencedirect.com/science/article/abs/pii/S2213624X18300270",
-      description:
-        "Gentrification of station areas and its impact on transit ridership"
+      heading: "Articles",
+      items: [
+        {
+          link:
+            "http://transitcenter.org/2017/11/14/in-portland-economic-displacement-may-be-a-driver-of-transit-ridership-loss/",
+          description:
+            "In Portland, Economic Displacement May Be A Driver of Transit Ridership Loss"
+        },
+        {
+          link:
+            "https://www.nrdc.org/onearth/when-public-transportation-leads-gentrification",
+          description: "When Public Transit Leads Gentrification"
+        },
+        {
+          link:
+            "http://transitcenter.org/publications/inclusive-transit-advancing-equity-improved-access-opportunity/",
+          description:
+            "Inclusive Transit: Advancing Equity Through Improved Access and Opportunity"
+        }
+      ]
     },
-    { section: "Articles" },
     {
-      link:
-        "http://transitcenter.org/2017/11/14/in-portland-economic-displacement-may-be-a-driver-of-transit-ridership-loss/",
-      description:
-        "In Portland, Economic Displacement May Be A Driver of Transit Ridership Loss"
-    },
-    {
-      link:
-        "https://www.nrdc.org/onearth/when-public-transportation-leads-gentrification",
-      description: "When Public Transit Leads Gentrification"
-    },
-    {
-      link:
-        "http://transitcenter.org/publications/inclusive-transit-advancing-equity-improved-access-opportunity/",
-      description:
-        "Inclusive Transit: Advancing Equity Through Improved Access and Opportunity"
-    },
-    { section: "Organizations" },
-    { link: "https://trimet.org/", description: "TriMet" },
-    {
-      link: "https://www.portlandoregon.gov/bps/",
-      description: "Portland Bureau of Planning and Sustainability"
-    },
-    { link: "https://www.paalf.org/", description: "PAALF" },
-    { link: "http://transitcenter.org/", description: "TransitCenter" }
+      heading: "Organizations",
+      items: [
+        { link: "https://trimet.org/", description: "TriMet" },
+        {
+          link: "https://www.portlandoregon.gov/bps/",
+          description: "Portland Bureau of Planning and Sustainability"
+        },
+        { link: "https://www.paalf.org/", description: "PAALF" },
+        { link: "http://transitcenter.org/", description: "TransitCenter" }
+      ]
+    }
   ],
   // authors likely an array of keys in the future
   authors: [

--- a/packages/2019-template/src/components/TemplateAPICard/templateAPICardMeta.js
+++ b/packages/2019-template/src/components/TemplateAPICard/templateAPICardMeta.js
@@ -112,12 +112,17 @@ const TemplateAPICardMeta = (/* data */) => ({
     </Collapsable>
   ),
   resources: [
-    { link: "http://www.hackoregon.org", description: "Hack Oregon" },
     {
-      link: "https://www.civicsoftwarefoundation.org",
-      description: "Civic Software Foundation"
-    },
-    { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      heading: "Organizations",
+      items: [
+        { link: "http://www.hackoregon.org", description: "Hack Oregon" },
+        {
+          link: "https://www.civicsoftwarefoundation.org",
+          description: "Civic Software Foundation"
+        },
+        { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      ]
+    }
   ],
   // authors likely an array of keys in the future
   authors: [

--- a/packages/2019-template/src/components/TemplateFileCard/templateFileCardMeta.js
+++ b/packages/2019-template/src/components/TemplateFileCard/templateFileCardMeta.js
@@ -113,12 +113,17 @@ const TemplateFileCardMeta = (/* data */) => ({
     </Collapsable>
   ),
   resources: [
-    { link: "http://www.hackoregon.org", description: "Hack Oregon" },
     {
-      link: "https://www.civicsoftwarefoundation.org",
-      description: "Civic Software Foundation"
-    },
-    { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      heading: "Organizations",
+      items: [
+        { link: "http://www.hackoregon.org", description: "Hack Oregon" },
+        {
+          link: "https://www.civicsoftwarefoundation.org",
+          description: "Civic Software Foundation"
+        },
+        { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      ]
+    }
   ],
   // authors likely an array of keys in the future
   authors: [

--- a/packages/2019-transportation/src/components/TransportationCard/transportationCardMeta.js
+++ b/packages/2019-transportation/src/components/TransportationCard/transportationCardMeta.js
@@ -113,12 +113,17 @@ const transportationCardMeta = (/* data */) => ({
     </Collapsable>
   ),
   resources: [
-    { link: "http://www.hackoregon.org", description: "Hack Oregon" },
     {
-      link: "https://www.civicsoftwarefoundation.org",
-      description: "Civic Software Foundation"
-    },
-    { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      heading: "Organizations",
+      items: [
+        { link: "http://www.hackoregon.org", description: "Hack Oregon" },
+        {
+          link: "https://www.civicsoftwarefoundation.org",
+          description: "Civic Software Foundation"
+        },
+        { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      ]
+    }
   ],
   // authors likely an array of keys in the future
   authors: [

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -105,7 +105,7 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
           </p>
           <CollapsableSection
             items={cardMeta.resources.map(item => (
-              <Resource item={item} key={generate()} />
+              <Resource section={item} key={generate()} />
             ))}
             collapseAfter={7}
           />

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
@@ -150,7 +150,7 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
             </p>
             <CollapsableSection
               items={cardMeta.resources.map(item => (
-                <Resource item={item} key={generate()} />
+                <Resource section={item} key={generate()} />
               ))}
               collapseAfter={7}
             />

--- a/packages/component-library/src/CivicCard/LayoutComponents.js
+++ b/packages/component-library/src/CivicCard/LayoutComponents.js
@@ -32,20 +32,30 @@ Chip.propTypes = {
   index: PropTypes.number
 };
 
-export function Resource({ item }) {
-  return _.has(item, "section") ? (
-    <h3>{item.section}</h3>
-  ) : (
-    <li>
-      <a href={item.link}>{item.description}</a>
-    </li>
+export function Resource({ section }) {
+  return (
+    <Fragment>
+      <h3>{section.heading}</h3>
+      <ul>
+        {section.items.map(item => (
+          <li>
+            <a href={item.link}>{item.description}</a>
+          </li>
+        ))}
+      </ul>
+    </Fragment>
   );
 }
 
 Resource.propTypes = {
-  item: PropTypes.shape({
-    link: PropTypes.string,
-    description: PropTypes.string
+  section: PropTypes.shape({
+    heading: PropTypes.string,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        link: PropTypes.string,
+        description: PropTypes.string
+      })
+    )
   })
 };
 

--- a/packages/component-library/src/CivicCard/cardMetaTypes.js
+++ b/packages/component-library/src/CivicCard/cardMetaTypes.js
@@ -18,13 +18,15 @@ const cardMetaObjectProperties = {
     ])
   ),
   resources: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.shape({ section: PropTypes.string }),
-      PropTypes.shape({
-        link: PropTypes.string /* url */,
-        description: PropTypes.string
-      })
-    ])
+    PropTypes.shape({
+      heading: PropTypes.string,
+      items: PropTypes.arrayOf(
+        PropTypes.shape({
+          link: PropTypes.string,
+          description: PropTypes.string
+        })
+      )
+    })
   ),
   authors: PropTypes.arrayOf(PropTypes.string /* image url */)
 };

--- a/packages/component-library/stories/CivicCard.story.js
+++ b/packages/component-library/stories/CivicCard.story.js
@@ -433,44 +433,56 @@ const demoCardMeta = (/* data */) => ({
     }
   ],
   resources: [
-    { section: "Studies and Papers" },
     {
-      link: "https://www.portlandoregon.gov/bps/62635",
-      description:
-        "Gentrification and Displacement Study - Portland Bureau of Planning and Sustainability"
+      heading: "Studies and Papers",
+      items: [
+        {
+          link: "https://www.portlandoregon.gov/bps/62635",
+          description:
+            "Gentrification and Displacement Study - Portland Bureau of Planning and Sustainability"
+        },
+        {
+          link:
+            "https://www.sciencedirect.com/science/article/abs/pii/S2213624X18300270",
+          description:
+            "Gentrification of station areas and its impact on transit ridership"
+        }
+      ]
     },
     {
-      link:
-        "https://www.sciencedirect.com/science/article/abs/pii/S2213624X18300270",
-      description:
-        "Gentrification of station areas and its impact on transit ridership"
+      heading: "Articles",
+      items: [
+        {
+          link:
+            "http://transitcenter.org/2017/11/14/in-portland-economic-displacement-may-be-a-driver-of-transit-ridership-loss/",
+          description:
+            "In Portland, Economic Displacement May Be A Driver of Transit Ridership Loss"
+        },
+        {
+          link:
+            "https://www.nrdc.org/onearth/when-public-transportation-leads-gentrification",
+          description: "When Public Transit Leads Gentrification"
+        },
+        {
+          link:
+            "http://transitcenter.org/publications/inclusive-transit-advancing-equity-improved-access-opportunity/",
+          description:
+            "Inclusive Transit: Advancing Equity Through Improved Access and Opportunity"
+        }
+      ]
     },
-    { section: "Articles" },
     {
-      link:
-        "http://transitcenter.org/2017/11/14/in-portland-economic-displacement-may-be-a-driver-of-transit-ridership-loss/",
-      description:
-        "In Portland, Economic Displacement May Be A Driver of Transit Ridership Loss"
-    },
-    {
-      link:
-        "https://www.nrdc.org/onearth/when-public-transportation-leads-gentrification",
-      description: "When Public Transit Leads Gentrification"
-    },
-    {
-      link:
-        "http://transitcenter.org/publications/inclusive-transit-advancing-equity-improved-access-opportunity/",
-      description:
-        "Inclusive Transit: Advancing Equity Through Improved Access and Opportunity"
-    },
-    { section: "Organizations" },
-    { link: "https://trimet.org/", description: "TriMet" },
-    {
-      link: "https://www.portlandoregon.gov/bps/",
-      description: "Portland Bureau of Planning and Sustainability"
-    },
-    { link: "https://www.paalf.org/", description: "PAALF" },
-    { link: "http://transitcenter.org/", description: "TransitCenter" }
+      heading: "Organizations",
+      items: [
+        { link: "https://trimet.org/", description: "TriMet" },
+        {
+          link: "https://www.portlandoregon.gov/bps/",
+          description: "Portland Bureau of Planning and Sustainability"
+        },
+        { link: "https://www.paalf.org/", description: "PAALF" },
+        { link: "http://transitcenter.org/", description: "TransitCenter" }
+      ]
+    }
   ],
   // authors likely an array of keys in the future
   authors: [


### PR DESCRIPTION
This resolves #789.

In order to accomplish this, it improves the shape of the `cardMeta.resources` -- rather than taking an array of items that could be section headings or links, it now takes an array of sections with headings and an array of items.