### PR TITLE
Feature/authors list

### DIFF
--- a/packages/2019-template/src/components/DemoCard/demoCardMeta.js
+++ b/packages/2019-template/src/components/DemoCard/demoCardMeta.js
@@ -509,18 +509,9 @@ const demoCardMeta = (/* data */) => ({
     }
   ],
   authors: [
-    {
-      name: "Dustin Henderson",
-      email: "scicampwinner07@gmail.com"
-    },
-    {
-      name: "Jim Hopper",
-      email: "jim.hopper@yahoo.com"
-    },
-    {
-      name: "Joyce Byers",
-      email: "byers0180@hotmail.com"
-    }
+    "scicampwinner07@gmail.com",
+    "jim.hopper@yahoo.com",
+    "byers0180@hotmail.com"
   ]
   // authors likely an array of keys in the future
   // authors: [

--- a/packages/2019-template/src/components/DemoCard/demoCardMeta.js
+++ b/packages/2019-template/src/components/DemoCard/demoCardMeta.js
@@ -508,11 +508,25 @@ const demoCardMeta = (/* data */) => ({
       ]
     }
   ],
-  // authors likely an array of keys in the future
   authors: [
-    "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
-    "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+    {
+      name: "Dustin Henderson",
+      email: "scicampwinner07@gmail.com"
+    },
+    {
+      name: "Jim Hopper",
+      email: "jim.hopper@yahoo.com"
+    },
+    {
+      name: "Joyce Byers",
+      email: "byers0180@hotmail.com"
+    }
   ]
+  // authors likely an array of keys in the future
+  // authors: [
+  //   "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
+  //   "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+  // ]
 });
 
 export default demoCardMeta;

--- a/packages/2019-template/src/components/TemplateAPICard/templateAPICardMeta.js
+++ b/packages/2019-template/src/components/TemplateAPICard/templateAPICardMeta.js
@@ -125,18 +125,9 @@ const TemplateAPICardMeta = (/* data */) => ({
     }
   ],
   authors: [
-    {
-      name: "Dustin Henderson",
-      email: "scicampwinner07@gmail.com"
-    },
-    {
-      name: "Jim Hopper",
-      email: "jim.hopper@yahoo.com"
-    },
-    {
-      name: "Joyce Byers",
-      email: "byers0180@hotmail.com"
-    }
+    "scicampwinner07@gmail.com",
+    "jim.hopper@yahoo.com",
+    "byers0180@hotmail.com"
   ]
   // authors likely an array of keys in the future
   // authors: [

--- a/packages/2019-template/src/components/TemplateAPICard/templateAPICardMeta.js
+++ b/packages/2019-template/src/components/TemplateAPICard/templateAPICardMeta.js
@@ -124,11 +124,25 @@ const TemplateAPICardMeta = (/* data */) => ({
       ]
     }
   ],
-  // authors likely an array of keys in the future
   authors: [
-    "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
-    "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+    {
+      name: "Dustin Henderson",
+      email: "scicampwinner07@gmail.com"
+    },
+    {
+      name: "Jim Hopper",
+      email: "jim.hopper@yahoo.com"
+    },
+    {
+      name: "Joyce Byers",
+      email: "byers0180@hotmail.com"
+    }
   ]
+  // authors likely an array of keys in the future
+  // authors: [
+  //   "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
+  //   "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+  // ]
 });
 
 export default TemplateAPICardMeta;

--- a/packages/2019-template/src/components/TemplateFileCard/templateFileCardMeta.js
+++ b/packages/2019-template/src/components/TemplateFileCard/templateFileCardMeta.js
@@ -126,18 +126,9 @@ const TemplateFileCardMeta = (/* data */) => ({
     }
   ],
   authors: [
-    {
-      name: "Dustin Henderson",
-      email: "scicampwinner07@gmail.com"
-    },
-    {
-      name: "Jim Hopper",
-      email: "jim.hopper@yahoo.com"
-    },
-    {
-      name: "Joyce Byers",
-      email: "byers0180@hotmail.com"
-    }
+    "scicampwinner07@gmail.com",
+    "jim.hopper@yahoo.com",
+    "byers0180@hotmail.com"
   ]
   // authors likely an array of keys in the future
   // authors: [

--- a/packages/2019-template/src/components/TemplateFileCard/templateFileCardMeta.js
+++ b/packages/2019-template/src/components/TemplateFileCard/templateFileCardMeta.js
@@ -125,11 +125,25 @@ const TemplateFileCardMeta = (/* data */) => ({
       ]
     }
   ],
-  // authors likely an array of keys in the future
   authors: [
-    "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
-    "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+    {
+      name: "Dustin Henderson",
+      email: "scicampwinner07@gmail.com"
+    },
+    {
+      name: "Jim Hopper",
+      email: "jim.hopper@yahoo.com"
+    },
+    {
+      name: "Joyce Byers",
+      email: "byers0180@hotmail.com"
+    }
   ]
+  // authors likely an array of keys in the future
+  // authors: [
+  //   "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
+  //   "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+  // ]
 });
 
 export default TemplateFileCardMeta;

--- a/packages/2019-transportation/src/components/TransportationCard/transportationCardMeta.js
+++ b/packages/2019-transportation/src/components/TransportationCard/transportationCardMeta.js
@@ -125,21 +125,12 @@ const transportationCardMeta = (/* data */) => ({
       ]
     }
   ],
-  // authors likely an array of keys in the future
   authors: [
-    {
-      name: "Dustin Henderson",
-      email: "scicampwinner07@gmail.com"
-    },
-    {
-      name: "Jim Hopper",
-      email: "jim.hopper@yahoo.com"
-    },
-    {
-      name: "Joyce Byers",
-      email: "byers0180@hotmail.com"
-    }
+    "scicampwinner07@gmail.com",
+    "jim.hopper@yahoo.com",
+    "byers0180@hotmail.com"
   ]
+  // authors likely an array of keys in the future
   // authors: [
   //   "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
   //   "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"

--- a/packages/2019-transportation/src/components/TransportationCard/transportationCardMeta.js
+++ b/packages/2019-transportation/src/components/TransportationCard/transportationCardMeta.js
@@ -127,9 +127,23 @@ const transportationCardMeta = (/* data */) => ({
   ],
   // authors likely an array of keys in the future
   authors: [
-    "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
-    "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+    {
+      name: "Dustin Henderson",
+      email: "scicampwinner07@gmail.com"
+    },
+    {
+      name: "Jim Hopper",
+      email: "jim.hopper@yahoo.com"
+    },
+    {
+      name: "Joyce Byers",
+      email: "byers0180@hotmail.com"
+    }
   ]
+  // authors: [
+  //   "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
+  //   "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+  // ]
 });
 
 export default transportationCardMeta;

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -32,11 +32,11 @@ const sectionMaxWidthMedium = css`
   max-width: 900px;
 `;
 
-const authorPhoto = css`
-  width: 50%;
-  filter: grayscale(100%);
-  cursor: pointer;
-`;
+// const authorPhoto = css`
+//   width: 50%;
+//   filter: grayscale(100%);
+//   cursor: pointer;
+// `;
 
 function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
   return (
@@ -113,14 +113,23 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="authors">
           <h2>Who made this?</h2>
-          {cardMeta.authors.map(photo => (
-            <img
-              css={authorPhoto}
-              src={photo}
-              alt="Pictures of people who worked on this"
-              key={generate()}
-            />
+          {cardMeta.authors.map(authorInfo => (
+            <p>
+              {authorInfo.name}:{" "}
+              <a href={`mailto:${authorInfo.email}`}>{authorInfo.email}</a>
+            </p>
           ))}
+          {/*
+            Future implementation:
+            {cardMeta.authors.map(photo => (
+              <img
+                css={authorPhoto}
+                src={photo}
+                alt="Pictures of people who worked on this"
+                key={generate()}
+              />
+            ))}
+          */}
         </section>
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="improve">

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -113,10 +113,9 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="authors">
           <h2>Who made this?</h2>
-          {cardMeta.authors.map(authorInfo => (
-            <p>
-              {authorInfo.name}:{" "}
-              <a href={`mailto:${authorInfo.email}`}>{authorInfo.email}</a>
+          {cardMeta.authors.map(authorEmail => (
+            <p key={authorEmail}>
+              <a href={`mailto:${authorEmail}`}>{authorEmail}</a>
             </p>
           ))}
           {/*

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
@@ -32,11 +32,11 @@ const sectionMaxWidthMedium = css`
   max-width: 900px;
 `;
 
-const authorPhoto = css`
-  width: 50%;
-  filter: grayscale(100%);
-  cursor: pointer;
-`;
+// const authorPhoto = css`
+//   width: 50%;
+//   filter: grayscale(100%);
+//   cursor: pointer;
+// `;
 
 const cardMetaItem = css`
   border: 1px solid red;
@@ -162,14 +162,20 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
             id="authors"
           >
             <h2>Who made this?</h2>
-            {cardMeta.authors.map(photo => (
+            {cardMeta.authors.map(authorInfo => (
+              <p>
+                {authorInfo.name}:{" "}
+                <a href={`mailto:${authorInfo.email}`}>{authorInfo.email}</a>
+              </p>
+            ))}
+            {/* {cardMeta.authors.map(photo => (
               <img
                 css={authorPhoto}
                 src={photo}
                 alt="Pictures of people who worked on this"
                 key={generate()}
               />
-            ))}
+            ))} */}
           </section>
           <Desc id="authors" />
           <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
@@ -162,10 +162,9 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
             id="authors"
           >
             <h2>Who made this?</h2>
-            {cardMeta.authors.map(authorInfo => (
-              <p>
-                {authorInfo.name}:{" "}
-                <a href={`mailto:${authorInfo.email}`}>{authorInfo.email}</a>
+            {cardMeta.authors.map(authorEmail => (
+              <p key={authorEmail}>
+                <a href={`mailto:${authorEmail}`}>{authorEmail}</a>
               </p>
             ))}
             {/* {cardMeta.authors.map(photo => (

--- a/packages/component-library/src/CivicCard/cardMetaDescriptions.js
+++ b/packages/component-library/src/CivicCard/cardMetaDescriptions.js
@@ -59,7 +59,7 @@ const cardMetaDescriptions = {
   authors: {
     title: "Authors",
     description:
-      "This section shows all of the people who worked on the card that want to be shown. It is currently a list of author names and their email addresses — later there will be images."
+      "This section shows all of the people who worked on the card that want to be shown. It is currently a list of author email addresses — later that will be used as an id to get associated images and more."
   }
 };
 

--- a/packages/component-library/src/CivicCard/cardMetaDescriptions.js
+++ b/packages/component-library/src/CivicCard/cardMetaDescriptions.js
@@ -59,7 +59,7 @@ const cardMetaDescriptions = {
   authors: {
     title: "Authors",
     description:
-      "This section shows all of the people who worked on the card that want to be shown"
+      "This section shows all of the people who worked on the card that want to be shown. It is currently a list of author names and their email addresses — later there will be images."
   }
 };
 

--- a/packages/component-library/src/CivicCard/cardMetaTypes.js
+++ b/packages/component-library/src/CivicCard/cardMetaTypes.js
@@ -27,7 +27,13 @@ const cardMetaObjectProperties = {
       )
     })
   ),
-  authors: PropTypes.arrayOf(PropTypes.string /* image url */)
+  // authors: PropTypes.arrayOf(PropTypes.string /* image url */)
+  authors: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      email: PropTypes.string
+    })
+  )
 };
 
 export const optionalCardMetaKeys = {

--- a/packages/component-library/src/CivicCard/cardMetaTypes.js
+++ b/packages/component-library/src/CivicCard/cardMetaTypes.js
@@ -28,12 +28,7 @@ const cardMetaObjectProperties = {
     })
   ),
   // authors: PropTypes.arrayOf(PropTypes.string /* image url */)
-  authors: PropTypes.arrayOf(
-    PropTypes.shape({
-      name: PropTypes.string,
-      email: PropTypes.string
-    })
-  )
+  authors: PropTypes.arrayOf(PropTypes.string /* author email */)
 };
 
 export const optionalCardMetaKeys = {

--- a/packages/component-library/stories/CivicCard.story.js
+++ b/packages/component-library/stories/CivicCard.story.js
@@ -484,11 +484,25 @@ const demoCardMeta = (/* data */) => ({
       ]
     }
   ],
-  // authors likely an array of keys in the future
   authors: [
-    "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
-    "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+    {
+      name: "Dustin Henderson",
+      email: "scicampwinner07@gmail.com"
+    },
+    {
+      name: "Jim Hopper",
+      email: "jim.hopper@yahoo.com"
+    },
+    {
+      name: "Joyce Byers",
+      email: "byers0180@hotmail.com"
+    }
   ]
+  // // authors likely an array of keys in the future
+  // authors: [
+  //   "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
+  //   "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+  // ]
 });
 
 const demoCardMetaSideBySide = data => {

--- a/packages/component-library/stories/CivicCard.story.js
+++ b/packages/component-library/stories/CivicCard.story.js
@@ -485,18 +485,9 @@ const demoCardMeta = (/* data */) => ({
     }
   ],
   authors: [
-    {
-      name: "Dustin Henderson",
-      email: "scicampwinner07@gmail.com"
-    },
-    {
-      name: "Jim Hopper",
-      email: "jim.hopper@yahoo.com"
-    },
-    {
-      name: "Joyce Byers",
-      email: "byers0180@hotmail.com"
-    }
+    "scicampwinner07@gmail.com",
+    "jim.hopper@yahoo.com",
+    "byers0180@hotmail.com"
   ]
   // // authors likely an array of keys in the future
   // authors: [


### PR DESCRIPTION
Update the author section CivicCard component, metadata, and layouts to handle a list of authors as an array of objects like so:
```javascript
authors: [
    {
      name: "Dustin Henderson",
      email: "scicampwinner07@gmail.com"
    },
    {
      name: "Jim Hopper",
      email: "jim.hopper@yahoo.com"
    },
    {
      name: "Joyce Byers",
      email: "byers0180@hotmail.com"
    }
  ]
```
I've commented out the previous authors code in case it's something we want for reference later, but I can quickly remove it if that's preferred.

Ran storybook, 2019-template, and 2019-transportation packages to check its working.