### PR TITLE
Add card error boundaries

### DIFF
--- a/packages/component-library/src/CivicCard/CivicCard.js
+++ b/packages/component-library/src/CivicCard/CivicCard.js
@@ -2,18 +2,23 @@ import React from "react";
 import PropTypes from "prop-types";
 import DataChecker from "./utils/DataChecker";
 import CivicCardLayoutFull from "./CivicCardLayoutFull";
+import ErrorBoundary from "../ErrorBoundary/ErrorBoundary";
 import { cardMetaKeys, optionalCardMetaKeys } from "./cardMetaTypes";
 
 const CivicCard = ({ cardMeta, data, isLoading, Layout }) => (
-  <DataChecker
-    data={cardMeta(data)}
-    dataAccessors={cardMetaKeys}
-    optionalKeys={optionalCardMetaKeys}
-    dataIsObject
-    message="Invalid cardMeta"
+  <ErrorBoundary
+    customMessage={`CivicCard: "${cardMeta(data).title}" failed to load`}
   >
-    <Layout cardMeta={cardMeta(data)} isLoading={isLoading} data={data} />
-  </DataChecker>
+    <DataChecker
+      data={cardMeta(data)}
+      dataAccessors={cardMetaKeys}
+      optionalKeys={optionalCardMetaKeys}
+      dataIsObject
+      message="Invalid cardMeta"
+    >
+      <Layout cardMeta={cardMeta(data)} isLoading={isLoading} data={data} />
+    </DataChecker>
+  </ErrorBoundary>
 );
 
 CivicCard.propTypes = {

--- a/packages/component-library/src/ErrorBoundary/ErrorBoundary.js
+++ b/packages/component-library/src/ErrorBoundary/ErrorBoundary.js
@@ -1,0 +1,36 @@
+import { Component } from "react";
+import { oneOfType, node, object, string } from "prop-types";
+
+class ErrorBoundary extends Component {
+  static propTypes = {
+    children: oneOfType([node, object]),
+    customErrorComponent: oneOfType([node, string]),
+    customMessage: string
+  };
+
+  static defaultProps = {
+    children: null,
+    customErrorComponent: null,
+    customMessage: null
+  };
+
+  state = { hasError: false, error: null, info: null };
+
+  componentDidCatch(error, info) {
+    // info.componentStack has error call stack
+    this.setState({ hasError: true, error, info });
+  }
+
+  render() {
+    const { customMessage, customErrorComponent, children } = this.props;
+    const { error, hasError, info } = this.state;
+
+    if (hasError) {
+      console.warn(customMessage, { error, info }); // eslint-disable-line
+      return customErrorComponent || null;
+    }
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/packages/component-library/src/index.js
+++ b/packages/component-library/src/index.js
@@ -98,3 +98,4 @@ export { default as civicFormat } from "./utils/civicFormat";
 export { default as ungroupBy } from "./utils/ungroupBy";
 export { default as DemoJSONLoader } from "./DemoJSONLoader/DemoJSONLoader";
 export { default as Badge } from "./Badge/Badge";
+export { default as ErrorBoundary } from "./ErrorBoundary/ErrorBoundary";


### PR DESCRIPTION
**This is just a proposal -- it might be better to have things crash, since it makes problems VERY obvious. Just thought it might be good to avoid catastrophic errors.** 

**Reason for this**: APIs keep subtly changing --> which cause a single card to blow up --> which subsequently takes down the WHOLE page

_...As is the case currently for Housing: http://civicplatform.org/2019/housing (you have to wait for the affected data to load for the page to crash)_

**What it does**: If you wrap something in an `<ErrorBoundary>` component, it will catch any errors generated by any React components inside the ErrorBoundary, hide the erring component and send a warning to the console. Since the errors are caught, the rest of the page will still function properly.

**Configuration**: You can just use a plain `<ErrorBoundary>`, or pass a custom message to display in the console with `customMessage` or render an error in the DOM by defining a `customErrorComponent`.