### PR TITLE
Fix incorrect registry injection

### DIFF
--- a/_templates/api-story-card/with-prompt/src/src-registry-import.ejs.t
+++ b/_templates/api-story-card/with-prompt/src/src-registry-import.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: packages/<%=package%>/src/registry.js
+to: packages/<%=package%>/src/index.js
 inject: true
 # This regex will inject this after the the last occurrence of a new line that begins with "import" (i.e. right after the other import statements)
 after: \nimport(?![\s\S]*\nimport).*

--- a/_templates/api-story-card/with-prompt/src/src-registry.ejs.t
+++ b/_templates/api-story-card/with-prompt/src/src-registry.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: packages/<%=package%>/src/registry.js
+to: packages/<%=package%>/src/index.js
 inject: true
 after: \[
 # Skip if the slug is found OR if the hygen:skip directive is found


### PR DESCRIPTION
I created a bug in #878.
The api-story-card generator was correctly implemented to inject the card registry before my change. I must have gotten confused by looking at an older package. Woopsie