### PR TITLE
Show spiffy photo

### DIFF
--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -32,11 +32,16 @@ const sectionMaxWidthMedium = css`
   max-width: 900px;
 `;
 
-// const authorPhoto = css`
-//   width: 50%;
-//   filter: grayscale(100%);
-//   cursor: pointer;
-// `;
+const authorPhoto = css`
+  width: 50%;
+  filter: grayscale(100%);
+  cursor: pointer;
+`;
+
+const demoAuthorPhotos = [
+  "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
+  "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+];
 
 function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
   return (
@@ -113,22 +118,20 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="authors">
           <h2>Who made this?</h2>
-          {cardMeta.authors.map(authorEmail => (
-            <p key={authorEmail}>
-              <a href={`mailto:${authorEmail}`}>{authorEmail}</a>
-            </p>
-          ))}
-          {/*
-            Future implementation:
-            {cardMeta.authors.map(photo => (
-              <img
-                css={authorPhoto}
-                src={photo}
-                alt="Pictures of people who worked on this"
-                key={generate()}
-              />
-            ))}
-          */}
+          {cardMeta.authors.length
+            ? cardMeta.authors.map(authorEmail => (
+                <p key={authorEmail}>
+                  <a href={`mailto:${authorEmail}`}>{authorEmail}</a>
+                </p>
+              ))
+            : demoAuthorPhotos.map(photo => (
+                <img
+                  css={authorPhoto}
+                  src={photo}
+                  alt="Pictures of people who worked on this"
+                  key={generate()}
+                />
+              ))}
         </section>
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="improve">

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
@@ -32,11 +32,11 @@ const sectionMaxWidthMedium = css`
   max-width: 900px;
 `;
 
-// const authorPhoto = css`
-//   width: 50%;
-//   filter: grayscale(100%);
-//   cursor: pointer;
-// `;
+const authorPhoto = css`
+  width: 50%;
+  filter: grayscale(100%);
+  cursor: pointer;
+`;
 
 const cardMetaItem = css`
   border: 1px solid red;
@@ -50,6 +50,11 @@ const description = css`
   max-width: 700px;
   margin: auto;
 `;
+
+const demoAuthorPhotos = [
+  "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",
+  "https://civicsoftwarefoundation.org/static/human-grid-test2-ea1849501456af341647068243fc72bb.png"
+];
 
 function Desc({ id }) {
   return (
@@ -158,23 +163,24 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
           <Desc id="resources" />
           <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
           <section
-            css={[sectionMarginSmall, sectionMaxWidthSmall, cardMetaItem]}
+            css={[sectionMarginSmall, sectionMaxWidthSmall]}
             id="authors"
           >
             <h2>Who made this?</h2>
-            {cardMeta.authors.map(authorEmail => (
-              <p key={authorEmail}>
-                <a href={`mailto:${authorEmail}`}>{authorEmail}</a>
-              </p>
-            ))}
-            {/* {cardMeta.authors.map(photo => (
-              <img
-                css={authorPhoto}
-                src={photo}
-                alt="Pictures of people who worked on this"
-                key={generate()}
-              />
-            ))} */}
+            {cardMeta.authors.length
+              ? cardMeta.authors.map(authorEmail => (
+                  <p key={authorEmail}>
+                    <a href={`mailto:${authorEmail}`}>{authorEmail}</a>
+                  </p>
+                ))
+              : demoAuthorPhotos.map(photo => (
+                  <img
+                    css={authorPhoto}
+                    src={photo}
+                    alt="Pictures of people who worked on this"
+                    key={generate()}
+                  />
+                ))}
           </section>
           <Desc id="authors" />
           <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />

--- a/packages/component-library/stories/CivicCard.story.js
+++ b/packages/component-library/stories/CivicCard.story.js
@@ -484,11 +484,7 @@ const demoCardMeta = (/* data */) => ({
       ]
     }
   ],
-  authors: [
-    "scicampwinner07@gmail.com",
-    "jim.hopper@yahoo.com",
-    "byers0180@hotmail.com"
-  ]
+  authors: [] // No authors so demo is *nice*
   // // authors likely an array of keys in the future
   // authors: [
   //   "https://civicsoftwarefoundation.org/static/human-grid-test-4c90bfc3f316f5d4e104320cb98c43c8.png",


### PR DESCRIPTION
In CivicCard, when authors is empty, show the default set of photos.