### PR TITLE
Remove dataSeriesLabel from standard LineChart and Scatterplot stories

### DIFF
--- a/packages/component-library/stories/LineChart.story.js
+++ b/packages/component-library/stories/LineChart.story.js
@@ -96,11 +96,6 @@ export default () =>
           { year: 2005, ridership: 134569, series: "sunday" }
         ];
         const sampleDataSeries = "series";
-        const sampleDataSeriesLabel = [
-          { category: "weekday", label: "Weekday" },
-          { category: "saturday", label: "Saturday" },
-          { category: "sunday", label: "Sunday" }
-        ];
 
         const title = text(
           "Title",
@@ -136,11 +131,6 @@ export default () =>
           sampleDataSeries,
           GROUP_IDS.DATA
         );
-        const dataSeriesLabel = object(
-          "Data series labels",
-          sampleDataSeriesLabel,
-          GROUP_IDS.DATA
-        );
         const data = object("Data", sampleTransportationData, GROUP_IDS.DATA);
 
         return (
@@ -149,7 +139,6 @@ export default () =>
             dataKey={dataKey}
             dataValue={dataValue}
             dataSeries={dataSeries}
-            dataSeriesLabel={dataSeriesLabel}
             subtitle={subtitle}
             title={title}
             xLabel={xLabel}

--- a/packages/component-library/stories/Scatterplot.story.js
+++ b/packages/component-library/stories/Scatterplot.story.js
@@ -107,11 +107,6 @@ export default () =>
           { experience: 17, students: 25, series: "elementary" },
           { experience: 18, students: 26, series: "elementary" }
         ];
-        const sampleDataSeriesLabel = [
-          { category: "high", label: "High School" },
-          { category: "middle", label: "Middle School" },
-          { category: "elementary", label: "Elementary School" }
-        ];
 
         const title = text(
           "Title",
@@ -144,11 +139,6 @@ export default () =>
         const dataKey = text("Data key", "experience", GROUP_IDS.DATA);
         const dataValue = text("Data value", "students", GROUP_IDS.DATA);
         const dataSeries = text("Data series", "series", GROUP_IDS.DATA);
-        const dataSeriesLabel = object(
-          "Data series labels",
-          sampleDataSeriesLabel,
-          GROUP_IDS.DATA
-        );
         const data = object("Data", sampleData, GROUP_IDS.DATA);
 
         return (
@@ -157,7 +147,6 @@ export default () =>
             dataKey={dataKey}
             dataValue={dataValue}
             dataSeries={dataSeries}
-            dataSeriesLabel={dataSeriesLabel}
             subtitle={subtitle}
             title={title}
             xLabel={xLabel}


### PR DESCRIPTION
Having these props in the Standard story makes mocking up charts much harder!

LineChart and Scatterplot will generate dataSeriesLabels by default