### PR TITLE
Improve generator scripts

### DIFF
--- a/_templates/api-story-card/with-prompt/__variables__.ejs.t
+++ b/_templates/api-story-card/with-prompt/__variables__.ejs.t
@@ -20,3 +20,8 @@
 # Story Card Name
 <%title = h.changeCase.title(card)%> 
 
+# api
+<%API = h.changeCase.pascal(api)%>
+
+<%aPI = h.changeCase.camel(api)%>
+

--- a/_templates/api-story-card/with-prompt/prompt.js
+++ b/_templates/api-story-card/with-prompt/prompt.js
@@ -11,5 +11,11 @@ module.exports = [
     type: "input",
     name: "card",
     message: "What will be the title of the card? (Capitalized With Spaces):"
+  },
+  {
+    type: "input",
+    name: "api",
+    message:
+      "What data you will be fetching from your API endpoint? (e.g. Annual Ridership)"
   }
 ];

--- a/_templates/api-story-card/with-prompt/src/components/App/TemplateAPICardVisualization.ejs.t
+++ b/_templates/api-story-card/with-prompt/src/components/App/TemplateAPICardVisualization.ejs.t
@@ -11,7 +11,7 @@ const <%=StoryCardName%>Visualization = ({ isLoading, data }) => (
   <>
     {!isLoading && data && (
       <LineChart
-        data={data.mockRidershipOverTime.value}
+        data={data.<%=aPI%>.value}
         dataKey="year"
         dataValue="weekday_sum_ons"
         title="Template API Plot"
@@ -22,7 +22,7 @@ const <%=StoryCardName%>Visualization = ({ isLoading, data }) => (
 
 <%=StoryCardName%>Visualization.propTypes = {
   isLoading: PropTypes.bool,
-  data: PropTypes.shape({ mockRidershipOverTime: resourceShape })
+  data: PropTypes.shape({ <%=aPI%>: resourceShape })
 };
 
 export default <%=StoryCardName%>Visualization;

--- a/_templates/api-story-card/with-prompt/src/components/index.ejs.t
+++ b/_templates/api-story-card/with-prompt/src/components/index.ejs.t
@@ -22,8 +22,7 @@ const <%=StoryCardName%> = ({ init, data, Layout }) => {
     */
   ]);
 
-  // FIXME: mockRidershipOverTime should be a variable
-  const loading = !isLoaded(data.mockRidershipOverTime);
+  const loading = !isLoaded(data.<%=aPI%>);
 
   return (
     <CivicCard
@@ -39,15 +38,14 @@ const <%=StoryCardName%> = ({ init, data, Layout }) => {
 
 <%=StoryCardName%>.propTypes = {
   init: PropTypes.func,
-  data: PropTypes.shape({ mockRidershipOverTime: resourceShape }),
+  data: PropTypes.shape({ <%=aPI%>: resourceShape }),
   Layout: PropTypes.func
 };
 
 export default connect(
   state => ({
     data: {
-      // FIXME: mockRidershipOverTime should be a variable
-      mockRidershipOverTime: api.selectors.getMockRidershipData(
+      <%=aPI%>: api.selectors.get<%=API%>Data(
         state.package<%= h.changeCase.pascalCase(package)%> || state
       )
     }
@@ -55,8 +53,7 @@ export default connect(
   }),
   dispatch => ({
     init() {
-      // FIXME: mockRidershipOverTime should be a variable
-      dispatch(api.actionCreators.getMockRidershipData());
+      dispatch(api.actionCreators.get<%=API%>Data());
     }
   })
 )(<%=StoryCardName%>);

--- a/_templates/api-story-card/with-prompt/src/components/index.ejs.t
+++ b/_templates/api-story-card/with-prompt/src/components/index.ejs.t
@@ -8,7 +8,7 @@ import { isLoaded } from "reduxful";
 import { resourceShape } from "reduxful/react-addons";
 import { CivicCard } from "@hackoregon/component-library";
 
-import <%=StoryCardName%>Meta from "./<%=storyCardName%>Meta";
+import <%=storyCardName%>Meta from "./<%=storyCardName%>Meta";
 import api from "../../state/<%=slug%>/api";
 
 const <%=StoryCardName%> = ({ init, data, Layout }) => {
@@ -26,7 +26,7 @@ const <%=StoryCardName%> = ({ init, data, Layout }) => {
 
   return (
     <CivicCard
-      cardMeta={<%=StoryCardName%>Meta}
+      cardMeta={<%=storyCardName%>Meta}
       isLoading={loading}
       data={data}
       Layout={Layout}

--- a/_templates/api-story-card/with-prompt/src/state/api.ejs.t
+++ b/_templates/api-story-card/with-prompt/src/state/api.ejs.t
@@ -10,7 +10,10 @@ const HOST = "https://service.civicpdx.org/transportation-systems";
 
 const apiDesc = {
   get<%=API%>Data: {
-    url: `${HOST}/passenger-census/system/annual/averages/?format=json`
+    url: `${HOST}/passenger-census/system/annual/averages/?format=json`,
+    // you can apply any needed data transformations to value here
+    // if complex, separate tranformation function to another file
+    dataTransform: data => data    
   }
 };
 

--- a/_templates/api-story-card/with-prompt/src/state/api.ejs.t
+++ b/_templates/api-story-card/with-prompt/src/state/api.ejs.t
@@ -6,11 +6,10 @@ import requestAdapter from "../request-adapter";
 
 const apiConfig = { requestAdapter };
 
-// FIXME: getMockRidershipData should be variable
 const HOST = "https://service.civicpdx.org/transportation-systems";
 
 const apiDesc = {
-  getMockRidershipData: {
+  get<%=API%>Data: {
     url: `${HOST}/passenger-census/system/annual/averages/?format=json`
   }
 };

--- a/_templates/package-generator/with-prompt/package.ejs.t
+++ b/_templates/package-generator/with-prompt/package.ejs.t
@@ -46,6 +46,7 @@ to: packages/<%=year%>-<%=packageTitle%>/package.json
     "cross-fetch": "^3.0.4",
     "express": "^4.14.1",
     "invariant": "^2.2.2",
+    "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "ramda": "^0.23.0",
     "react": "^16.8.4",

--- a/package.json
+++ b/package.json
@@ -1,51 +1,51 @@
 {
   "name": "@hackoregon/civic",
+  "private": true,
   "description": "Civic is an open source project of Hack Oregon, built entirely by volunteers committed to neutral, nonpartisan exploration of civic analytics.",
-  "author": "Hack Oregon",
-  "license": "MIT",
+  "keywords": [
+    "boilerplate",
+    "hackoregon",
+    "lerna",
+    "monorepo",
+    "react",
+    "react-router",
+    "redux",
+    "webpack"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/hackoregon/civic"
   },
-  "keywords": [
-    "react",
-    "react-router",
-    "webpack",
-    "redux",
-    "boilerplate",
-    "monorepo",
-    "lerna",
-    "hackoregon"
-  ],
+  "license": "MIT",
+  "author": "Hack Oregon",
   "workspaces": [
     "packages/*"
   ],
-  "private": true,
   "scripts": {
     "bootstrap": "yarn install --frozen-lockfile && yarn --cwd ./packages/component-library/ build && yarn --cwd ./packages/mock-wrapper/ build",
     "build": "lerna run build",
-    "new-card": "yarn card",
-    "new-card:local-data": "yarn card:local-data",
-    "new-package": "yarn hygen package-generator with-prompt && yarn",
-    "card": "yarn hygen api-story-card with-prompt && yarn",
-    "card:local-data": "yarn hygen local-data-story-card with-prompt && yarn",
-    "configure": "lerna run configure",
-    "publish-patch": "lerna publish bump patch --yes",
-    "publish-minor": "lerna publish bump minor --yes",
-    "publish-major": "lerna publish bump major --yes",
-    "publish-canary": "lerna publish --canary --yes --preid ci --npm-tag=ci -m '(🐦ci-canary): publish %s'",
+    "card": "yarn new-card",
+    "card:local-data": "yarn new-card:local-data",
     "clean": "lerna clean && rimraf node_modules",
-    "watch": "node scripts/watch",
-    "start": "node scripts/start",
+    "configure": "lerna run configure",
     "deploy-storybook": "NODE_OPTIONS=--max_old_space_size=4096 BABEL_ENV=esm storybook-to-ghpages",
+    "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
     "in": "lerna run --scope",
     "lint": "lerna run lint --no-bail",
     "lint:fix": "lerna run lint --no-bail -- --fix",
+    "new-card": "yarn hygen api-story-card with-prompt && yarn",
+    "new-card:local-data": "yarn hygen local-data-story-card with-prompt && yarn",
+    "new-package": "yarn hygen package-generator with-prompt && yarn",
+    "pretty": "prettier --write \"./**/*.{js,jsx,css,md}\"",
+    "publish-canary": "lerna publish --canary --yes --preid ci --npm-tag=ci -m '(🐦ci-canary): publish %s'",
+    "publish-major": "lerna publish bump major --yes",
+    "publish-minor": "lerna publish bump minor --yes",
+    "publish-patch": "lerna publish bump patch --yes",
+    "start": "node scripts/start",
     "storybook": "BABEL_ENV=esm start-storybook -p 6006",
     "test": "lerna exec yarn test --no-bail",
     "travis": "make travis",
-    "pretty": "prettier --write \"./**/*.{js,jsx,css,md}\"",
-    "eslint-check": "eslint --print-config . | eslint-config-prettier-check"
+    "watch": "node scripts/watch"
   },
   "husky": {
     "hooks": {
@@ -53,16 +53,17 @@
     }
   },
   "lint-staged": {
+    "*.{css,md,json}": [
+      "prettier --write",
+      "git add"
+    ],
     "*.{js,jsx}": [
       "prettier --write",
       "eslint --fix",
       "git add"
-    ],
-    "*.{css,md,json}": [
-      "prettier --write",
-      "git add"
     ]
   },
+  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
@@ -139,6 +140,5 @@
     "webpack-hot-middleware": "^2.24.3",
     "webpack-md5-hash": "^0.0.6",
     "webpack-node-externals": "^1.5.4"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   "scripts": {
     "bootstrap": "yarn install --frozen-lockfile && yarn --cwd ./packages/component-library/ build && yarn --cwd ./packages/mock-wrapper/ build",
     "build": "lerna run build",
+    "new-card": "yarn card",
+    "new-card:local-data": "yarn card:local-data",
     "new-package": "yarn hygen package-generator with-prompt && yarn",
     "card": "yarn hygen api-story-card with-prompt && yarn",
     "card:local-data": "yarn hygen local-data-story-card with-prompt && yarn",


### PR DESCRIPTION
This PR improves the package and card generators based on testing feedback

Package generator:
- add lodash to package generator dependencies

Card generator:
- added a prompt to ask for what the API is, and named variables based on that
- changed cardMeta to camel case
- add and documented dataTransform

Additional:
- #842 renamed card and card:local-data to new-card and new-card:local-data, kept as aliases
- sorted package.json