### PR TITLE
Fix line chart miscoloring

### DIFF
--- a/packages/2019-housing/src/components/HouseholdIncomeByRace/HouseholdIncomeByRaceVisualization.js
+++ b/packages/2019-housing/src/components/HouseholdIncomeByRace/HouseholdIncomeByRaceVisualization.js
@@ -42,6 +42,7 @@ const HouseholdIncomeByRaceVisualization = ({ data }) => {
           yLabel="Income"
           xNumberFormatter={x => civicFormat.year(x)}
           yNumberFormatter={y => civicFormat.dollars(y)}
+          protect
         />
       </span>
     )

--- a/packages/component-library/src/LineChart/LineChart.js
+++ b/packages/component-library/src/LineChart/LineChart.js
@@ -82,14 +82,14 @@ const LineChart = ({
     ? groupBy(safeData, dataSeries)
     : { category: safeData };
 
-  // TODO: if you have line data with categories that don't have the same length,
-  // then the below won't work.
+  const dataSeriesList = dataSeriesLabels || [{ category: "category" }];
+
   const lines = lineData
-    ? Object.keys(lineData).map((category, index) => (
+    ? dataSeriesList.map((item, index) => (
         <VictoryLine
           title="Line Chart"
           key={shortid.generate()}
-          data={lineData[category].map(d => ({
+          data={lineData[item.category].map(d => ({
             dataKey: d[dataKey],
             dataValue: d[dataValue],
             series: d[dataSeries]


### PR DESCRIPTION
This fixes lines that were being miscolored in some situations for Line Chart:

Before:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/7065695/64471068-4a1b8200-d101-11e9-96aa-888684f5ce0d.png">

After:
<img width="859" alt="image" src="https://user-images.githubusercontent.com/7065695/64471074-59023480-d101-11e9-915b-3681208b0a99.png">
