### PR TITLE
Feature/chapter timers

### DIFF
--- a/packages/project-disaster-trail/src/components/Game/DefaultScreen/index.js
+++ b/packages/project-disaster-trail/src/components/Game/DefaultScreen/index.js
@@ -1,23 +1,49 @@
-import React, { memo } from "react";
+import React, { memo, useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { PropTypes } from "prop-types";
 
-import { getActiveChapterData } from "../../../state/chapters";
+import { getActiveChapterData, goToNextChapter } from "../../../state/chapters";
+import Timer from "../../../utils/timer";
 
-const DefaultScreen = ({ activeChapter }) => (
-  <>
-    <h1>{activeChapter.title} screen</h1>
-  </>
-);
+const DefaultScreen = ({ activeChapter, endChapter, chapterDuration = 60 }) => {
+  const [chapterTimer] = useState(new Timer());
+
+  // start a timer for the _entire_ chapter
+  useEffect(() => {
+    chapterTimer.setDuration(chapterDuration);
+    chapterTimer.addCompleteCallback(() => endChapter());
+    chapterTimer.start();
+    return () => {
+      chapterTimer.stop();
+    };
+  }, [chapterDuration, chapterTimer, endChapter]);
+
+  return (
+    <>
+      <h1>{activeChapter.title} screen</h1>
+    </>
+  );
+};
 
 DefaultScreen.propTypes = {
   activeChapter: PropTypes.shape({
     title: PropTypes.string
-  })
+  }),
+  endChapter: PropTypes.func,
+  chapterDuration: PropTypes.number
 };
 
 const mapStateToProps = state => ({
   activeChapter: getActiveChapterData(state)
 });
 
-export default connect(mapStateToProps)(memo(DefaultScreen));
+const mapDispatchToProps = dispatch => ({
+  endChapter() {
+    dispatch(goToNextChapter());
+  }
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(memo(DefaultScreen));

--- a/packages/project-disaster-trail/src/components/Game/KitScreen/index.js
+++ b/packages/project-disaster-trail/src/components/Game/KitScreen/index.js
@@ -121,7 +121,6 @@ const mapDispatchToProps = dispatch => ({
   addPointsToState: bindActionCreators(addPoints, dispatch),
   addItemToPlayerKitInState: bindActionCreators(addItemToPlayerKit, dispatch),
   endChapter() {
-    console.log("Chapter complete");
     dispatch(goToNextChapter());
   }
 });

--- a/packages/project-disaster-trail/src/components/Game/index.js
+++ b/packages/project-disaster-trail/src/components/Game/index.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import styled from "@emotion/styled";
 
 import { getActiveChapterId } from "../../state/chapters";
-import { ATTRACTOR, KIT, TASKS } from "../../constants/chapters";
+import { ATTRACTOR, KIT, TASKS, QUAKE } from "../../constants/chapters";
 import { palette } from "../../constants/style";
 import media from "../../utils/mediaQueries";
 import TitleBar from "../atoms/TitleBar";
@@ -24,6 +24,8 @@ const Game = ({ activeChapterId }) => {
         return <KitScreen />;
       case TASKS:
         return <TaskScreen />;
+      case QUAKE:
+        return <DefaultScreen chapterDuration={15} />;
       default:
         return <DefaultScreen />;
     }

--- a/packages/project-disaster-trail/src/components/atoms/LevelView/index.js
+++ b/packages/project-disaster-trail/src/components/atoms/LevelView/index.js
@@ -12,6 +12,7 @@ const LevelContainer = styled.div`
   padding: 20px;
   background: ${palette.white};
   border-radius: 50px;
+  text-align: center;
   /* Just guessing here as shadow is baked into raster in comp */
   box-shadow: 10px 10px 10px 0px rgba(0, 0, 0, 0.15);
 

--- a/packages/project-disaster-trail/src/components/atoms/PointsView/index.js
+++ b/packages/project-disaster-trail/src/components/atoms/PointsView/index.js
@@ -11,6 +11,7 @@ const PointsContainer = styled.div`
   padding: 20px;
   background: ${palette.white};
   border-radius: 50px;
+  text-align: center;
   /* Just guessing here as shadow is baked into raster in comp */
   box-shadow: 10px 10px 10px 0px rgba(0, 0, 0, 0.15);
 

--- a/packages/project-disaster-trail/src/components/atoms/TitleBar/index.js
+++ b/packages/project-disaster-trail/src/components/atoms/TitleBar/index.js
@@ -18,7 +18,7 @@ const ContainerStyle = css`
   width: calc(100% - 200px);
   padding: 0 100px;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: 300px 1fr 300px;
   justify-content: center;
   align-items: flex-start;
   z-index: 103;


### PR DESCRIPTION
After the KitScreen has been 'played' for a minute, advance to the next chapter.
After the QuakeScreen has been visible for 15 seconds, advance to the next chapter.
Minor layout adjustments to TitleBar to prevent points from altering the layout. Previously, when the points increased from 0->10, or 10->100 (or anytime another digit was required to display the points), the `TitleBar` layout would shift to make room for the `auto`-sized PointsView. Now, the `LevelView` and `PointsView` component have fixed widths, which ensures the components do not move.