### PR TITLE
revert bar fill to plumLight

### DIFF
--- a/packages/component-library/src/_Themes/Victory/VictoryTheme.js
+++ b/packages/component-library/src/_Themes/Victory/VictoryTheme.js
@@ -7,7 +7,7 @@ const { victoryColors } = VisualizationColors;
 // Brand Colors
 const civicPrimary = BrandColors.primary.hex;
 const civicSecondary = BrandColors.secondary.hex;
-const civicTertiary = BrandColors.tertiary.hex;
+const civicTertiary = BrandColors.plumLight.hex; // keeping plumLight for bar fill
 const civicSecondaryLighter = BrandColors.medium.hex;
 const civicSecondaryLightest = BrandColors.subdued.hex;
 

--- a/packages/component-library/src/_Themes/VisualizationColors.js
+++ b/packages/component-library/src/_Themes/VisualizationColors.js
@@ -40,7 +40,7 @@ const victoryColors = [
   categorical.blue.hex,
   categorical.purple.hex,
   categorical.yellow.hex,
-  BrandColors.tertiary.hex
+  BrandColors.plumLight.hex
 ];
 
 const sequential = {


### PR DESCRIPTION
There's something amiss with the bar chart due to #900. This changes it back. Review please :) 

<img width="964" alt="image" src="https://user-images.githubusercontent.com/7065695/64198591-6daea600-ce3d-11e9-8ac3-404359f9b224.png">