### PR TITLE
Convert MultiLayer Choropleth Map from Polygon to GeoJSON layer

### DIFF
--- a/packages/component-library/src/MultiLayerMap/MultiChoroplethMap.js
+++ b/packages/component-library/src/MultiLayerMap/MultiChoroplethMap.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { PolygonLayer } from "deck.gl";
+import { GeoJsonLayer } from "deck.gl";
 import shortid from "shortid";
 import { number, string, bool, func, arrayOf, shape } from "prop-types";
 import {
@@ -74,7 +74,7 @@ const MultiChoroplethMap = props => {
   const getLineWidth = createSizeScale(polygonWidth);
 
   return (
-    <PolygonLayer
+    <GeoJsonLayer
       key={shortid.generate()}
       id={id}
       pickable={pickable}
@@ -89,6 +89,7 @@ const MultiChoroplethMap = props => {
       lineWidthMinPixels={1}
       lineWidthScale={1}
       lineJointRounded={false}
+      extruded={false}
       onHover={onHoverSlide}
       onClick={onLayerClick}
       autoHighlight={autoHighlight}

--- a/packages/component-library/stories/MapOverlay.story.js
+++ b/packages/component-library/stories/MapOverlay.story.js
@@ -237,6 +237,7 @@ export default () =>
           GROUP_IDS.MARKER
         );
 
+        const onLayerClick = info => action("Layer Clicked:")(info);
         const fetchURL = text("Data API URL:", CIVIC_API_URL, GROUP_IDS.DATA);
 
         return (
@@ -271,6 +272,7 @@ export default () =>
                     getFillColor={f =>
                       colorScale(f.properties[polygonFieldName])
                     }
+                    onLayerClick={onLayerClick}
                   />
                 </BaseMap>
               );
@@ -376,6 +378,7 @@ export default () =>
     .add(
       "Example: With Tooltip",
       () => {
+        const onLayerClick = info => action("Layer Clicked:")(info);
         return (
           <DemoJSONLoader urls={[CIVIC_API_URL]}>
             {data => (
@@ -383,6 +386,7 @@ export default () =>
                 <MapOverlay
                   data={data.results.features}
                   getFillColor={[25, 183, 170]}
+                  onLayerClick={onLayerClick}
                 >
                   <MapTooltip
                     primaryName="Earthquake - Total Day Injuries"


### PR DESCRIPTION
The deck gl polygon layer does not render MultiPolygons. As you can see in the two layers below, the first layer only shows geometries of the type polygon and the second layer displays both polygons and MultiPolygons.
![Polygons](https://user-images.githubusercontent.com/9361258/63564040-4cce8280-c518-11e9-898b-f0644645c76c.png)

![MultiPolygons](https://user-images.githubusercontent.com/9361258/63564041-4e984600-c518-11e9-8857-11ade6549817.png)

This is an issue because one of our data sets is made up entirely of MultiPolygons. So the current MultiLayer Choropleth Map does not shows anything when that data set is loaded.

This PR solves this issue by converting the MultiLayer Choropleth Map from the polygon layer to the GeoJSON layer.

