### PR TITLE
Include all Material UI components used in Radio Button Group component

### DIFF
--- a/packages/component-library/src/RadioButtonGroup/RadioButtonGroup.js
+++ b/packages/component-library/src/RadioButtonGroup/RadioButtonGroup.js
@@ -2,7 +2,12 @@
 import { jsx, css } from "@emotion/core";
 import PropTypes from "prop-types";
 import shortid from "shortid";
-import { FormControlLabel, FormLabel } from "@material-ui/core";
+import {
+  FormControlLabel,
+  FormLabel,
+  FormControl,
+  FormHelperText
+} from "@material-ui/core";
 import MaterialRadio from "@material-ui/core/Radio";
 import MaterialRadioGroup from "@material-ui/core/RadioGroup";
 
@@ -17,33 +22,36 @@ const RadioButtonGroup = ({
   value,
   grpLabel,
   labelPlacement,
-  row
+  row,
+  formHelperText
 }) => (
-  <MaterialRadioGroup
-    aria-label={grpLabel}
-    name={grpLabel}
-    onChange={onChange}
-    value={value}
-    row={row}
-    inputProps={{ "aria-labelledby": { grpLabel } }}
-  >
+  <FormControl disabled={disabled}>
     <FormLabel>{grpLabel}</FormLabel>
-    {labels.map(label => (
-      <FormControlLabel
-        key={shortid.generate()}
-        value={label}
-        control={
-          <MaterialRadio
-            disabled={disabled}
-            css={radioButtonGroupClass}
-            inputProps={{ "aria-label": { label } }}
-          />
-        }
-        label={label}
-        labelPlacement={labelPlacement}
-      />
-    ))}
-  </MaterialRadioGroup>
+    <MaterialRadioGroup
+      aria-label={grpLabel}
+      name={grpLabel}
+      onChange={onChange}
+      value={value}
+      row={row}
+      inputProps={{ "aria-labelledby": { grpLabel } }}
+    >
+      {labels.map(label => (
+        <FormControlLabel
+          key={shortid.generate()}
+          value={label}
+          control={
+            <MaterialRadio
+              css={radioButtonGroupClass}
+              inputProps={{ "aria-label": { label } }}
+            />
+          }
+          label={label}
+          labelPlacement={labelPlacement}
+        />
+      ))}
+    </MaterialRadioGroup>
+    <FormHelperText>{formHelperText}</FormHelperText>
+  </FormControl>
 );
 
 RadioButtonGroup.displayName = "RadioButtonGroup";
@@ -53,6 +61,7 @@ RadioButtonGroup.propTypes = {
   value: PropTypes.string,
   grpLabel: PropTypes.string,
   labelPlacement: PropTypes.string,
+  formHelperText: PropTypes.string,
   row: PropTypes.bool,
   disabled: PropTypes.bool,
   onChange: PropTypes.func
@@ -63,6 +72,7 @@ RadioButtonGroup.defaultProps = {
   value: "Label 1",
   grpLabel: "GroupLabel",
   labelPlacement: "end",
+  formHelperText: "Helper text",
   row: false,
   disabled: false
 };

--- a/packages/component-library/src/RadioButtonGroup/RadioButtonGroup.js
+++ b/packages/component-library/src/RadioButtonGroup/RadioButtonGroup.js
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { jsx, css } from "@emotion/core";
 import PropTypes from "prop-types";
 import FormLabel from "@material-ui/core/FormLabel";

--- a/packages/component-library/src/RadioButtonGroup/RadioButtonGroup.js
+++ b/packages/component-library/src/RadioButtonGroup/RadioButtonGroup.js
@@ -1,9 +1,8 @@
 /** @jsx jsx */
 import { jsx, css } from "@emotion/core";
 import PropTypes from "prop-types";
-import FormLabel from "@material-ui/core/FormLabel";
 import shortid from "shortid";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
+import { FormControlLabel, FormLabel } from "@material-ui/core";
 import MaterialRadio from "@material-ui/core/Radio";
 import MaterialRadioGroup from "@material-ui/core/RadioGroup";
 

--- a/packages/component-library/stories/RadioButtonGroup.story.js
+++ b/packages/component-library/stories/RadioButtonGroup.story.js
@@ -13,8 +13,7 @@ import {
   select,
   array
 } from "@storybook/addon-knobs";
-import FormControl from "@material-ui/core/FormControl";
-import FormHelperText from "@material-ui/core/FormHelperText";
+import { FormControl, FormHelperText } from "@material-ui/core";
 import { RadioButtonGroup } from "../src";
 import { storybookStyles } from "./storyStyles";
 import StatefulWrapper from "../src/utils/StatefulWrapper";

--- a/packages/component-library/stories/RadioButtonGroup.story.js
+++ b/packages/component-library/stories/RadioButtonGroup.story.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react";
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -13,7 +13,6 @@ import {
   select,
   array
 } from "@storybook/addon-knobs";
-import { FormControl, FormHelperText } from "@material-ui/core";
 import { RadioButtonGroup } from "../src";
 import { storybookStyles } from "./storyStyles";
 import StatefulWrapper from "../src/utils/StatefulWrapper";
@@ -56,6 +55,7 @@ export default () =>
                   }}
                   value={get("value")}
                   disabled={disabled}
+                  formHelperText=""
                 />
               );
             }}
@@ -70,6 +70,11 @@ export default () =>
         const grpLabel = text("Group label", "Year", GROUP_IDS.LABELS);
         const radioLabels = ["2016", "2017", "2018"];
         const labels = array("Labels", radioLabels, ", ", GROUP_IDS.LABELS);
+        const formHelperText = text(
+          "Helper text",
+          "* Show results for this year",
+          GROUP_IDS.LABELS
+        );
         const disabled = boolean("Disabled", false, GROUP_IDS.STATE);
         const options = {
           Top: "top",
@@ -99,6 +104,7 @@ export default () =>
                   disabled={disabled}
                   labelPlacement={labelPlacement}
                   row={row}
+                  formHelperText={formHelperText}
                 />
               );
             }}
@@ -114,7 +120,7 @@ export default () =>
         const radioLabels = ["2016", "2017", "2018"];
         const labels = array("Labels", radioLabels, ", ", GROUP_IDS.LABELS);
         const formHelperText = text(
-          "Form helper text",
+          "Helper text",
           "* Show results for this year",
           GROUP_IDS.LABELS
         );
@@ -125,22 +131,18 @@ export default () =>
           <StatefulWrapper initialState={{ value: radioLabels[0] }}>
             {({ get, set }) => {
               return (
-                <FormControl>
-                  <Fragment>
-                    <RadioButtonGroup
-                      grpLabel={grpLabel}
-                      labels={labels}
-                      onChange={event => {
-                        set({ value: event.target.value });
-                        action("onChange")(event);
-                      }}
-                      value={get("value")}
-                      disabled={disabled}
-                      row={row}
-                    />
-                  </Fragment>
-                  <FormHelperText>{formHelperText}</FormHelperText>
-                </FormControl>
+                <RadioButtonGroup
+                  grpLabel={grpLabel}
+                  labels={labels}
+                  onChange={event => {
+                    set({ value: event.target.value });
+                    action("onChange")(event);
+                  }}
+                  value={get("value")}
+                  disabled={disabled}
+                  row={row}
+                  formHelperText={formHelperText}
+                />
               );
             }}
           </StatefulWrapper>

--- a/packages/component-library/stories/radioButtonGroup.notes.md
+++ b/packages/component-library/stories/radioButtonGroup.notes.md
@@ -18,6 +18,7 @@ The Custom story shows all possible properties that can be passed to the Radio B
 
 - Label placement
 - Display all radio buttons in a row
+- Helper text
 
 ## Example:
 
@@ -27,4 +28,4 @@ This example story shows the radio button group as it would be used in a form. I
 - Labels
 - Display all radio buttons in a row
 - Disable the group of radio buttons
-- Form helper text
+- Helper text


### PR DESCRIPTION
Made the following Material UI components part of the CIVIC Radio Button Group component so developers won't need to know Material UI:
FormControl
FormLabel
FormHelperText

Updated Storybook stories and notes.
Improved the import statements for Material UI components.
Removed unnecessary eslint command.