### PR TITLE
Orb Bounds and Orb Optimize

### DIFF
--- a/packages/project-disaster-trail/src/components/Game/KitScreen/KitItem.js
+++ b/packages/project-disaster-trail/src/components/Game/KitScreen/KitItem.js
@@ -25,7 +25,7 @@ const KitItem = ({ emptySvg, fullSvg, playerKit, itemType }) => {
     if (playerKit[itemType] && !filledItem) {
       setFilledItem(true);
     }
-  });
+  }, [playerKit, itemType, filledItem]);
 
   const EmptyKitItem = css`
     background-image: url(${emptySvg});

--- a/packages/project-disaster-trail/src/components/Game/Orb.js
+++ b/packages/project-disaster-trail/src/components/Game/Orb.js
@@ -57,12 +57,25 @@ export default class Orb extends PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    // What properties have changed?
+    // useful for debugging
+    // for (const i in prevProps) {
+    //   if (this.props[i] !== prevProps[i]) {
+    //     console.log(
+    //       i,
+    //       prevProps[i],
+    //       this.props[i],
+    //       this.props[i] === prevProps[i]
+    //     );
+    //   }
+    // }
+
     const { isComplete } = this.state;
-    const { addOrbScore, orb, setOrbComplete } = this.props;
+    const { addOrbScore, orbId, setOrbComplete } = this.props;
 
     if (!prevState.isComplete && isComplete) {
-      addOrbScore(orb);
-      setOrbComplete(orb);
+      addOrbScore(orbId);
+      setOrbComplete(orbId);
     }
   }
 
@@ -84,26 +97,26 @@ export default class Orb extends PureComponent {
 
   handleOrbPress = () => {
     const { isComplete } = this.state;
-    const { orb, setOrbTouched } = this.props;
+    const { orbId, setOrbTouched } = this.props;
     // if already pressed, do nothing
     if (isComplete) return;
 
     this.setState({ isActive: true }, () => {
       this.incrementGauge();
     });
-    setOrbTouched(orb, true);
+    setOrbTouched(orbId, true);
   };
 
   handleOrbRelease = () => {
     this.setState({ isActive: false });
-    const { orb, setOrbTouched } = this.props;
-    setOrbTouched(orb, false);
+    const { orbId, setOrbTouched } = this.props;
+    setOrbTouched(orbId, false);
   };
 
   render() {
     const { isActive, isComplete, percent } = this.state;
     // eslint-disable-next-line no-unused-vars
-    const { size, orb } = this.props;
+    const { size, imageSVG, imgAlt } = this.props;
 
     const sizeStyle = css`
       height: ${size}px;
@@ -145,7 +158,7 @@ export default class Orb extends PureComponent {
           `}
           className={orbClass}
         >
-          <img src={orb.imageSVG} alt={orb.imgAlt} css={iconStyle} />
+          <img src={imageSVG} alt={imgAlt} css={iconStyle} />
         </div>
       </div>
     );
@@ -154,9 +167,11 @@ export default class Orb extends PureComponent {
 }
 
 Orb.propTypes = {
+  orbId: PropTypes.string,
   setOrbTouched: PropTypes.func,
   setOrbComplete: PropTypes.func,
   addOrbScore: PropTypes.func,
-  orb: PropTypes.shape({}),
+  imageSVG: PropTypes.string,
+  imgAlt: PropTypes.string,
   size: PropTypes.number
 };

--- a/packages/project-disaster-trail/src/components/Game/OrbManager.js
+++ b/packages/project-disaster-trail/src/components/Game/OrbManager.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-named-as-default */
-import React, { useEffect, useState, memo, useRef } from "react";
+import React, { useEffect, useState, memo, useRef, useCallback } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-import { map } from "lodash";
+import { map, find as _find } from "lodash";
 import styled from "@emotion/styled";
 
 import remove from "lodash/remove";
@@ -14,6 +14,17 @@ import useAnimationFrame from "../../state/hooks/useAnimationFrame";
 import Orb from "./Orb";
 import { addItemToPlayerKit, getKitCreationItems } from "../../state/kit";
 import { addPoints } from "../../state/user";
+
+const ORB_CONFIG = {
+  period: 1,
+  orbCount: 10,
+  orbSize: 40,
+  maxVelocityY: 0,
+  minVelocityX: 0.5,
+  minVelocityY: 0,
+  maxVelocityX: 2,
+  verticalBuffer: 25
+};
 
 function createOrbsFromKit(kitItems, bounds, config) {
   if (!kitItems.length) {
@@ -30,7 +41,9 @@ function createOrbsFromKit(kitItems, bounds, config) {
     for (let j = 0; j < totalGeneratedOrbs; j += 1) {
       const orbId = `${kitData.type}-${j}`;
       kitData.x = Math.random() * bounds.width;
-      kitData.y = Math.random() * (bounds.height - config.orbSize / 2);
+      kitData.y =
+        ORB_CONFIG.verticalBuffer +
+        Math.random() * (bounds.height - ORB_CONFIG.verticalBuffer * 2);
       kitData.velocity = {
         x:
           config.minVelocityX +
@@ -48,16 +61,6 @@ function createOrbsFromKit(kitItems, bounds, config) {
 
   return orbCollection;
 }
-
-const ORB_CONFIG = {
-  period: 1,
-  orbCount: 10,
-  orbSize: 40,
-  maxVelocityY: 0,
-  minVelocityX: 0.1,
-  minVelocityY: 0.1,
-  maxVelocityX: 2
-};
 
 /**
  * OrbManager is responsible for moving Orbs
@@ -98,7 +101,42 @@ const OrbManager = ({
       setHasInitialized(true);
       setOrbsState(newOrbs);
     }
-  }, [bounds]);
+  }, [bounds, hasInitialized, kitItems, prevBounds]);
+
+  const addOrbScore = useCallback(
+    orbId => {
+      const theOrb = _find(orbs, orb => orb.orbId === orbId);
+      if (theOrb.good) {
+        addItemToPlayerKitInState(theOrb.type);
+        addPointsToState(theOrb.points);
+      }
+    },
+    // update when orbs.length changes
+    // if we udpate when orbs changes, the addOrbScore will continuously be recreated,
+    // and, in turn, causes `Orb` to render continously.
+    // eslint-disable-next-line
+    [addItemToPlayerKitInState, addPointsToState, orbs.length]
+  );
+
+  const setOrbTouched = useCallback(
+    (orbId, isTouched) => {
+      if (isTouched) {
+        setTouchedOrb(prevOrbs => [...prevOrbs, orbId]);
+        return;
+      }
+
+      const updatedOrbs = remove(
+        touchedOrbs,
+        touchedOrb => touchedOrb.orbId === orbId
+      );
+      setTouchedOrb(updatedOrbs);
+    },
+    [touchedOrbs]
+  );
+
+  const setOrbComplete = useCallback(orbId => {
+    setCompletedOrbs(prevOrbs => [...prevOrbs, orbId]);
+  }, []);
 
   // `animate` is called every frame
   // eslint-disable-next-line consistent-return
@@ -106,6 +144,8 @@ const OrbManager = ({
     if (!bounds || !bounds.width || !hasInitialized) return null;
 
     const tempModels = [];
+    const centerY = (bounds.height - ORB_CONFIG.verticalBuffer * 2) / 2;
+
     // we re-use tempModels by pushing updated data in to it.
     for (let i = 0; i < orbs.length; i += 1) {
       // get the model
@@ -133,9 +173,27 @@ const OrbManager = ({
       if (currentOrb.x > bounds.width)
         currentOrb.x -= bounds.width + ORB_CONFIG.orbSize;
 
-      if (currentOrb.y < -ORB_CONFIG.orbSize) currentOrb.y += bounds.height;
-      if (currentOrb.y > bounds.height)
-        currentOrb.y -= bounds.height + ORB_CONFIG.orbSize;
+      // keep the orb within vertical bounds
+      if (currentOrb.y < ORB_CONFIG.verticalBuffer)
+        currentOrb.y = ORB_CONFIG.verticalBuffer;
+      if (
+        currentOrb.y >
+        bounds.height - ORB_CONFIG.verticalBuffer - ORB_CONFIG.orbSize
+      )
+        currentOrb.y =
+          bounds.height - ORB_CONFIG.verticalBuffer - ORB_CONFIG.orbSize;
+
+      // apply a 'force' that pulls the orbs vertically towards the center of the screen
+      const distanceFromCenter = currentOrb.y - centerY;
+      // if the orb is far enough away from the vertical center,
+      // the further the orb is from the center,
+      // the larger the distance
+      // and the greater the 'pull' towards the center
+      if (Math.abs(distanceFromCenter) > 80) {
+        currentOrb.y += -distanceFromCenter * 0.02;
+      }
+
+      currentOrb.y = Math.round(currentOrb.y * 10) / 10;
 
       // store the updated model.
       tempModels.push(currentOrb);
@@ -149,33 +207,6 @@ const OrbManager = ({
 
   useAnimationFrame(() => animate());
 
-  const addOrbScore = orb => {
-    if (orb.good) {
-      addItemToPlayerKitInState(orb.type);
-      addPointsToState(orb.points);
-    }
-  };
-
-  const setOrbTouched = (orb, isTouched) => {
-    const { orbId } = orb;
-
-    if (isTouched) {
-      setTouchedOrb(prevOrbs => [...prevOrbs, orbId]);
-      return;
-    }
-
-    const updatedOrbs = remove(
-      touchedOrbs,
-      touchedOrb => touchedOrb.orbId === orbId
-    );
-    setTouchedOrb(updatedOrbs);
-  };
-
-  const setOrbComplete = orb => {
-    const { orbId } = orb;
-    setCompletedOrbs(prevOrbs => [...prevOrbs, orbId]);
-  };
-
   return (
     <OrbsStyle ref={boundsRef}>
       {map(orbs, (orb, index) => (
@@ -187,7 +218,9 @@ const OrbManager = ({
           }}
         >
           <Orb
-            orb={orb}
+            orbId={orb.orbId}
+            imageSVG={orb.imageSVG}
+            imgAlt={orb.imgAlt}
             size={ORB_CONFIG.orbSize}
             addOrbScore={addOrbScore}
             setOrbTouched={setOrbTouched}

--- a/packages/project-disaster-trail/src/components/Game/TaskScreen/index.js
+++ b/packages/project-disaster-trail/src/components/Game/TaskScreen/index.js
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState, Fragment } from "react";
+import { memo, useEffect, useState, Fragment, useCallback } from "react";
 import { PropTypes } from "prop-types";
 import { connect } from "react-redux";
 /** @jsx jsx */
@@ -58,7 +58,7 @@ const TaskScreen = ({
   // 2) Vote
   // 3) Move Map
   // 4) Go to step 1
-  const onTimerComplete = () => {
+  const onTimerComplete = useCallback(() => {
     switch (action) {
       case ACTIONS.SOLVING:
         if (activeTask) {
@@ -76,17 +76,20 @@ const TaskScreen = ({
         console.warn("Unknown action in onTimerComplete ", action);
         break;
     }
-  };
+  }, [action, activeTask, completeActiveTask]);
 
-  const startTimer = duration => {
-    timer.setDuration(duration);
-    timer.reset();
-    timer.addCallback((t, p) => {
-      setPercentComplete(p);
-    });
-    timer.addCompleteCallback(() => onTimerComplete());
-    timer.start();
-  };
+  const startTimer = useCallback(
+    duration => {
+      timer.setDuration(duration);
+      timer.reset();
+      timer.addCallback((t, p) => {
+        setPercentComplete(p);
+      });
+      timer.addCompleteCallback(() => onTimerComplete());
+      timer.start();
+    },
+    [onTimerComplete, timer]
+  );
 
   // when the component mounts, start a timer of the active task's time
   useEffect(() => {
@@ -97,7 +100,7 @@ const TaskScreen = ({
     return () => {
       timer.stop();
     };
-  }, [timer, activeTask, action]);
+  }, [timer, activeTask, action, startTimer]);
 
   // start a timer for the _entire_ chapter
   useEffect(() => {
@@ -107,7 +110,7 @@ const TaskScreen = ({
     return () => {
       chapterTimer.stop();
     };
-  }, [chapterTimer]);
+  }, [chapterTimer, endChapter]);
 
   // when an action is complete, what should happen next?
   useEffect(() => {
@@ -134,7 +137,7 @@ const TaskScreen = ({
         console.warn("Unknown action: ", action);
         break;
     }
-  }, [prevActiveTask, activeTask, votingComplete, movingMapComplete]);
+  }, [prevActiveTask, activeTask, votingComplete, movingMapComplete, action]);
 
   // when the user transitions from one action to another,
   // start a timer
@@ -154,7 +157,7 @@ const TaskScreen = ({
           console.log("unknown action ", action);
       }
     }
-  }, [action, prevAction]);
+  }, [action, prevAction, startTimer]);
 
   const onItemSelection = item => {
     // eslint-disable-next-line no-console

--- a/packages/project-disaster-trail/src/state/hooks/useAnimationFrame.js
+++ b/packages/project-disaster-trail/src/state/hooks/useAnimationFrame.js
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useLayoutEffect } from "react";
+import { useRef, useEffect, useLayoutEffect, useCallback } from "react";
 
 const useAnimationFrame = callback => {
   const callbackRef = useRef(callback);
@@ -8,16 +8,16 @@ const useAnimationFrame = callback => {
     callbackRef.current = callback;
   }, [callback]);
 
-  const loop = () => {
+  const loop = useCallback(() => {
     frameRef.current = window.requestAnimationFrame(loop);
     const cb = callbackRef.current;
     cb();
-  };
+  }, []);
 
   useLayoutEffect(() => {
     frameRef.current = window.requestAnimationFrame(loop);
     return () => window.cancelAnimationFrame(frameRef.current);
-  }, []);
+  }, [loop]);
 };
 
 export default useAnimationFrame;

--- a/packages/project-disaster-trail/src/state/hooks/useBounds.js
+++ b/packages/project-disaster-trail/src/state/hooks/useBounds.js
@@ -55,7 +55,7 @@ const useBounds = ref => {
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  }, [ref.current]);
+  }, [handleResize, ref]);
 
   return rect;
 };

--- a/packages/project-disaster-trail/src/state/hooks/useUser.js
+++ b/packages/project-disaster-trail/src/state/hooks/useUser.js
@@ -12,9 +12,13 @@ const useUser = () => {
 
   const points = useSelector(state => _getPoints(state));
 
-  const setPoints = useCallback(_points => dispatch(_setPoints(_points)), []);
+  const setPoints = useCallback(_points => dispatch(_setPoints(_points)), [
+    dispatch
+  ]);
 
-  const addPoints = useCallback(_points => dispatch(_addPoints(_points)), []);
+  const addPoints = useCallback(_points => dispatch(_addPoints(_points)), [
+    dispatch
+  ]);
 
   return {
     points,


### PR DESCRIPTION
The OrbManager is now aware of ORB_CONFIG.verticalBuffer, which ensures `<Orb />` components stay away from the vertical bounds of the container. 

The OrbManager pulls `<Orb />` components closer to the vertical center of the container when they approach the vertical bounds of the container. This prevents a 'hard edge' of the verticalBuffer.

The OrbManager does not slowly push `<Orb />` components downwards.

`<Orb />` components have been refactored to not render on every frame, which was caused by inline callbacks (setOrbTouched, setOrbComplete, addOrbScore) being redefined every frame in the `<OrbManager />`. The refactor is simply to wrap the functions in `useCallback` so the callbacks are properly memoized. The `<Orb />` components are also not passed the entire orb model; if the orb model changes the component would unnecessarily re-render.