### PR TITLE
Feature/add tooltip value formatter

### DIFF
--- a/packages/component-library/src/MapTooltip/MapTooltip.js
+++ b/packages/component-library/src/MapTooltip/MapTooltip.js
@@ -22,6 +22,8 @@ const MapTooltip = props => {
     tooltipInfo,
     x,
     y,
+    formatPrimaryField,
+    formatSecondaryField,
     primaryName,
     primaryField,
     secondaryName,
@@ -35,6 +37,13 @@ const MapTooltip = props => {
       : x - get(window, "innerWidth", 1000) * 0.1;
   const yPostition = y < 375 ? y : y - 50;
 
+  const getProperty = (property, formatFunction) => {
+    if (formatFunction) {
+      return formatFunction(property);
+    }
+    return property;
+  };
+
   return (
     <div
       css={tooltip}
@@ -43,22 +52,28 @@ const MapTooltip = props => {
         top: yPostition
       }}
     >
-      {primaryName ? (
+      {primaryName && (
         <div>
-          {primaryName}: {tooltipInfo.properties[primaryField]}
+          {`${primaryName}: ${getProperty(
+            tooltipInfo.properties[primaryField],
+            formatPrimaryField
+          )}`}
         </div>
-      ) : null}
-      {secondaryName ? (
+      )}
+      {secondaryName && (
         <div>
-          {secondaryName}: {tooltipInfo.properties[secondaryField]}
+          {`${secondaryName}: ${getProperty(
+            tooltipInfo.properties[secondaryField],
+            formatSecondaryField
+          )}`}
         </div>
-      ) : null}
-      {isHex ? (
+      )}
+      {isHex && (
         <div>
           <div>elevation: {tooltipInfo.elevationValue}</div>
           <div>coordinates: {tooltipInfo.centroid.join(", ")}</div>
         </div>
-      ) : null}
+      )}
     </div>
   );
 };
@@ -67,11 +82,18 @@ MapTooltip.propTypes = {
   tooltipInfo: PropTypes.shape({}),
   x: PropTypes.number,
   y: PropTypes.number,
+  formatPrimaryField: PropTypes.func,
+  formatSecondaryField: PropTypes.func,
   primaryName: PropTypes.string,
   primaryField: PropTypes.string,
   secondaryName: PropTypes.string,
   secondaryField: PropTypes.string,
   isHex: PropTypes.bool
+};
+
+MapTooltip.defaultProps = {
+  formatPrimaryField: null,
+  formatSecondaryField: null
 };
 
 export default MapTooltip;

--- a/packages/component-library/src/utils/civicFormat.js
+++ b/packages/component-library/src/utils/civicFormat.js
@@ -36,6 +36,8 @@ const numeric = d => {
   return formatted;
 };
 
+const roundedDecimal = d => format(",.2f")(d);
+
 const scalesShort = [
   [1000000000000, "t"],
   [1000000000, "b"],
@@ -93,6 +95,7 @@ const monthYear = timeFormat("%B %Y");
 
 const civicFormat = {
   numeric,
+  roundedDecimal,
   year,
   percentage,
   dollars,

--- a/packages/component-library/src/utils/civicFormat.test.js
+++ b/packages/component-library/src/utils/civicFormat.test.js
@@ -12,6 +12,16 @@ describe("civicFormat", () => {
     expect(civicFormat.numeric(73000000000)).to.eql("73 billion");
   });
 
+  it("should format to rounded decimal correctly", () => {
+    expect(civicFormat.roundedDecimal(1)).to.eql("1.00");
+    expect(civicFormat.roundedDecimal(0.5)).to.eql("0.50");
+    expect(civicFormat.roundedDecimal(1.001)).to.eql("1.00");
+    expect(civicFormat.roundedDecimal(0.1501)).to.eql("0.15");
+    expect(civicFormat.roundedDecimal(100000.0000001)).to.eql("100,000.00");
+    expect(civicFormat.roundedDecimal(1000000.0000001)).to.eql("1,000,000.00");
+    expect(civicFormat.roundedDecimal(-0.7300001)).to.eql("-0.73");
+  });
+
   it("should abbriviate numbers correctly", () => {
     expect(civicFormat.numericShort(0.1)).to.eql("0");
     expect(civicFormat.numericShort(0.5)).to.eql("1");

--- a/packages/component-library/stories/MapOverlay.story.js
+++ b/packages/component-library/stories/MapOverlay.story.js
@@ -6,6 +6,7 @@ import {
   withKnobs,
   select,
   object,
+  optionsKnob as options,
   boolean,
   number,
   text
@@ -14,7 +15,14 @@ import { action } from "@storybook/addon-actions";
 import { checkA11y } from "@storybook/addon-a11y";
 import { scaleQuantize, extent } from "d3";
 import { at } from "lodash";
-import { BaseMap, MapOverlay, MapTooltip, DemoJSONLoader } from "../src";
+import {
+  civicFormat,
+  BaseMap,
+  MapOverlay,
+  MapTooltip,
+  DemoJSONLoader
+} from "../src";
+import { getKeyNames } from "./shared";
 import notes from "./mapOverlay.notes.md";
 
 const GROUP_IDS = {
@@ -96,7 +104,7 @@ const colorSchemeOptions = {
 };
 
 const CIVIC_API_URL =
-  "http://service.civicpdx.org/disaster-resilience/api/DisasterNeighborhoodView/?format=json&limit=100";
+  "https://service.civicpdx.org/disaster-resilience/api/DisasterNeighborhoodView/?format=json&limit=102";
 
 export default () =>
   storiesOf("Component Lib|Maps/Map Overlay", module)
@@ -379,6 +387,15 @@ export default () =>
       "Example: With Tooltip",
       () => {
         const onLayerClick = info => action("Layer Clicked:")(info);
+
+        const formatOption = options(
+          "Tooltip value format",
+          getKeyNames(civicFormat),
+          "numericShort",
+          { display: "select" },
+          GROUP_IDS.LABELS
+        );
+
         return (
           <DemoJSONLoader urls={[CIVIC_API_URL]}>
             {data => (
@@ -393,6 +410,8 @@ export default () =>
                     primaryField="injuriestotal_day"
                     secondaryName="Earthquake - Total Night Injuries"
                     secondaryField="injuriestotal_night"
+                    formatPrimaryField={f => civicFormat[formatOption](f)}
+                    formatSecondaryField={f => civicFormat[formatOption](f)}
                   />
                 </MapOverlay>
               </BaseMap>


### PR DESCRIPTION
Add the option to format the values displayed in map tooltips. (Also added the option to round a value to 2 decimal places -- roundedDecimal)

Unformatted:
<img width="305" alt="Screen Shot 2019-09-07 at 3 20 58 PM" src="https://user-images.githubusercontent.com/9246015/64480796-5516f680-d183-11e9-977e-e5004d233878.png">

Numeric
<img width="264" alt="Screen Shot 2019-09-07 at 3 20 40 PM" src="https://user-images.githubusercontent.com/9246015/64480798-5a744100-d183-11e9-968e-82321ce9e56f.png">

Rounded Decimal:
<img width="297" alt="Screen Shot 2019-09-07 at 3 20 50 PM" src="https://user-images.githubusercontent.com/9246015/64480799-5f38f500-d183-11e9-9804-06c13a27764e.png">
