### PR TITLE
Remove unnecessary yarn configure in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
 - npm i -g rimraf
 - npm i -g cross-env
 - yarn bootstrap
-- yarn run configure
 matrix:
   include:
 #  - env: SUITE=2017


### PR DESCRIPTION
We noticed while investigating #832 that `yarn bootstrap` already builds the `component-library` and `mock-wrapper`, which are the only things that `yarn configure` does. This PR removes that duplication