### PR TITLE
add tags and pull through to card page

### DIFF
--- a/packages/2018-disaster-resilience/src/components/ProactivePlanning/index.js
+++ b/packages/2018-disaster-resilience/src/components/ProactivePlanning/index.js
@@ -19,6 +19,7 @@ const ProactivePlanning = ({ init, data, Layout }) => {
 };
 
 ProactivePlanning.displayName = "ProactivePlanning";
+ProactivePlanning.tags = proactivePlanningMeta().tags;
 
 ProactivePlanning.propTypes = {
   init: PropTypes.func,

--- a/packages/2018-disaster-resilience/src/components/ProactivePlanning/proactivePlanningMeta.js
+++ b/packages/2018-disaster-resilience/src/components/ProactivePlanning/proactivePlanningMeta.js
@@ -7,7 +7,7 @@ const ProactivePlanningMeta = (/* data */) => ({
   visualization: ProactivePlanningVisualization, // data is passed to this as props
   additionalText: null, // TODO
   shareText: null, // TODO
-  tags: null, // TODO
+  tags: ["Disaster Resilience", "Portland", "Chart"],
   selector: null,
   analysis: null, // TODO
   metadata: null, // TODO

--- a/packages/2018-disaster-resilience/src/components/SignificantStructuralDamage/index.js
+++ b/packages/2018-disaster-resilience/src/components/SignificantStructuralDamage/index.js
@@ -9,6 +9,7 @@ const SignificantStructuralDamage = ({ Layout }) => (
 );
 
 SignificantStructuralDamage.displayName = "SignificantStructuralDamage";
+SignificantStructuralDamage.tags = significantStructuralDamageMeta().tags;
 
 SignificantStructuralDamage.propTypes = {
   Layout: PropTypes.func

--- a/packages/2018-disaster-resilience/src/components/SignificantStructuralDamage/significantStructuralDamageMeta.js
+++ b/packages/2018-disaster-resilience/src/components/SignificantStructuralDamage/significantStructuralDamageMeta.js
@@ -52,7 +52,7 @@ const SignificantStructuralDamageMeta = (/* data */) => ({
     </Collapsable>
   ),
   shareText: null, // TODO
-  tags: null, // TODO
+  tags: ["Disaster Resilience", "Portland", "Infographic"],
   selector: null,
   analysis: null, // TODO
   metadata: null, // TODO

--- a/packages/2018-disaster-resilience/src/components/WhatYouCanDoToPrepare/index.js
+++ b/packages/2018-disaster-resilience/src/components/WhatYouCanDoToPrepare/index.js
@@ -9,6 +9,7 @@ const WhatYouCanDoToPrepare = ({ Layout }) => (
 );
 
 WhatYouCanDoToPrepare.displayName = "WhatYouCanDoToPrepare";
+WhatYouCanDoToPrepare.tags = whatYouCanDoToPrepareMeta().tags;
 
 WhatYouCanDoToPrepare.propTypes = {
   Layout: PropTypes.func

--- a/packages/2018-disaster-resilience/src/components/WhatYouCanDoToPrepare/whatYouCanDoToPrepareMeta.js
+++ b/packages/2018-disaster-resilience/src/components/WhatYouCanDoToPrepare/whatYouCanDoToPrepareMeta.js
@@ -7,7 +7,7 @@ const WhatYouCanDoToPrepareMeta = (/* data */) => ({
   visualization: WhatYouCanDoToPrepareVisualization, // data, isLoading are passed to this as props
   additionalText: null,
   shareText: null,
-  tags: null,
+  tags: ["Disaster Resilience", "Portland", "Quiz"],
   selector: null,
   analysis: null,
   metadata: null,

--- a/packages/2018-disaster-resilience/src/components/YouAndYourNeighbors/index.js
+++ b/packages/2018-disaster-resilience/src/components/YouAndYourNeighbors/index.js
@@ -19,6 +19,7 @@ const YouAndYourNeighbors = ({ init, data, Layout }) => {
 };
 
 YouAndYourNeighbors.displayName = "YouAndYourNeighbors";
+YouAndYourNeighbors.tags = youAndYourNeighborsMeta().tags;
 
 YouAndYourNeighbors.propTypes = {
   init: PropTypes.func,

--- a/packages/2018-disaster-resilience/src/components/YouAndYourNeighbors/youAndYourNeighborsMeta.js
+++ b/packages/2018-disaster-resilience/src/components/YouAndYourNeighbors/youAndYourNeighborsMeta.js
@@ -27,7 +27,7 @@ const YouAndYourNeighborsMeta = (/* data */) => ({
   visualization: YouAndYourNeighborsVisualization, // data, isLoading are passed to this as props
   additionalText: null,
   shareText: null,
-  tags: null,
+  tags: ["Disaster Resilience", "Portland", "Map"],
   selector: null,
   analysis: null,
   metadata: null,

--- a/packages/2018/src/tags.js
+++ b/packages/2018/src/tags.js
@@ -1,5 +1,5 @@
 export default {
-  topics: ["Transportation", "Disaster Resilience", "Housing"],
+  topics: ["Transportation", "Disaster Resilience", "Housing", "Race"],
   locations: ["Portland", "Nationwide", "Your City"],
-  visualizations: ["Bar Chart", "Cloropleth Map", "Scatterplot"]
+  visualizations: ["Chart", "Map", "Infographic", "Quiz"]
 };

--- a/packages/2019-education/src/components/IsThereEvidenceTheProgramWorked/isThereEvidenceTheProgramWorkedMeta.js
+++ b/packages/2019-education/src/components/IsThereEvidenceTheProgramWorked/isThereEvidenceTheProgramWorkedMeta.js
@@ -7,9 +7,7 @@ const IsThereEvidenceTheProgramWorkedMeta = (/* data */) => ({
   visualization: IsThereEvidenceTheProgramWorkedVisualization, // data, isLoading are passed to this as props
   additionalText: null,
   shareText: null,
-  tags: [
-    /* "Transportation", "Bus", "Rail", "Portland" */
-  ],
+  tags: ["Education", "Portland", "Chart"],
   selector: null,
   analysis: null,
   metadata: null,

--- a/packages/2019-housing/src/components/AduDistributions/aduDistributionsMeta.js
+++ b/packages/2019-housing/src/components/AduDistributions/aduDistributionsMeta.js
@@ -10,7 +10,7 @@ const AduDistributionsMeta = (/* data */) => ({
   visualization: AduDistributionsVisualization, // data, isLoading are passed to this as props
   additionalText: <p>ADDITIONAL TEXT: TBD</p>,
   shareText: "TODO: Add share text!",
-  tags: ["Housing", "Portland"],
+  tags: ["Housing", "Portland", "Chart", "Map"],
   selector: null,
   analysis: (
     <Collapsable>

--- a/packages/2019-housing/src/components/AduDistributions/index.js
+++ b/packages/2019-housing/src/components/AduDistributions/index.js
@@ -19,6 +19,7 @@ const AduDistributions = ({ init, data, Layout }) => {
 };
 
 AduDistributions.displayName = "AduDistributions";
+AduDistributions.tags = aduDistributionsMeta().tags;
 
 AduDistributions.propTypes = {
   init: PropTypes.func,

--- a/packages/2019-housing/src/components/BlackPopulationChange/blackPopulationChangeMeta.js
+++ b/packages/2019-housing/src/components/BlackPopulationChange/blackPopulationChangeMeta.js
@@ -17,7 +17,7 @@ const BlackPopulationChangeMeta = (/* data */) => ({
   visualization: BlackPopulationChangeVisualization, // data, isLoading are passed to this as props
   additionalText: <p>ADDITIONAL TEXT: TBD</p>,
   shareText: "TODO: Add share text!",
-  tags: ["Housing", "Portland"],
+  tags: ["Housing", "Race", "Map", "Portland"],
   selector: null,
   analysis: (
     <Collapsable>

--- a/packages/2019-housing/src/components/BlackPopulationChange/index.js
+++ b/packages/2019-housing/src/components/BlackPopulationChange/index.js
@@ -28,6 +28,7 @@ const BlackPopulationChange = ({ init, data, Layout }) => {
 };
 
 BlackPopulationChange.displayName = "BlackPopulationChange";
+BlackPopulationChange.tags = blackPopulationChangeMeta().tags;
 
 BlackPopulationChange.propTypes = {
   init: PropTypes.func,

--- a/packages/2019-housing/src/components/HolcRedlining/holcRedliningMeta.js
+++ b/packages/2019-housing/src/components/HolcRedlining/holcRedliningMeta.js
@@ -21,7 +21,7 @@ const HolcRedliningMeta = (/* data */) => ({
   visualization: HolcRedliningVisualization, // data, isLoading are passed to this as props
   additionalText: <p>ADDITIONAL TEXT: TBD</p>,
   shareText: "TODO: Add share text!",
-  tags: ["Housing", "Portland"],
+  tags: ["Housing", "Portland", "Map"],
   selector: null,
   analysis: (
     <Collapsable>

--- a/packages/2019-housing/src/components/HolcRedlining/index.js
+++ b/packages/2019-housing/src/components/HolcRedlining/index.js
@@ -17,6 +17,7 @@ const HolcRedlining = ({ init, data, Layout }) => {
 };
 
 HolcRedlining.displayName = "HolcRedlining";
+HolcRedlining.tags = holcRedliningMeta().tags;
 
 HolcRedlining.propTypes = {
   init: PropTypes.func,

--- a/packages/2019-housing/src/components/HomeAppreciation/homeAppreciationMeta.js
+++ b/packages/2019-housing/src/components/HomeAppreciation/homeAppreciationMeta.js
@@ -10,7 +10,7 @@ const HomeAppreciationMeta = (/* data */) => ({
   visualization: HomeAppreciationVisualization, // data, isLoading are passed to this as props
   additionalText: <p>ADDITIONAL TEXT: TBD</p>,
   shareText: "TODO: Add share text!",
-  tags: ["Housing", "Portland"],
+  tags: ["Housing", "Portland", "Map"],
   selector: null,
   analysis: (
     <Collapsable>

--- a/packages/2019-housing/src/components/HomeAppreciation/index.js
+++ b/packages/2019-housing/src/components/HomeAppreciation/index.js
@@ -19,6 +19,7 @@ const HomeAppreciation = ({ init, data, Layout }) => {
 };
 
 HomeAppreciation.displayName = "HomeAppreciation";
+HomeAppreciation.tags = homeAppreciationMeta().tags;
 
 HomeAppreciation.propTypes = {
   init: PropTypes.func,

--- a/packages/2019-housing/src/components/HomeLoanApprovals/index.js
+++ b/packages/2019-housing/src/components/HomeLoanApprovals/index.js
@@ -26,6 +26,7 @@ const HomeLoanApprovals = ({ init, data, Layout }) => {
 };
 
 HomeLoanApprovals.displayName = "HomeLoanApprovals";
+HomeLoanApprovals.tags = homeLoanApprovalsMeta().tags;
 
 HomeLoanApprovals.propTypes = {
   init: PropTypes.func,

--- a/packages/2019-housing/src/components/HomeOwnershipRates/homeOwnershipRatesMeta.js
+++ b/packages/2019-housing/src/components/HomeOwnershipRates/homeOwnershipRatesMeta.js
@@ -18,7 +18,7 @@ const HomeOwnershipRatesMeta = (/* data */) => ({
   visualization: HomeOwnershipRatesVisualization, // data, isLoading are passed to this as props
   additionalText: <p>ADDITIONAL TEXT: TBD</p>,
   shareText: "TODO: Add share text!",
-  tags: ["Housing", "Portland"],
+  tags: ["Housing", "Race", "Portland", "Chart"],
   selector: null,
   analysis: (
     <Collapsable>

--- a/packages/2019-housing/src/components/HomeOwnershipRates/index.js
+++ b/packages/2019-housing/src/components/HomeOwnershipRates/index.js
@@ -19,6 +19,7 @@ const HomeOwnershipRates = ({ init, data, Layout }) => {
 };
 
 HomeOwnershipRates.displayName = "HomeOwnershipRates";
+HomeOwnershipRates.tags = homeOwnershipRatesMeta().tags;
 
 HomeOwnershipRates.propTypes = {
   init: PropTypes.func,

--- a/packages/2019-housing/src/components/HouseholdIncomeByRace/householdIncomeByRaceMeta.js
+++ b/packages/2019-housing/src/components/HouseholdIncomeByRace/householdIncomeByRaceMeta.js
@@ -25,7 +25,7 @@ const HouseholdIncomeByRaceMeta = (/* data */) => ({
   visualization: HouseholdIncomeByRaceVisualization, // data, isLoading are passed to this as props
   additionalText: <p>ADDITIONAL TEXT: TBD</p>,
   shareText: "TODO: Add share text!",
-  tags: ["Housing", "Portland"],
+  tags: ["Housing", "Race", "Chart", "Portland"],
   selector: null,
   analysis: (
     <Collapsable>

--- a/packages/2019-housing/src/components/HouseholdIncomeByRace/index.js
+++ b/packages/2019-housing/src/components/HouseholdIncomeByRace/index.js
@@ -23,6 +23,7 @@ const HouseholdIncomeByRace = ({ init, data, Layout }) => {
 };
 
 HouseholdIncomeByRace.displayName = "HouseholdIncomeByRace";
+HouseholdIncomeByRace.tags = householdIncomeByRaceMeta().tags;
 
 HouseholdIncomeByRace.propTypes = {
   init: PropTypes.func,

--- a/packages/2019-housing/src/components/HousingDisplacement/housingDisplacementMeta.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/housingDisplacementMeta.js
@@ -18,7 +18,7 @@ const HousingDisplacementMeta = (/* data */) => ({
   visualization: HousingDisplacementVisualization, // data, isLoading are passed to this as props
   additionalText: <p>ADDITIONAL TEXT: TBD</p>,
   shareText: "TODO: Add share text!",
-  tags: ["Housing", "Portland"],
+  tags: ["Housing", "Race", "Portland", "Chart"],
   selector: null,
   analysis: (
     <Collapsable>

--- a/packages/2019-housing/src/components/HousingDisplacement/index.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/index.js
@@ -31,6 +31,7 @@ const HousingDisplacement = ({ init, data, Layout }) => {
 };
 
 HousingDisplacement.displayName = "HousingDisplacement";
+HousingDisplacement.tags = housingDisplacementMeta().tags;
 
 HousingDisplacement.propTypes = {
   init: PropTypes.func,

--- a/packages/2019-template/src/components/DemoCard/demoCardMeta.js
+++ b/packages/2019-template/src/components/DemoCard/demoCardMeta.js
@@ -45,14 +45,7 @@ const demoCardMeta = (/* data */) => ({
   ),
   shareText:
     "TriMet has cited economic displacement as a main driver of ridership loss",
-  tags: [
-    "Transportation",
-    "Housing",
-    "Gentrification",
-    "Transit",
-    "Portland",
-    "Demo"
-  ],
+  tags: ["Transportation", "Housing", "Race", "Portland", "Chart"],
   selector: null,
   analysis: (
     <Collapsable>

--- a/packages/2019-template/src/components/TemplateFileCard/index.js
+++ b/packages/2019-template/src/components/TemplateFileCard/index.js
@@ -31,7 +31,6 @@ class TemplateFileCard extends Component {
 }
 
 TemplateFileCard.displayName = "TemplateFileCard";
-TemplateFileCard.tags = TemplateFileCardMeta().tags
 
 TemplateFileCard.propTypes = {
   init: PropTypes.func,

--- a/packages/2019-transportation/src/components/DisturbanceStops/disturbanceStopsMeta.js
+++ b/packages/2019-transportation/src/components/DisturbanceStops/disturbanceStopsMeta.js
@@ -31,9 +31,7 @@ const DisturbanceStopsMeta = (/* data */) => ({
   ),
   shareText:
     "Ice cream candy canes brownie marzipan jelly chocolate bar marshmallow.",
-  tags: [
-    /* "Transportation", "Bus", "Rail", "Portland" */
-  ],
+  tags: ["Transportation", "Portland", "Map"],
   selector: null,
   analysis: (
     <Collapsable>

--- a/packages/2019-transportation/src/components/DisturbanceStops/index.js
+++ b/packages/2019-transportation/src/components/DisturbanceStops/index.js
@@ -19,6 +19,7 @@ const DisturbanceStops = ({ init, data, Layout }) => {
 };
 
 DisturbanceStops.displayName = "DisturbanceStops";
+DisturbanceStops.tags = disturbanceStopsMeta().tags;
 
 DisturbanceStops.propTypes = {
   init: PropTypes.func,

--- a/packages/component-library/src/CardList/CardList.js
+++ b/packages/component-library/src/CardList/CardList.js
@@ -267,7 +267,7 @@ const CardList = ({ CardRegistry, tagsList = tagsListExample }) => {
           </Hidden>
         </nav>
         <main className={classes.content}>
-          <h1>Did you know?</h1>
+          <h1>Cards Under Construction</h1>
           <section className={classes.filtersButton}>
             <Button aria-label="open filters list" onClick={handleDrawerToggle}>
               Filter Stories


### PR DESCRIPTION
Add tags to all current cards so that they show up on the /cards page

This will show the current state of the content for all cards. Which may spur some action :)