### PR TITLE
Feature/750 no orb overlap

### DIFF
--- a/packages/project-disaster-trail/src/components/Game/KitScreen/index.js
+++ b/packages/project-disaster-trail/src/components/Game/KitScreen/index.js
@@ -13,7 +13,7 @@ const KitScreen = () => (
     <DurationBar step="Choose supplies" />
     <Ticker text="Ticker tape text that goes across the screen to give instructions" />
     <GUIStyle>
-      <OrbManager />
+      <OrbManager frozenOrbInterface />
     </GUIStyle>
   </>
 );

--- a/packages/project-disaster-trail/src/components/Game/Orb.js
+++ b/packages/project-disaster-trail/src/components/Game/Orb.js
@@ -1,13 +1,15 @@
-/** @jsx jsx */
-import { PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { PropTypes } from "prop-types";
+/** @jsx jsx */
 import { jsx, css } from "@emotion/core";
+import { TweenMax, Power2 } from "gsap/TweenMax";
 
 import { palette } from "../../constants/style";
 import RadialGauge from "./RadialGauge";
 
 const orbContainerStyle = css`
   position: relative;
+  opacity: 0;
 `;
 
 const circleDefaultStyle = css`
@@ -47,13 +49,31 @@ const defaultState = {
   isActive: false,
   isComplete: false,
   isCorrect: false,
-  percent: 0
+  percent: 0,
+  hasAnimated: false
 };
 
 export default class Orb extends PureComponent {
   constructor(props) {
     super(props);
     this.state = defaultState;
+    this.orbRef = React.createRef();
+  }
+
+  componentDidMount() {
+    // is this the first render?
+    const { hasAnimated } = this.state;
+    const { delay } = this.props;
+    if (!hasAnimated) {
+      TweenMax.fromTo(
+        this.orbRef.current,
+        1,
+        { autoAlpha: 0, y: 25, scale: 0 },
+        { autoAlpha: 1, ease: Power2.easeOut, delay, y: 0, scale: 1 }
+      );
+      // eslint-disable-next-line no-did-update-set-state
+      this.setState({ hasAnimated: true });
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -137,6 +157,7 @@ export default class Orb extends PureComponent {
     /* eslint-disable jsx-a11y/no-static-element-interactions */
     return (
       <div
+        ref={this.orbRef}
         css={css`
           ${orbContainerStyle};
           ${sizeStyle};
@@ -173,5 +194,6 @@ Orb.propTypes = {
   addOrbScore: PropTypes.func,
   imageSVG: PropTypes.string,
   imgAlt: PropTypes.string,
-  size: PropTypes.number
+  size: PropTypes.number,
+  delay: PropTypes.number
 };

--- a/packages/project-disaster-trail/src/components/Game/Orb.js
+++ b/packages/project-disaster-trail/src/components/Game/Orb.js
@@ -61,10 +61,13 @@ export default class Orb extends PureComponent {
   }
 
   componentDidMount() {
-    // is this the first render?
+    // If this is the first render
     const { hasAnimated } = this.state;
     const { delay } = this.props;
+
     if (!hasAnimated) {
+      // make the component 0 alpha, smaller, and slightly lower on the screen
+      // and animate it to full opacity, regular size, and to it's correct coordinates
       TweenMax.fromTo(
         this.orbRef.current,
         1,

--- a/packages/project-disaster-trail/src/components/Game/OrbManager.js
+++ b/packages/project-disaster-trail/src/components/Game/OrbManager.js
@@ -15,7 +15,8 @@ import useAnimationFrame from "../../state/hooks/useAnimationFrame";
 import Orb from "./Orb";
 import {
   completedOrbHandler,
-  createOrbsFromKit,
+  createFixedLayout,
+  createRandomLayout,
   uncompletedOrbHandler
 } from "./OrbManagerHelpers";
 import { addItemToPlayerKit, getKitCreationItems } from "../../state/kit";
@@ -45,7 +46,8 @@ const OrbManager = ({
   kitItems,
   activeTask,
   addItemToPlayerKitInState,
-  addPointsToState
+  addPointsToState,
+  frozenOrbInterface = false
 } = {}) => {
   const [hasInitialized, setHasInitialized] = useState(false);
   const [orbs, setOrbsState] = useState([]);
@@ -68,11 +70,13 @@ const OrbManager = ({
   useEffect(() => {
     // ensure we only run this once
     if (prevBounds && !prevBounds.width && bounds.width && !hasInitialized) {
-      const newOrbs = createOrbsFromKit(kitItems, bounds, ORB_CONFIG);
+      const newOrbs = frozenOrbInterface
+        ? createFixedLayout(kitItems, bounds, ORB_CONFIG)
+        : createRandomLayout(kitItems, bounds, ORB_CONFIG);
       setHasInitialized(true);
       setOrbsState(newOrbs);
     }
-  }, [bounds, hasInitialized, kitItems, prevBounds]);
+  }, [bounds, frozenOrbInterface, hasInitialized, kitItems, prevBounds]);
 
   const addOrbScore = useCallback(
     orbId => {
@@ -131,9 +135,19 @@ const OrbManager = ({
       }
 
       if (isOrbCompleted) {
-        currentOrb = completedOrbHandler(currentOrb, activeTask);
+        currentOrb = completedOrbHandler(
+          currentOrb,
+          activeTask,
+          frozenOrbInterface
+        );
       } else {
-        currentOrb = uncompletedOrbHandler(currentOrb, tick, i, ORB_CONFIG);
+        currentOrb = uncompletedOrbHandler(
+          currentOrb,
+          tick,
+          i,
+          ORB_CONFIG,
+          frozenOrbInterface
+        );
       }
 
       // is it offscreen?
@@ -215,6 +229,7 @@ const OrbManager = ({
             addOrbScore={addOrbScore}
             setOrbTouched={setOrbTouched}
             setOrbComplete={setOrbComplete}
+            delay={orb.delay}
           />
         </div>
       ))}

--- a/packages/project-disaster-trail/src/components/Game/OrbManagerHelpers.js
+++ b/packages/project-disaster-trail/src/components/Game/OrbManagerHelpers.js
@@ -34,6 +34,16 @@ export function createRandomLayout(kitItems, bounds, config) {
   return orbCollection;
 }
 
+// createFixedLayout is responsible for
+// creating orbModels,
+// laying them out in a grid
+// and setting a `delay` in each orb for sequential animations
+//
+// use `totalGeneratedOrbs` to control how many orbs should be made at once
+// note that this creates `n` number of orbs based on what's found in the kit
+//
+// use `columnsInRow` to define how many columns (ie instances across, remember columns hold things up)
+// the grid will auto populate the number of rows required to display all the orbs
 export function createFixedLayout(
   kitItems,
   bounds,
@@ -70,24 +80,34 @@ export function createFixedLayout(
   // rearranges the orbs so the layout appears random
   orbCollection = sampleSize(orbCollection, orbCollection.length);
 
-  // build a staggered grid of 4 columns, then 3 in the next
-  // if we have 11 items, rows will be 6 and columns will be 3
+  // perform some grid-related calculations to derive
+  // rows (we already know columns from function args),
+  // rowHeight and columnWidth
+  // be sure to account for verticalBuffer
+  // and orbSize (remember orb's 0,0 coordinate is its own top-left, not center of component)
   const rows = Math.ceil(orbCollection.length / columnsInRow);
   const columnWidth =
     (bounds.width - config.verticalBuffer * 2 - config.orbSize / 2) /
     (columnsInRow - 1);
   const rowHeight = (bounds.height - config.verticalBuffer * 2) / rows;
 
+  // for each orb, calculate and assign the x/y coordinates
   for (let i = 0; i < orbCollection.length; i += 1) {
     const orb = orbCollection[i];
 
+    // rowIndex is from 0 (left of container) to columnsInRow (right of container)
     const rowIndex = Math.floor(i / columnsInRow);
+
+    // columnIndex is from 0 (top of container) to rows (bottom of container)
     const columnIndex = i % columnsInRow;
     orb.x =
       config.verticalBuffer + columnIndex * columnWidth - config.orbSize / 2;
     orb.y = config.verticalBuffer + rowIndex * rowHeight - config.orbSize / 2;
+
+    // also pass a delay for sequential animations
     orb.delay = i * 0.05;
 
+    // store the data
     orbCollection[i] = orb;
   }
 


### PR DESCRIPTION
Enables Kit Screens OrbManager to lay out orbs in a grid.

The `<OrbManager />` component will apply the grid layout when its `frozenOrbInterface` property is true.

The layout supports creating any number of orbs (based on what's available in it's `kit` property). The layout shuffles the orbs so they are randomly arranged (ie not grouped by type). It also assigns a `delay` property of each orb to support sequential animation reveals.

Other `<OrbManager />` instances are not affected by the layout change.

![image](https://user-images.githubusercontent.com/1304729/64081202-c7cf3000-ccb2-11e9-977d-eac0f61f47aa.png)
