### PR TITLE
Add Mapbox Pencil style as an option to the BaseMap

### DIFF
--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -17,7 +17,13 @@ import { isEqual } from "lodash";
 import mapboxgl from "./mapboxgl";
 import { MapGLResources } from "../_Themes/index";
 
-const { MAPBOX_TOKEN, CIVIC_LIGHT, CIVIC_DARK, DISASTER_GAME } = MapGLResources;
+const {
+  MAPBOX_TOKEN,
+  CIVIC_LIGHT,
+  CIVIC_DARK,
+  CIVIC_PENCIL,
+  DISASTER_GAME
+} = MapGLResources;
 
 const mapWrapper = css`
   margin: 0 auto;
@@ -201,6 +207,8 @@ class BaseMap extends Component {
     let baseMapboxStyleURL = CIVIC_LIGHT;
     if (civicMapStyle === "dark") {
       baseMapboxStyleURL = CIVIC_DARK;
+    } else if (civicMapStyle === "pencil") {
+      baseMapboxStyleURL = CIVIC_PENCIL;
     } else if (civicMapStyle === "disaster-game") {
       baseMapboxStyleURL = DISASTER_GAME;
     }
@@ -284,7 +292,7 @@ BaseMap.propTypes = {
   containerHeight: PropTypes.number,
   containerWidth: PropTypes.number,
   mapboxToken: PropTypes.string,
-  civicMapStyle: PropTypes.string,
+  civicMapStyle: PropTypes.oneOf(["light", "dark", "pencil", "disaster-game"]),
   navigation: PropTypes.bool,
   locationMarker: PropTypes.bool,
   locationMarkerCoord: PropTypes.shape({

--- a/packages/component-library/src/_Themes/MapGL/remoteResources.js
+++ b/packages/component-library/src/_Themes/MapGL/remoteResources.js
@@ -4,5 +4,6 @@ export default {
   // Hosted Themes
   CIVIC_LIGHT: "mapbox://styles/hackoregon/cjiazbo185eib2srytwzleplg",
   CIVIC_DARK: "mapbox://styles/mapbox/dark-v9",
+  CIVIC_PENCIL: "mapbox://styles/hackoregon/ck0blt1d63wrm1cqhcnccrf9s",
   DISASTER_GAME: "mapbox://styles/hackoregon/cjzki4sok5wgd1cmxadz9xdxi"
 };

--- a/packages/component-library/stories/BaseMap.story.js
+++ b/packages/component-library/stories/BaseMap.story.js
@@ -22,7 +22,9 @@ const GROUP_IDS = {
 
 const MAP_STYLE_OPTIONS = {
   light: "light",
-  dark: "dark"
+  dark: "dark",
+  disaster: "disaster-game",
+  pencil: "pencil"
 };
 
 const ZOOM_OPTIONS = {


### PR DESCRIPTION
This is **not important for demo day** -- We were thinking about using this in Housing & decided against it, but already set it up so I wanted to make a PR before it gets lost

Adds the "Pencil" style as an option to the base map. 

![Screen Shot 2019-09-09 at 7 04 04 PM](https://user-images.githubusercontent.com/9246015/64578618-ccd85300-d334-11e9-9e24-367126032644.png)
