### PR TITLE
Export MaterialUI Theme from component-library

### DIFF
--- a/packages/component-library/src/index.js
+++ b/packages/component-library/src/index.js
@@ -6,7 +6,8 @@ export {
   BrandColors,
   BrandTheme,
   VictoryTheme,
-  VictoryCrazyTheme
+  VictoryCrazyTheme,
+  MaterialTheme
 } from "./_Themes/index";
 
 // COMPONENTS


### PR DESCRIPTION
So that it can be used in other packages, similar to other themes.