### PR TITLE
Issue 857 - Chart loading skeleton

### DIFF
--- a/packages/2019-housing/src/components/HomeAppreciation/HomeAppreciationVisualization.js
+++ b/packages/2019-housing/src/components/HomeAppreciation/HomeAppreciationVisualization.js
@@ -91,12 +91,14 @@ const HomeAppreciationVisualization = ({ data }) => {
         xLabel="Home Ownership Rate"
         yLabel="Race"
         dataValueFormatter={x => civicFormat.percentage(x)}
+        protect
       />
       <strong style={{ color: "crimson" }}>
         LineChart Visualization TODO:
         <ul>
           <li>
             Make the confidence interval lines dashed & all lines the same color
+            (see note on lineChartData)
           </li>
         </ul>
       </strong>
@@ -112,6 +114,7 @@ const HomeAppreciationVisualization = ({ data }) => {
         yLabel="Appreciation ($)"
         xNumberFormatter={x => civicFormat.year(x)}
         yNumberFormatter={y => civicFormat.dollars(y)}
+        protect
       />
       <strong style={{ color: "crimson" }}>
         Map Visualization TODO:

--- a/packages/2019-housing/src/components/HomeAppreciation/HomeAppreciationVisualization.js
+++ b/packages/2019-housing/src/components/HomeAppreciation/HomeAppreciationVisualization.js
@@ -33,8 +33,8 @@ const HomeAppreciationVisualization = ({ data }) => {
   const lineChartData = data.annualHomeAppreciation.value.results.flatMap(
     yearData => [
       {
-        series: "raw_appreciation_med",
-        value: yearData.raw_appreciation_med,
+        series: "raw_appreciation_med", // make this match the dataSeriesLabels
+        value: yearData.raw_appreciation_med, // make this match the dataSeriesLabels
         sale_year: yearData.sale_year
       },
       {

--- a/packages/2019-housing/src/components/HomeOwnershipRates/HomeOwnershipRatesVisualization.js
+++ b/packages/2019-housing/src/components/HomeOwnershipRates/HomeOwnershipRatesVisualization.js
@@ -33,6 +33,7 @@ const HomeOwnershipRatesVisualization = ({ data }) => {
         yLabel="Home Ownership Rate"
         xNumberFormatter={x => civicFormat.year(x)}
         yNumberFormatter={y => civicFormat.decimalToPercent(y)}
+        protect
       />
     )
   );

--- a/packages/2019-housing/src/components/HousingDisplacement/HousingDisplacementVisualization.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/HousingDisplacementVisualization.js
@@ -82,6 +82,7 @@ const HousingDisplacementVisualization = ({ isLoading, data }) => {
             xLabel={xLabel}
             yLabel={yLabel}
             xNumberFormatter={tick => tick.toString()}
+            protect
           />
         </div>
         <div style={{ width: "50%" }}>
@@ -94,6 +95,7 @@ const HousingDisplacementVisualization = ({ isLoading, data }) => {
             xLabel={xLabel}
             yLabel={yLabel}
             xNumberFormatter={tick => tick.toString()}
+            protect
           />
         </div>
       </div>

--- a/packages/2019-template/src/components/DemoCard/DemoCardVisualization.js
+++ b/packages/2019-template/src/components/DemoCard/DemoCardVisualization.js
@@ -76,19 +76,18 @@ export default function DemoCardVisualization({ isLoading, data }) {
           Late Gentrification
         </Button>
       </div>
-      {!isLoading && data[dataType] && (
-        <LineChart
-          data={data[dataType]}
-          dataKey="year"
-          dataValue="ridership"
-          dataSeries="series"
-          title={title}
-          xLabel="Year"
-          yLabel="Ridership"
-          xNumberFormatter={civicFormat.year}
-          subtitle={`Average daily ridership ${dataTypeDescription}`}
-        />
-      )}
+      <LineChart
+        loading={isLoading}
+        data={data[dataType]}
+        dataKey="year"
+        dataValue="ridership"
+        dataSeries="series"
+        title={title}
+        xLabel="Year"
+        yLabel="Ridership"
+        xNumberFormatter={civicFormat.year}
+        subtitle={`Average daily ridership ${dataTypeDescription}`}
+      />
     </Fragment>
   );
 }

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -86,6 +86,7 @@
     "@emotion/core": "^10.0.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/styles": "^4.3.3",
+    "@material-ui/lab": "^4.0.0-alpha.24",
     "@turf/center-of-mass": "^6.0.1",
     "copy-to-clipboard": "^3.0.5",
     "create-react-ref": "^0.1.0",

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -86,7 +86,6 @@
     "@emotion/core": "^10.0.15",
     "@material-ui/core": "^4.4.0",
     "@material-ui/styles": "^4.3.3",
-    "@material-ui/lab": "^4.0.0-alpha.24",
     "@turf/center-of-mass": "^6.0.1",
     "copy-to-clipboard": "^3.0.5",
     "create-react-ref": "^0.1.0",

--- a/packages/component-library/src/BarChart/BarChart.js
+++ b/packages/component-library/src/BarChart/BarChart.js
@@ -34,7 +34,8 @@ const BarChart = ({
   error,
   theme
 }) => {
-  const chartDomain = domain || getDefaultDomain(data, dataKey, dataValue);
+  const safeData = data && data.length ? data : [{}];
+  const chartDomain = domain || getDefaultDomain(safeData, dataKey, dataValue);
 
   return (
     <ThemeProvider theme={theme}>
@@ -44,7 +45,7 @@ const BarChart = ({
         loading={loading}
         error={error}
       >
-        <DataChecker dataAccessors={{ dataKey, dataValue }} data={data}>
+        <DataChecker dataAccessors={{ dataKey, dataValue }} data={safeData}>
           <VictoryChart
             padding={{ left: 90, right: 50, bottom: 50, top: 50 }}
             domainPadding={{ x: [40, 40], y: [0, 0] }}
@@ -95,7 +96,7 @@ const BarChart = ({
                   theme={theme}
                 />
               }
-              data={data.map(d => ({
+              data={safeData.map(d => ({
                 dataKey: d[dataKey],
                 dataValue: d[dataValue],
                 label: `${xLabel}: ${xNumberFormatter(

--- a/packages/component-library/src/ChartContainer/ChartContainer.js
+++ b/packages/component-library/src/ChartContainer/ChartContainer.js
@@ -1,20 +1,17 @@
 import PropTypes from "prop-types";
 /** @jsx jsx */
 import { jsx, css } from "@emotion/core";
+import Skeleton from "@material-ui/lab/Skeleton";
 
 import ChartTitle from "../ChartTitle";
-
-const chartLoading = css`
-  text-align: center;
-  background: #eee;
-  height: 100%;
-`;
 
 const chartError = css`
   text-align: center;
   background: #fdd;
   height: 100%;
 `;
+
+const defaultVictoryAspectRatio = 650 / 350;
 
 /**
   ChartContainer renders titles, subtitles, and provides some default styling for charts.
@@ -29,7 +26,8 @@ const ChartContainer = ({
   loading,
   subtitle,
   children,
-  className
+  className,
+  aspectRatio
 }) => {
   const figureWrapper = css`
     margin: 0;
@@ -40,21 +38,24 @@ const ChartContainer = ({
     width: 100%;
     ${className};
   `;
+  const fullHeight = css`
+    padding-top: ${100 / aspectRatio}%;
+  `;
 
-  let content = (
-    <figure css={figureWrapper}>
-      <ChartTitle title={title} subtitle={subtitle} />
-      <div css={wrapperStyle}>{children}</div>
-    </figure>
-  );
+  let content = <div css={wrapperStyle}>{children}</div>;
 
   if (loading) {
-    content = <div css={chartLoading}>Loading...</div>;
+    content = <Skeleton css={[wrapperStyle, fullHeight]} />;
   } else if (error) {
-    content = <div css={chartError}>{error}</div>;
+    content = <div css={[wrapperStyle, fullHeight, chartError]}>{error}</div>;
   }
 
-  return content;
+  return (
+    <figure css={figureWrapper}>
+      <ChartTitle title={title} subtitle={subtitle} />
+      {content}
+    </figure>
+  );
 };
 
 ChartContainer.propTypes = {
@@ -63,9 +64,12 @@ ChartContainer.propTypes = {
   loading: PropTypes.bool,
   children: PropTypes.node,
   subtitle: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
+  aspectRatio: PropTypes.number
 };
 
-ChartContainer.defaultProps = {};
+ChartContainer.defaultProps = {
+  aspectRatio: defaultVictoryAspectRatio
+};
 
 export default ChartContainer;

--- a/packages/component-library/src/ChartContainer/ChartContainer.js
+++ b/packages/component-library/src/ChartContainer/ChartContainer.js
@@ -1,8 +1,7 @@
 import PropTypes from "prop-types";
 /** @jsx jsx */
 import { jsx, css } from "@emotion/core";
-import Skeleton from "@material-ui/lab/Skeleton";
-
+import { BrandColors } from "../index";
 import ChartTitle from "../ChartTitle";
 import Logo from "../Logo/Logo";
 
@@ -12,8 +11,6 @@ const chartError = css`
   height: 100%;
 `;
 
-const defaultVictoryHeight = 350;
-const defaultVictoryWidth = 650;
 const defaultVictoryAspectRatio = 650 / 350;
 
 /**
@@ -47,20 +44,21 @@ const ChartContainer = ({
     height: 100%;
   `;
 
-  const centerContent = css`
-    img {
-      position: absolute;
-      left: 50%;
-      margin-left: -50px;
-      top: 50%;
-      margin-top: -50px;
-    }
+  const skeletonStyle = css`
+    margin: 0 auto;
+    width: 100%;
+    max-width: 900px;
+    height: calc(100vw / ${aspectRatio});
+    max-height: ${900 / aspectRatio}px;
+    background-color: ${BrandColors.subdued.hex};
+    display: grid;
+    justify-items: center;
+    align-items: center;
   `;
 
   let content = (
-    <div css={[wrapperStyle, centerContent]}>
+    <div css={skeletonStyle}>
       <Logo type="squareLogoAnimated" />
-      <Skeleton height={defaultVictoryHeight} width={defaultVictoryWidth} />
     </div>
   );
 

--- a/packages/component-library/src/ChartContainer/ChartContainer.js
+++ b/packages/component-library/src/ChartContainer/ChartContainer.js
@@ -4,6 +4,7 @@ import { jsx, css } from "@emotion/core";
 import Skeleton from "@material-ui/lab/Skeleton";
 
 import ChartTitle from "../ChartTitle";
+import Logo from "../Logo/Logo";
 
 const chartError = css`
   text-align: center;
@@ -11,6 +12,8 @@ const chartError = css`
   height: 100%;
 `;
 
+const defaultVictoryHeight = 350;
+const defaultVictoryWidth = 650;
 const defaultVictoryAspectRatio = 650 / 350;
 
 /**
@@ -39,11 +42,27 @@ const ChartContainer = ({
     ${className};
   `;
   const fullHeight = css`
+    position: relative;
     padding-top: ${100 / aspectRatio}%;
     height: 100%;
   `;
 
-  let content = <Skeleton css={[wrapperStyle, fullHeight]} />;
+  const centerContent = css`
+    img {
+      position: absolute;
+      left: 50%;
+      margin-left: -50px;
+      top: 50%;
+      margin-top: -50px;
+    }
+  `;
+
+  let content = (
+    <div css={[wrapperStyle, centerContent]}>
+      <Logo type="squareLogoAnimated" />
+      <Skeleton height={defaultVictoryHeight} width={defaultVictoryWidth} />
+    </div>
+  );
 
   if (!loading) {
     content = <div css={wrapperStyle}>{children}</div>;

--- a/packages/component-library/src/ChartContainer/ChartContainer.js
+++ b/packages/component-library/src/ChartContainer/ChartContainer.js
@@ -40,6 +40,7 @@ const ChartContainer = ({
   `;
   const fullHeight = css`
     padding-top: ${100 / aspectRatio}%;
+    height: 100%;
   `;
 
   let content = <Skeleton css={[wrapperStyle, fullHeight]} />;

--- a/packages/component-library/src/ChartContainer/ChartContainer.js
+++ b/packages/component-library/src/ChartContainer/ChartContainer.js
@@ -42,10 +42,10 @@ const ChartContainer = ({
     padding-top: ${100 / aspectRatio}%;
   `;
 
-  let content = <div css={wrapperStyle}>{children}</div>;
+  let content = <Skeleton css={[wrapperStyle, fullHeight]} />;
 
-  if (loading) {
-    content = <Skeleton css={[wrapperStyle, fullHeight]} />;
+  if (!loading) {
+    content = <div css={wrapperStyle}>{children}</div>;
   } else if (error) {
     content = <div css={[wrapperStyle, fullHeight, chartError]}>{error}</div>;
   }

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
@@ -106,6 +106,7 @@ const HorizontalBarChart = ({
       subtitle={subtitle}
       loading={loading}
       error={error}
+      aspectRatio={650 / (dataHeight + additionalHeight)}
     >
       <DataChecker dataAccessors={{ dataValue }} data={safeData}>
         {legendData &&

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
@@ -21,6 +21,7 @@ import {
 } from "../utils/chartHelpers";
 import groupByKey from "../utils/groupByKey";
 import DataChecker from "../utils/DataChecker";
+import protectData from "../utils/protectData";
 import { VictoryTheme } from "../_Themes/index";
 
 const HorizontalBarChart = ({
@@ -45,7 +46,10 @@ const HorizontalBarChart = ({
   legendComponent,
   theme
 }) => {
-  const safeData = data && data.length ? data : [{}];
+  const safeData =
+    data && data.length
+      ? protectData(data, { dataLabel, dataSeriesKey })
+      : [{}];
 
   const groupedDataIfStacked = () => {
     if (stacked) {

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
@@ -44,11 +44,15 @@ const HorizontalBarChart = ({
   dataSeriesKey,
   dataSeriesLabel,
   legendComponent,
-  theme
+  theme,
+  protect
 }) => {
   const safeData =
+    // eslint-disable-next-line no-nested-ternary
     data && data.length
-      ? protectData(data, { dataLabel, dataSeriesKey })
+      ? protect
+        ? protectData(data, { dataLabel, dataSeriesKey })
+        : data
       : [{}];
 
   const groupedDataIfStacked = () => {
@@ -294,7 +298,8 @@ HorizontalBarChart.propTypes = {
   dataSeriesKey: PropTypes.string,
   dataSeriesLabel: PropTypes.shape({}),
   legendComponent: PropTypes.func,
-  theme: PropTypes.shape({})
+  theme: PropTypes.shape({}),
+  protect: PropTypes.bool
 };
 
 HorizontalBarChart.defaultProps = {
@@ -315,7 +320,8 @@ HorizontalBarChart.defaultProps = {
   dataSeriesKey: null,
   dataSeriesLabel: {},
   legendComponent: null,
-  theme: VictoryTheme
+  theme: VictoryTheme,
+  protect: false
 };
 
 export default HorizontalBarChart;

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.js
@@ -45,24 +45,26 @@ const HorizontalBarChart = ({
   legendComponent,
   theme
 }) => {
+  const safeData = data && data.length ? data : [{}];
+
   const groupedDataIfStacked = () => {
     if (stacked) {
       if (hundredPercentData) {
         return transformDatato100(
-          groupByKey(data, dataSeriesKey, dataLabel),
+          groupByKey(safeData, dataSeriesKey, dataLabel),
           dataLabel,
           dataValue
         );
       }
-      return groupByKey(data, dataSeriesKey, dataLabel);
+      return groupByKey(safeData, dataSeriesKey, dataLabel);
     }
-    return data;
+    return safeData;
   };
   const groupedData = groupedDataIfStacked();
   const barData =
     sortOrder && sortOrder.length
-      ? data
-      : data.map((d, index) => {
+      ? safeData
+      : safeData.map((d, index) => {
           return { ...d, defaultSort: index + 1 };
         });
   const sortOrderKey =
@@ -73,13 +75,13 @@ const HorizontalBarChart = ({
   const barHeight = theme.bar.style.data.width;
   const spaceHeight = theme.bar.style.data.padding * 2;
   const additionalHeight = padding.bottom + padding.top;
-  const minValue = Math.min(0, ...data.map(d => d[dataValue]));
+  const minValue = Math.min(0, ...safeData.map(d => d[dataValue]));
 
-  const bars = stacked ? groupedData.length : data.length;
+  const bars = stacked ? groupedData.length : safeData.length;
   const spaces = bars - 1;
   const dataHeight = bars * barHeight + spaces * spaceHeight;
   const dataSeriesLabels = dataSeriesKey
-    ? dataSeriesLabel || getDefaultDataSeriesLabels(data, dataSeriesKey)
+    ? dataSeriesLabel || getDefaultDataSeriesLabels(safeData, dataSeriesKey)
     : null;
   const legendData =
     dataSeriesLabels && dataSeriesLabels.length
@@ -101,7 +103,7 @@ const HorizontalBarChart = ({
       loading={loading}
       error={error}
     >
-      <DataChecker dataAccessors={{ dataValue }} data={data}>
+      <DataChecker dataAccessors={{ dataValue }} data={safeData}>
         {legendData &&
           (legendComponent ? (
             legendComponent(legendData)

--- a/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.test.js
+++ b/packages/component-library/src/HorizontalBarChart/HorizontalBarChart.test.js
@@ -18,6 +18,21 @@ const updatedSimpleData = [
   { x: 500, y: "bat" }
 ];
 
+const simpleColorData = [
+  { x: 100, y: "black" },
+  { x: 200, y: "white" },
+  { x: 300, y: "red" },
+  { x: 400, y: "rat" }
+];
+
+const updatedSimpleColorData = [
+  { x: 100, y: "black" },
+  { x: 200, y: "white" },
+  { x: 300, y: "red" },
+  { x: 400, y: "rat" },
+  { x: 500, y: "bat" }
+];
+
 const simpleDataDomain = { x: [0, 400], y: [0, 4] };
 
 const sampleUnstructuredData = [
@@ -148,6 +163,7 @@ describe("HorizontalBarChart", () => {
     const wrapper = shallow(<HorizontalBarChart data={simpleData} />);
     const dataProp = wrapper
       .find("VictoryBar")
+
       .first()
       .prop("data");
     expect(dataProp).to.have.length(4);
@@ -166,4 +182,45 @@ describe("HorizontalBarChart", () => {
     expect(xProp).to.eql("sortOrder");
     expect(yProp).to.eql("dataValue");
   });
+
+  // Tests for https://github.com/FormidableLabs/victory/issues/928 workaround
+
+  it("renders a HorizontalBarChart correctly with sample color data **invisible whitespace warning, see protectData util**", () => {
+    const c = "‌‌​"; // U+200B (zero-width space character)
+    const wrapper = shallow(
+      <HorizontalBarChart data={simpleColorData} protect />
+    );
+    expect(wrapper.find({ title: "Horizontal Bar Chart" }).length).to.eql(1);
+    expect(wrapper.find({ title: "Horizontal Bar Chart" }).props().data).to.eql(
+      // invisible whitespace character injected in label before :
+      [
+        { sortOrder: 1, dataValue: 100, label: `black${c}: 100` },
+        { sortOrder: 2, dataValue: 200, label: `white${c}: 200` },
+        { sortOrder: 3, dataValue: 300, label: `red${c}: 300` },
+        { sortOrder: 4, dataValue: 400, label: `rat${c}: 400` }
+      ]
+    );
+  });
+
+  it("renders an updated HorizontalBarChart when passed new data **invisible whitespace warning, see protectData util**", () => {
+    const c = "‌‌​"; // U+200B (zero-width space character)
+    const wrapper = shallow(
+      <HorizontalBarChart data={simpleColorData} protect />
+    );
+    expect(wrapper.find({ title: "Horizontal Bar Chart" }).length).to.eql(1);
+    wrapper.setProps({ data: updatedSimpleColorData });
+
+    expect(wrapper.find({ title: "Horizontal Bar Chart" }).props().data).to.eql(
+      // invisible whitespace character injected in label before :
+      [
+        { sortOrder: 1, dataValue: 100, label: `black${c}: 100` },
+        { sortOrder: 2, dataValue: 200, label: `white${c}: 200` },
+        { sortOrder: 3, dataValue: 300, label: `red${c}: 300` },
+        { sortOrder: 4, dataValue: 400, label: `rat${c}: 400` },
+        { sortOrder: 5, dataValue: 500, label: `bat${c}: 500` }
+      ]
+    );
+  });
+
+  // End tests for https://github.com/FormidableLabs/victory/issues/928 workaround
 });

--- a/packages/component-library/src/LineChart/LineChart.js
+++ b/packages/component-library/src/LineChart/LineChart.js
@@ -18,6 +18,7 @@ import { VictoryTheme } from "../_Themes/index";
 import ChartContainer from "../ChartContainer";
 import SimpleLegend from "../SimpleLegend";
 import civicFormat from "../utils/civicFormat";
+import protectData from "../utils/protectData";
 import DataChecker from "../utils/DataChecker";
 import {
   chartEvents,
@@ -48,11 +49,18 @@ const LineChart = ({
   loading,
   theme
 }) => {
-  const safeData = data && data.length ? data : [{}];
+  const safeData =
+    data && data.length
+      ? protectData(data, { dataSeries, dataSeriesLabel })
+      : [{}];
+  const safeDataSeriesLabel =
+    dataSeriesLabel && dataSeriesLabel.length
+      ? protectData(dataSeriesLabel, { x: "category", y: "label" })
+      : null;
   const chartDomain = domain || getDefaultDomain(safeData, dataKey, dataValue);
 
   const dataSeriesLabels = dataSeries
-    ? dataSeriesLabel || getDefaultDataSeriesLabels(safeData, dataSeries)
+    ? safeDataSeriesLabel || getDefaultDataSeriesLabels(safeData, dataSeries)
     : null;
 
   const scatterPlotStyle =
@@ -67,6 +75,8 @@ const LineChart = ({
     ? groupBy(safeData, dataSeries)
     : { category: safeData };
 
+  // TODO: if you have line data with categories that don't have the same length,
+  // then the below won't work.
   const lines = lineData
     ? Object.keys(lineData).map((category, index) => (
         <VictoryLine

--- a/packages/component-library/src/LineChart/LineChart.js
+++ b/packages/component-library/src/LineChart/LineChart.js
@@ -45,12 +45,14 @@ const LineChart = ({
   xNumberFormatter,
   yNumberFormatter,
   legendComponent,
+  loading,
   theme
 }) => {
-  const chartDomain = domain || getDefaultDomain(data, dataKey, dataValue);
+  const safeData = data && data.length ? data : [{}];
+  const chartDomain = domain || getDefaultDomain(safeData, dataKey, dataValue);
 
   const dataSeriesLabels = dataSeries
-    ? dataSeriesLabel || getDefaultDataSeriesLabels(data, dataSeries)
+    ? dataSeriesLabel || getDefaultDataSeriesLabels(safeData, dataSeries)
     : null;
 
   const scatterPlotStyle =
@@ -61,7 +63,9 @@ const LineChart = ({
       ? dataSeriesLabels.map(series => ({ name: series.label }))
       : null;
 
-  const lineData = dataSeries ? groupBy(data, dataSeries) : { category: data };
+  const lineData = dataSeries
+    ? groupBy(safeData, dataSeries)
+    : { category: safeData };
 
   const lines = lineData
     ? Object.keys(lineData).map((category, index) => (
@@ -87,8 +91,8 @@ const LineChart = ({
 
   return (
     <ThemeProvider theme={theme}>
-      <ChartContainer title={title} subtitle={subtitle}>
-        <DataChecker dataAccessors={{ dataKey, dataValue }} data={data}>
+      <ChartContainer title={title} subtitle={subtitle} loading={loading}>
+        <DataChecker dataAccessors={{ dataKey, dataValue }} data={safeData}>
           {legendData &&
             (legendComponent ? (
               legendComponent(legendData, theme)
@@ -140,7 +144,7 @@ const LineChart = ({
             {lines}
             <VictoryScatter
               //        categories={{ x: categoryData }}
-              data={data.map(d => ({
+              data={safeData.map(d => ({
                 dataKey: d[dataKey],
                 dataValue: d[dataValue],
                 label: `${dataKeyLabel || xLabel}: ${xNumberFormatter(
@@ -200,7 +204,8 @@ LineChart.propTypes = {
   xNumberFormatter: PropTypes.func,
   yNumberFormatter: PropTypes.func,
   legendComponent: PropTypes.func,
-  theme: PropTypes.shape({})
+  theme: PropTypes.shape({}),
+  loading: PropTypes.bool
 };
 
 LineChart.defaultProps = {
@@ -221,7 +226,8 @@ LineChart.defaultProps = {
   xNumberFormatter: civicFormat.numeric,
   yNumberFormatter: civicFormat.numeric,
   legendComponent: null,
-  theme: VictoryTheme
+  theme: VictoryTheme,
+  loading: null
 };
 
 export default LineChart;

--- a/packages/component-library/src/LineChart/LineChart.js
+++ b/packages/component-library/src/LineChart/LineChart.js
@@ -87,6 +87,7 @@ const LineChart = ({
   const lines = lineData
     ? Object.keys(lineData).map((category, index) => (
         <VictoryLine
+          title="Line Chart"
           key={shortid.generate()}
           data={lineData[category].map(d => ({
             dataKey: d[dataKey],

--- a/packages/component-library/src/LineChart/LineChart.js
+++ b/packages/component-library/src/LineChart/LineChart.js
@@ -47,15 +47,22 @@ const LineChart = ({
   yNumberFormatter,
   legendComponent,
   loading,
-  theme
+  theme,
+  protect
 }) => {
   const safeData =
+    // eslint-disable-next-line no-nested-ternary
     data && data.length
-      ? protectData(data, { dataSeries, dataSeriesLabel })
+      ? protect
+        ? protectData(data, { dataSeries, dataSeriesLabel })
+        : data
       : [{}];
   const safeDataSeriesLabel =
+    // eslint-disable-next-line no-nested-ternary
     dataSeriesLabel && dataSeriesLabel.length
-      ? protectData(dataSeriesLabel, { x: "category", y: "label" })
+      ? protect
+        ? protectData(dataSeriesLabel, { x: "category", y: "label" })
+        : dataSeriesLabel
       : null;
   const chartDomain = domain || getDefaultDomain(safeData, dataKey, dataValue);
 
@@ -215,7 +222,8 @@ LineChart.propTypes = {
   yNumberFormatter: PropTypes.func,
   legendComponent: PropTypes.func,
   theme: PropTypes.shape({}),
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  protect: PropTypes.bool
 };
 
 LineChart.defaultProps = {
@@ -237,7 +245,8 @@ LineChart.defaultProps = {
   yNumberFormatter: civicFormat.numeric,
   legendComponent: null,
   theme: VictoryTheme,
-  loading: null
+  loading: null,
+  protect: false
 };
 
 export default LineChart;

--- a/packages/component-library/src/LineChart/LineChart.test.js
+++ b/packages/component-library/src/LineChart/LineChart.test.js
@@ -4,22 +4,145 @@ import { shallow } from "enzyme";
 import LineChart from "./LineChart";
 
 describe("LineChart", () => {
-  const data = [
-    { year: 2015, population: 1 },
-    { year: 2016, population: 2 },
-    { year: 2017, population: 3 }
+  const simpleData = [{ x: 100, y: 10 }, { x: 200, y: 20 }];
+
+  const updatedSimpleData = [
+    { x: 100, y: 10 },
+    { x: 200, y: 20 },
+    { x: 300, y: 30 }
   ];
 
-  const defaultProps = {
-    data,
-    dataKey: "year",
-    dataValue: "population"
-  };
+  const simpleCategoryData = [
+    { x: 100, y: 10, category: "cat" },
+    { x: 200, y: 20, category: "cat" },
+    { x: 100, y: 20, category: "dog" },
+    { x: 200, y: 10, category: "dog" }
+  ];
+
+  const updatedSimpleCategoryData = [
+    { x: 200, y: 20, category: "cat" },
+    { x: 300, y: 30, category: "cat" },
+    { x: 100, y: 20, category: "dog" },
+    { x: 200, y: 10, category: "dog" },
+    { x: 100, y: 10, category: "fish" },
+    { x: 300, y: 25, category: "fish" }
+  ];
+
+  const simpleColorData = [
+    { x: 100, y: 10, category: "black" },
+    { x: 200, y: 20, category: "black" },
+    { x: 100, y: 20, category: "white" },
+    { x: 200, y: 10, category: "white" }
+  ];
+
+  const updatedSimpleColorData = [
+    { x: 200, y: 20, category: "black" },
+    { x: 300, y: 30, category: "black" },
+    { x: 100, y: 20, category: "white" },
+    { x: 200, y: 10, category: "white" },
+    { x: 100, y: 10, category: "fish" },
+    { x: 300, y: 25, category: "fish" }
+  ];
 
   it("should render a VictoryChart", () => {
-    const wrapper = shallow(<LineChart {...defaultProps} />);
+    const wrapper = shallow(<LineChart data={simpleData} />);
 
     expect(wrapper.find("VictoryChart").length).to.eql(1);
+  });
+
+  it("renders a LineChart with sample data", () => {
+    const wrapper = shallow(<LineChart data={simpleData} />);
+    expect(wrapper.find({ title: "Line Chart" }).length).to.eql(1);
+    expect(wrapper.find({ title: "Line Chart" }).props().data).to.eql([
+      { dataKey: 100, dataValue: 10, series: undefined },
+      { dataKey: 200, dataValue: 20, series: undefined }
+    ]);
+  });
+
+  it("renders an updated LineChart when passed new data", () => {
+    const wrapper = shallow(<LineChart data={simpleData} />);
+    expect(wrapper.find({ title: "Line Chart" }).length).to.eql(1);
+    wrapper.setProps({ data: updatedSimpleData });
+
+    expect(wrapper.find({ title: "Line Chart" }).props().data).to.eql([
+      { dataKey: 100, dataValue: 10, series: undefined },
+      { dataKey: 200, dataValue: 20, series: undefined },
+      { dataKey: 300, dataValue: 30, series: undefined }
+    ]);
+  });
+
+  it("renders a LineChart with sample category data", () => {
+    const wrapper = shallow(
+      <LineChart data={simpleCategoryData} dataSeries="category" />
+    );
+    expect(wrapper.find({ title: "Line Chart" }).length).to.eql(2);
+    expect(
+      wrapper
+        .find({ title: "Line Chart" })
+        .first()
+        .props().data
+    ).to.eql([
+      { dataKey: 100, dataValue: 10, series: "cat" },
+      { dataKey: 200, dataValue: 20, series: "cat" }
+    ]);
+  });
+
+  it("renders an updated LineChart when passed new category data", () => {
+    const wrapper = shallow(
+      <LineChart data={simpleCategoryData} dataSeries="category" />
+    );
+    expect(wrapper.find({ title: "Line Chart" }).length).to.eql(2);
+    wrapper.setProps({ data: updatedSimpleCategoryData });
+    expect(wrapper.find({ title: "Line Chart" }).length).to.eql(3);
+
+    expect(
+      wrapper
+        .find({ title: "Line Chart" })
+        .first()
+        .props().data
+    ).to.eql([
+      { dataKey: 200, dataValue: 20, series: "cat" },
+      { dataKey: 300, dataValue: 30, series: "cat" }
+    ]);
+  });
+
+  // Tests for https://github.com/FormidableLabs/victory/issues/928 workaround
+
+  it("renders a LineChart with sample color category data", () => {
+    const c = "‌‌​"; // U+200B (zero-width space character)
+    const wrapper = shallow(
+      <LineChart data={simpleColorData} dataSeries="category" protect />
+    );
+    expect(wrapper.find({ title: "Line Chart" }).length).to.eql(2);
+    expect(
+      wrapper
+        .find({ title: "Line Chart" })
+        .first()
+        .props().data
+    ).to.eql([
+      { dataKey: 100, dataValue: 10, series: `black${c}` },
+      { dataKey: 200, dataValue: 20, series: `black${c}` }
+    ]);
+  });
+
+  it("renders an updated LineChart when passed new color category data", () => {
+    const c = "‌‌​"; // U+200B (zero-width space character)
+    const wrapper = shallow(
+      <LineChart data={simpleColorData} dataSeries="category" protect />
+    );
+    expect(wrapper.find({ title: "Line Chart" }).length).to.eql(2);
+    wrapper.setProps({ data: updatedSimpleColorData });
+    expect(wrapper.find({ title: "Line Chart" }).length).to.eql(3);
+
+    expect(
+      wrapper
+        .find({ title: "Line Chart" })
+        .first()
+        .props().data
+    ).to.eql([
+      { dataKey: 200, dataValue: 20, series: `black${c}` },
+      { dataKey: 300, dataValue: 30, series: `black${c}` }
+    ]);
   });
   /* TODO: rewrite these tests
   it('should render the relevant axis', () => {

--- a/packages/component-library/src/PieChart/PieChart.js
+++ b/packages/component-library/src/PieChart/PieChart.js
@@ -24,12 +24,14 @@ const PieChart = props => {
     theme
   } = props;
 
+  const safeData = data && data.length ? data : [{}];
   const startAngle = halfDoughnut ? -90 : 0;
   const endAngle = halfDoughnut ? 90 : 360;
   const adjustedHeight = halfDoughnut ? height / 2 : height;
-  const legendLabels = data.map(value => ({ name: value[dataLabel] }));
+  const legendLabels = safeData.map(value => ({ name: value[dataLabel] }));
   const legendProps = {};
   const colorScale = colors.length ? colors : theme.group.colorScale;
+  const aspectRatio = halfDoughnut ? 650 / 175 : 650 / 350;
 
   if (useLegend) {
     legendProps.labels = () => null;
@@ -42,8 +44,9 @@ const PieChart = props => {
       subtitle={subtitle}
       loading={loading}
       error={error}
+      aspectRatio={aspectRatio}
     >
-      <DataChecker dataAccessors={{ dataValue }} data={data}>
+      <DataChecker dataAccessors={{ dataValue }} data={safeData}>
         {useLegend && (
           <SimpleLegend
             className="legend"
@@ -54,7 +57,7 @@ const PieChart = props => {
         <VictoryPie
           width={width}
           height={height}
-          data={data}
+          data={safeData}
           innerRadius={innerRadius}
           colorScale={colorScale}
           theme={theme}

--- a/packages/component-library/src/Scatterplot/Scatterplot.js
+++ b/packages/component-library/src/Scatterplot/Scatterplot.js
@@ -60,15 +60,22 @@ const Scatterplot = ({
   invertY,
   legendComponent,
   theme,
-  loading
+  loading,
+  protect
 }) => {
   const safeData =
+    // eslint-disable-next-line no-nested-ternary
     data && data.length
-      ? protectData(data, { dataSeries, dataSeriesLabel })
+      ? protect
+        ? protectData(data, { dataSeries, dataSeriesLabel })
+        : data
       : [{}];
   const safeDataSeriesLabel =
+    // eslint-disable-next-line no-nested-ternary
     dataSeriesLabel && dataSeriesLabel.length
-      ? protectData(dataSeriesLabel, { x: "category", y: "label" })
+      ? protect
+        ? protectData(dataSeriesLabel, { x: "category", y: "label" })
+        : dataSeriesLabel
       : null;
   const chartDomain = domain || getDefaultDomain(safeData, dataKey, dataValue);
 
@@ -210,7 +217,8 @@ Scatterplot.propTypes = {
   invertY: PropTypes.bool,
   legendComponent: PropTypes.func,
   theme: PropTypes.shape({}),
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  protect: PropTypes.bool
 };
 
 Scatterplot.defaultProps = {
@@ -234,7 +242,8 @@ Scatterplot.defaultProps = {
   invertY: false,
   legendComponent: null,
   theme: VictoryTheme,
-  loading: null
+  loading: null,
+  protect: false
 };
 
 export default Scatterplot;

--- a/packages/component-library/src/Scatterplot/Scatterplot.js
+++ b/packages/component-library/src/Scatterplot/Scatterplot.js
@@ -58,12 +58,14 @@ const Scatterplot = ({
   invertX,
   invertY,
   legendComponent,
-  theme
+  theme,
+  loading
 }) => {
-  const chartDomain = domain || getDefaultDomain(data, dataKey, dataValue);
+  const safeData = data && data.length ? data : [{}];
+  const chartDomain = domain || getDefaultDomain(safeData, dataKey, dataValue);
 
   const dataSeriesLabels = dataSeries
-    ? dataSeriesLabel || getDefaultDataSeriesLabels(data, dataSeries)
+    ? dataSeriesLabel || getDefaultDataSeriesLabels(safeData, dataSeries)
     : null;
 
   const scatterPlotStyle =
@@ -75,7 +77,7 @@ const Scatterplot = ({
       : null;
 
   return (
-    <ChartContainer title={title} subtitle={subtitle}>
+    <ChartContainer title={title} subtitle={subtitle} loading={loading}>
       {legendData &&
         (legendComponent ? (
           legendComponent(legendData, theme)
@@ -86,7 +88,7 @@ const Scatterplot = ({
             theme={theme}
           />
         ))}
-      <DataChecker dataAccessors={{ dataKey, dataValue }} data={data}>
+      <DataChecker dataAccessors={{ dataKey, dataValue }} data={safeData}>
         <VictoryChart
           domain={chartDomain}
           theme={theme}
@@ -134,7 +136,7 @@ const Scatterplot = ({
             minBubbleSize={size && size.minSize}
             maxBubbleSize={size && size.maxSize}
             //        categories={{ x: categoryData }}
-            data={data.map(d => ({
+            data={safeData.map(d => ({
               dataKey: d[dataKey],
               dataValue: d[dataValue],
               label: `${
@@ -199,7 +201,8 @@ Scatterplot.propTypes = {
   invertX: PropTypes.bool,
   invertY: PropTypes.bool,
   legendComponent: PropTypes.func,
-  theme: PropTypes.shape({})
+  theme: PropTypes.shape({}),
+  loading: PropTypes.bool
 };
 
 Scatterplot.defaultProps = {
@@ -222,7 +225,8 @@ Scatterplot.defaultProps = {
   invertX: false,
   invertY: false,
   legendComponent: null,
-  theme: VictoryTheme
+  theme: VictoryTheme,
+  loading: null
 };
 
 export default Scatterplot;

--- a/packages/component-library/src/Scatterplot/Scatterplot.js
+++ b/packages/component-library/src/Scatterplot/Scatterplot.js
@@ -12,6 +12,7 @@ import {
 import ChartContainer from "../ChartContainer";
 import SimpleLegend from "../SimpleLegend";
 import civicFormat from "../utils/civicFormat";
+import protectData from "../utils/protectData";
 import DataChecker from "../utils/DataChecker";
 import {
   chartEvents,
@@ -61,11 +62,18 @@ const Scatterplot = ({
   theme,
   loading
 }) => {
-  const safeData = data && data.length ? data : [{}];
+  const safeData =
+    data && data.length
+      ? protectData(data, { dataSeries, dataSeriesLabel })
+      : [{}];
+  const safeDataSeriesLabel =
+    dataSeriesLabel && dataSeriesLabel.length
+      ? protectData(dataSeriesLabel, { x: "category", y: "label" })
+      : null;
   const chartDomain = domain || getDefaultDomain(safeData, dataKey, dataValue);
 
   const dataSeriesLabels = dataSeries
-    ? dataSeriesLabel || getDefaultDataSeriesLabels(safeData, dataSeries)
+    ? safeDataSeriesLabel || getDefaultDataSeriesLabels(safeData, dataSeries)
     : null;
 
   const scatterPlotStyle =

--- a/packages/component-library/src/Scatterplot/Scatterplot.test.js
+++ b/packages/component-library/src/Scatterplot/Scatterplot.test.js
@@ -35,6 +35,20 @@ const unstructuredMultiSeriesData = [
   { amount: 200, rate: 3, type: "second" }
 ];
 
+const multiSeriesColorData = [
+  { amount: 100, rate: 1, series: "black" },
+  { amount: 200, rate: 2, series: "black" },
+  { amount: 100, rate: 3, series: "white" },
+  { amount: 200, rate: 3, series: "white" }
+];
+
+const unstructuredMultiSeriesColorData = [
+  { amount: 100, rate: 1, type: "black" },
+  { amount: 200, rate: 2, type: "black" },
+  { amount: 100, rate: 3, type: "white" },
+  { amount: 200, rate: 3, type: "white" }
+];
+
 describe("Scatterplot", () => {
   it("renders a VictoryChart", () => {
     const wrapper = shallow(<Scatterplot data={simpleData} />);
@@ -159,6 +173,85 @@ describe("Scatterplot", () => {
       { name: "second" }
     ]);
   });
+
+  // Tests for https://github.com/FormidableLabs/victory/issues/928 workaround
+  it("renders multi-series color data", () => {
+    const c = "‌‌​"; // U+200B (zero-width space character)
+    const props = {
+      data: multiSeriesColorData,
+      dataKey: "amount",
+      dataValue: "rate",
+      dataSeries: "series",
+      protect: true
+    };
+    const wrapper = shallow(<Scatterplot {...props} />);
+    expect(wrapper.find({ title: "Scatter Plot" }).props().data).to.eql([
+      {
+        dataKey: 100,
+        dataValue: 1,
+        label: "X: 100 • Y: 1",
+        series: `black${c}`
+      },
+      {
+        dataKey: 200,
+        dataValue: 2,
+        label: "X: 200 • Y: 2",
+        series: `black${c}`
+      },
+      {
+        dataKey: 100,
+        dataValue: 3,
+        label: "X: 100 • Y: 3",
+        series: `white${c}`
+      },
+      {
+        dataKey: 200,
+        dataValue: 3,
+        label: "X: 200 • Y: 3",
+        series: `white${c}`
+      }
+    ]);
+  });
+
+  it("renders unstructured multi-series color data", () => {
+    const c = "‌‌​"; // U+200B (zero-width space character)
+    const props = {
+      data: unstructuredMultiSeriesColorData,
+      dataKey: "amount",
+      dataValue: "rate",
+      dataSeries: "type",
+      protect: true
+    };
+    const wrapper = shallow(<Scatterplot {...props} />);
+    expect(wrapper.find({ title: "Scatter Plot" }).props().data).to.eql([
+      {
+        dataKey: 100,
+        dataValue: 1,
+        label: "X: 100 • Y: 1",
+        series: `black${c}`
+      },
+      {
+        dataKey: 200,
+        dataValue: 2,
+        label: "X: 200 • Y: 2",
+        series: `black${c}`
+      },
+      {
+        dataKey: 100,
+        dataValue: 3,
+        label: "X: 100 • Y: 3",
+        series: `white${c}`
+      },
+      {
+        dataKey: 200,
+        dataValue: 3,
+        label: "X: 200 • Y: 3",
+        series: `white${c}`
+      }
+    ]);
+  });
+
+  // End tests for https://github.com/FormidableLabs/victory/issues/928 workaround
 
   // TODO: make this test pass
 

--- a/packages/component-library/src/StackedAreaChart/StackedAreaChart.js
+++ b/packages/component-library/src/StackedAreaChart/StackedAreaChart.js
@@ -44,13 +44,15 @@ const StackedAreaChart = ({
   xNumberFormatter,
   yNumberFormatter,
   legendComponent,
-  theme
+  theme,
+  loading
 }) => {
+  const safeData = data && data.length ? data : [{}];
   const chartDomain =
-    domain || getDefaultStackedDomain(data, dataKey, dataValue);
+    domain || getDefaultStackedDomain(safeData, dataKey, dataValue);
 
   const dataSeriesLabels = dataSeries
-    ? dataSeriesLabel || getDefaultDataSeriesLabels(data, dataSeries)
+    ? dataSeriesLabel || getDefaultDataSeriesLabels(safeData, dataSeries)
     : null;
 
   const scatterPlotStyle = style || {
@@ -62,7 +64,9 @@ const StackedAreaChart = ({
       ? dataSeriesLabels.map(series => ({ name: series.label }))
       : null;
 
-  const lineData = dataSeries ? groupBy(data, dataSeries) : { category: data };
+  const lineData = dataSeries
+    ? groupBy(safeData, dataSeries)
+    : { category: safeData };
 
   const areas = lineData
     ? Object.keys(lineData).map((category, index) => (
@@ -120,8 +124,8 @@ const StackedAreaChart = ({
     : null;
 
   return (
-    <ChartContainer title={title} subtitle={subtitle}>
-      <DataChecker dataAccessors={{ dataKey, dataValue }} data={data}>
+    <ChartContainer title={title} subtitle={subtitle} loading={loading}>
+      <DataChecker dataAccessors={{ dataKey, dataValue }} data={safeData}>
         {legendData &&
           (legendComponent ? (
             legendComponent(legendData, theme)
@@ -203,7 +207,8 @@ StackedAreaChart.propTypes = {
   xNumberFormatter: PropTypes.func,
   yNumberFormatter: PropTypes.func,
   legendComponent: PropTypes.func,
-  theme: PropTypes.shape({})
+  theme: PropTypes.shape({}),
+  loading: PropTypes.bool
 };
 
 StackedAreaChart.defaultProps = {
@@ -224,7 +229,8 @@ StackedAreaChart.defaultProps = {
   xNumberFormatter: civicFormat.numeric,
   yNumberFormatter: civicFormat.numeric,
   legendComponent: null,
-  theme: VictoryTheme
+  theme: VictoryTheme,
+  loading: null
 };
 
 export default StackedAreaChart;

--- a/packages/component-library/src/utils.js
+++ b/packages/component-library/src/utils.js
@@ -1,2 +1,3 @@
 export { default as civicFormat } from "./utils/civicFormat";
 export { default as ungroupBy } from "./utils/ungroupBy";
+export { default as protectData } from "./utils/protectData";

--- a/packages/component-library/src/utils/protectData.js
+++ b/packages/component-library/src/utils/protectData.js
@@ -1,3 +1,5 @@
+import { fromPairs } from "lodash";
+
 const c = "‌‌​"; // U+200B (zero-width space character)
 
 /**
@@ -13,7 +15,7 @@ function protectData(data, dataAccessors) {
   return data.map(d => {
     return {
       ...d,
-      ...Object.fromEntries(
+      ...fromPairs(
         Object.values(dataAccessors).map(property => {
           return [property, `${d[property]}${c}`];
         })

--- a/packages/component-library/src/utils/protectData.js
+++ b/packages/component-library/src/utils/protectData.js
@@ -1,0 +1,25 @@
+const c = "‌‌​"; // U+200B (zero-width space character)
+
+/**
+ * This function protects data attributes from being accessed by d3-interpolate
+ * to work around https://github.com/FormidableLabs/victory/issues/928
+ *
+ * @param {array} data - An array of data objects
+ * @param {object} dataAccessors - An object with { dataKey, dataValue, etc ..}
+ * @return {array} An array with each element transformed for each dataAcccessor to add a zero-width space character
+ */
+
+function protectData(data, dataAccessors) {
+  return data.map(d => {
+    return {
+      ...d,
+      ...Object.fromEntries(
+        Object.values(dataAccessors).map(property => {
+          return [property, `${d[property]}${c}`];
+        })
+      )
+    };
+  });
+}
+
+export default protectData;

--- a/packages/component-library/stories/HorizontalBarChart.story.js
+++ b/packages/component-library/stories/HorizontalBarChart.story.js
@@ -118,6 +118,7 @@ export default () =>
           { display: "select" },
           GROUP_IDS.CUSTOM
         );
+        const loading = boolean("Loading", false, GROUP_IDS.CUSTOM);
 
         return (
           <HorizontalBarChart
@@ -133,6 +134,7 @@ export default () =>
             dataValueFormatter={x => civicFormat[optionSelectX](x)}
             minimalist={minimalist}
             theme={(name => themes[name])(theme)}
+            loading={loading}
           />
         );
       },

--- a/packages/component-library/stories/LineChart.story.js
+++ b/packages/component-library/stories/LineChart.story.js
@@ -7,7 +7,8 @@ import {
   text,
   number,
   withKnobs,
-  optionsKnob as options
+  optionsKnob as options,
+  boolean
 } from "@storybook/addon-knobs";
 import {
   LineChart,
@@ -250,6 +251,7 @@ export default () =>
           { display: "select" },
           GROUP_IDS.CUSTOM
         );
+        const loading = boolean("Loading", false, GROUP_IDS.CUSTOM);
 
         return (
           <LineChart
@@ -270,6 +272,7 @@ export default () =>
             yNumberFormatter={y => civicFormat[optionSelectY](y)}
             legendComponent={customLegend}
             theme={(name => themes[name])(theme)}
+            loading={loading}
           />
         );
       },

--- a/packages/component-library/stories/PieChart.story.js
+++ b/packages/component-library/stories/PieChart.story.js
@@ -85,6 +85,7 @@ export default () =>
         const chartHeight = number("Chart height", 350, {}, GROUP_IDS.CUSTOM);
         const chartWidth = number("Chart width", 650, {}, GROUP_IDS.CUSTOM);
         const innerRadius = number("Inner radius", 50, {}, GROUP_IDS.CUSTOM);
+        const loading = boolean("Loading", false, GROUP_IDS.CUSTOM);
         const themes = {
           VictoryTheme,
           VictoryCrazyTheme
@@ -112,6 +113,7 @@ export default () =>
             halfDoughnut={halfDoughnut}
             useLegend={useLegend}
             theme={(name => themes[name])(theme)}
+            loading={loading}
           />
         );
       },

--- a/packages/component-library/stories/Scatterplot.story.js
+++ b/packages/component-library/stories/Scatterplot.story.js
@@ -273,6 +273,7 @@ export default () =>
           { display: "select" },
           GROUP_IDS.CUSTOM
         );
+        const loading = boolean("Loading", false, GROUP_IDS.CUSTOM);
 
         return (
           <Scatterplot
@@ -293,6 +294,7 @@ export default () =>
             invertY={invertY}
             legendComponent={customLegend}
             theme={(name => themes[name])(theme)}
+            loading={loading}
           />
         );
       },

--- a/packages/component-library/stories/StackedAreaChart.story.js
+++ b/packages/component-library/stories/StackedAreaChart.story.js
@@ -7,7 +7,8 @@ import {
   object,
   text,
   withKnobs,
-  optionsKnob as options
+  optionsKnob as options,
+  boolean
 } from "@storybook/addon-knobs";
 import { StackedAreaChart, civicFormat, SimpleLegend } from "../src";
 import { getKeyNames } from "./shared";
@@ -273,6 +274,7 @@ export default () =>
           { display: "select" },
           GROUP_IDS.CUSTOM
         );
+        const loading = boolean("Loading", false, GROUP_IDS.CUSTOM);
 
         return (
           <StackedAreaChart
@@ -290,6 +292,7 @@ export default () =>
             yNumberFormatter={y => civicFormat[optionSelectY](y)}
             legendComponent={customLegend}
             theme={(name => themes[name])(theme)}
+            loading={loading}
           />
         );
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2214,6 +2214,17 @@
     react-transition-group "^4.0.0"
     warning "^4.0.1"
 
+"@material-ui/lab@^4.0.0-alpha.24":
+  version "4.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.24.tgz#e8250c81ac0eb30c5f7bb81f5c4f471c2cb276bb"
+  integrity sha512-WpPr3Z+bs8cjfJgEBwH3f+iv80UlwI1O7AbefqvYGA4N7lW0w0rjg4jdSbR7bHI2g2eYgrTj8n1X5RG/si1uDQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.1.0"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    warning "^4.0.3"
+
 "@material-ui/styles@^4.3.3":
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.3.3.tgz#39867dd6f3779a8326075e097d72208d3c5b4977"
@@ -5071,7 +5082,7 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
-clsx@^1.0.2:
+clsx@^1.0.2, clsx@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.0.4.tgz#0c0171f6d5cb2fe83848463c15fcc26b4df8c2ec"
   integrity sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==
@@ -5801,6 +5812,11 @@ d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
 d3-array@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
+
+d3-array@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.3.1.tgz#145cb03967578e675db8c62e41f3c406fa7acc73"
+  integrity sha512-YlOh8kwqIz0pDECEdCeqVNelaLQXznD0g6yidhhklMgKxKqbNDrYfoudLMkk9THlqvFll+pXMmXYAyN49yWsmg==
 
 d3-axis@1:
   version "1.0.12"
@@ -16389,7 +16405,7 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^4.0.1, warning@^4.0.2:
+warning@^4.0.1, warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2214,17 +2214,6 @@
     react-transition-group "^4.0.0"
     warning "^4.0.1"
 
-"@material-ui/lab@^4.0.0-alpha.24":
-  version "4.0.0-alpha.24"
-  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.24.tgz#e8250c81ac0eb30c5f7bb81f5c4f471c2cb276bb"
-  integrity sha512-WpPr3Z+bs8cjfJgEBwH3f+iv80UlwI1O7AbefqvYGA4N7lW0w0rjg4jdSbR7bHI2g2eYgrTj8n1X5RG/si1uDQ==
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@material-ui/utils" "^4.1.0"
-    clsx "^1.0.4"
-    prop-types "^15.7.2"
-    warning "^4.0.3"
-
 "@material-ui/styles@^4.3.3":
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.3.3.tgz#39867dd6f3779a8326075e097d72208d3c5b4977"
@@ -5082,7 +5071,7 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
-clsx@^1.0.2, clsx@^1.0.4:
+clsx@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.0.4.tgz#0c0171f6d5cb2fe83848463c15fcc26b4df8c2ec"
   integrity sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==
@@ -16405,7 +16394,7 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^4.0.1, warning@^4.0.2, warning@^4.0.3:
+warning@^4.0.1, warning@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   dependencies:


### PR DESCRIPTION
Resolves #857.

This adds a loading skeleton to charts.

Prior to this PR, charts did not have a height before they were loaded, so it caused a page reflow.

| Before  | After |
| ------------- | ------------- |
| ![Screen Recording 2019-08-28 at 2 25 55 AM](https://user-images.githubusercontent.com/7065695/63843581-7124c780-c93b-11e9-9b32-849e2fcfe543.gif)  | ![Screen Recording 2019-08-28 at 2 22 22 AM](https://user-images.githubusercontent.com/7065695/63843582-7124c780-c93b-11e9-8503-abc638588574.gif)  |
 
That said, there's a number of things on this PR that I'm not especially confident in.

- This adds a dependency on @material-ui/labs, as the Skeleton component is not yet in the @material-ui/core. Rather than add a dependency, should we just implement this as an individual component?
- Should the Skeleton be its own component? Or is it ok to just have it be implemented in ChartWrapper?
- I added a check for `safeData` to avoid having the charts throw errors if `data` is null and `isLoading` is true, but it smells fishy to me.

