### PR TITLE
Remove --fix from lint hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     ],
     "*.{js,jsx}": [
       "prettier --write",
-      "eslint --fix",
+      "eslint",
       "git add"
     ]
   },


### PR DESCRIPTION
This changes functionality of the commit hook to spit back out fixable eslint errors instead of fixing them automatically.

Fixing the errors automatically could result in unexpected behavior, which I witnessed @worc have an issue with

