### PR TITLE
Add transportation-2019 to card-registry

### DIFF
--- a/packages/2018/src/card-registry.js
+++ b/packages/2018/src/card-registry.js
@@ -7,6 +7,7 @@ import { CardRegistry as TransportationSystems } from "@hackoregon/2018-transpor
 // 2019 project routes
 import { CardRegistry as Template2019 } from "@hackoregon/2019-template";
 import { CardRegistry as Housing2019 } from "@hackoregon/2019-housing";
+import { CardRegistry as Transportation2019 } from "@hackoregon/2019-transportation";
 
 import Registry from "./utils/registry";
 
@@ -35,6 +36,6 @@ const allEntries = []
   )
   // 2019 project routes
   .concat(Template2019.map(decorate("@hackoregon/2019-template")))
-  .concat(Housing2019.map(decorate("@hackoregon/2019-housing")));
-
+  .concat(Housing2019.map(decorate("@hackoregon/2019-housing")))
+  .concat(Transportation2019.map(decorate("@hackoregon/2019-transportation")));
 export default new Registry(allEntries);


### PR DESCRIPTION
Transportation-2019 was missing from the card-registry. This adds it.