### PR TITLE
More ComparisonMap Improvements

### DIFF
--- a/packages/component-library/src/ComparisonMap/ComparisonMap.js
+++ b/packages/component-library/src/ComparisonMap/ComparisonMap.js
@@ -10,8 +10,10 @@ const ComparisonMap = props => {
     initialViewport,
     leftMap,
     leftMapTitle,
+    leftTitleColor,
     rightMap,
     rightMapTitle,
+    rightTitleColor,
     showDivider,
     sliderStartPosition
   } = props;
@@ -73,17 +75,32 @@ const ComparisonMap = props => {
     box-shadow: -3px 0px 4px gray;
   `;
 
-  const mapTitleWrapper = css`
-    padding: 5px 10px 0 10px;
-    display: flex;
-    justify-content: space-between;
-  `;
-
-  const titleStyle = css`
+  const leftTitleStyle = css`
+    z-index: 1;
+    position: absolute;
     font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, sans-serif;
     font-size: 18px;
     font-weight: bold;
     margin: 0;
+
+    // Left Specific Formatting
+    right: calc(100% - ${sliderPosition}% + 20px);
+    color: ${leftTitleColor};
+    text-align: right;
+  `;
+
+  const rightTitleStyle = css`
+    z-index: 1;
+    position: absolute;
+    font-family: "Roboto Condensed", "Helvetica Neue", Helvetica, sans-serif;
+    font-size: 18px;
+    font-weight: bold;
+    margin: 0;
+
+    // Right Specific Formatting
+    left: calc(${sliderPosition}% + 20px);
+    color: ${rightTitleColor};
+    text-align: left;
   `;
 
   const sliderMin = 5;
@@ -100,10 +117,8 @@ const ComparisonMap = props => {
   return (
     <div css={container}>
       <div css={mapsWrapper}>
-        <div css={mapTitleWrapper}>
-          {leftMapTitle && <h2 css={titleStyle}>{leftMapTitle}</h2>}
-          {rightMapTitle && <h2 css={titleStyle}>{rightMapTitle}</h2>}
-        </div>
+        {leftMapTitle && <h2 css={leftTitleStyle}>{leftMapTitle}</h2>}
+        {rightMapTitle && <h2 css={rightTitleStyle}>{rightMapTitle}</h2>}
         {showDivider && <div css={divider} />}
         <div css={sliderWrapper}>
           <CompareSlider
@@ -127,8 +142,10 @@ ComparisonMap.propTypes = {
   initialViewport: shape({}),
   leftMap: node.isRequired,
   leftMapTitle: string,
+  leftTitleColor: string,
   rightMap: node.isRequired,
   rightMapTitle: string,
+  rightTitleColor: string,
   showDivider: bool,
   sliderStartPosition: number
 };
@@ -136,7 +153,9 @@ ComparisonMap.propTypes = {
 ComparisonMap.defaultProps = {
   height: 550,
   leftMapTitle: "",
+  leftTitleColor: "black",
   rightMapTitle: "",
+  rightTitleColor: "black",
   showDivider: true,
   sliderStartPosition: 50
 };

--- a/packages/component-library/src/ComparisonMap/ComparisonMap.js
+++ b/packages/component-library/src/ComparisonMap/ComparisonMap.js
@@ -65,10 +65,12 @@ const ComparisonMap = props => {
   const divider = css`
     z-index: 1;
     position: absolute;
-    left: calc(${sliderPosition}% - 1px); // The 1px is to adjust for the border
-    width: 0px;
+    left: calc(${sliderPosition}% - 1.5px); // 1.5px is to adjust for the border
+    width: 0;
+    background: white;
     height: ${height}px;
-    border: 1px solid white;
+    border-left: 3px solid white;
+    box-shadow: -3px 0px 4px gray;
   `;
 
   const mapTitleWrapper = css`

--- a/packages/component-library/stories/ComparisonMap.story.js
+++ b/packages/component-library/stories/ComparisonMap.story.js
@@ -105,6 +105,17 @@ export default () =>
         const leftMapTitle = text("Map Title - Left", "", GROUP_IDS.DESIGN);
         const rightMapTitle = text("Map Title - Right", "", GROUP_IDS.DESIGN);
 
+        const leftTitleColor = text(
+          "Map color - Left",
+          "black",
+          GROUP_IDS.DESIGN
+        );
+        const rightTitleColor = text(
+          "Title Color - Right",
+          "white",
+          GROUP_IDS.DESIGN
+        );
+
         const onLayerClick = info => action("Layer Clicked:")(info);
         const fetchURL = text("Data API URL:", API_URL, GROUP_IDS.DATA);
 
@@ -170,8 +181,10 @@ export default () =>
                   initialViewport={initialViewport}
                   leftMap={leftMap}
                   leftMapTitle={leftMapTitle}
+                  leftTitleColor={leftTitleColor}
                   rightMap={rightMap}
                   rightMapTitle={rightMapTitle}
+                  rightTitleColor={rightTitleColor}
                   showDivider={showDivider}
                   sliderStartPosition={sliderStartPosition}
                 />


### PR DESCRIPTION
Update the Comparison map based on feedback from the housing team:
- Make the divider a little bigger & give it some shadow
- Move the Left/Right map titles into the map on either side of the divider & have them move with the map
- Add a prop to configure the color of the map titles so they work on either dark or light maps

<img width="1048" alt="Screen Shot 2019-09-10 at 2 55 52 AM" src="https://user-images.githubusercontent.com/9246015/64604193-94f1ff80-d376-11e9-808c-3e7a41f3ed5c.png">
<img width="1042" alt="Screen Shot 2019-09-10 at 2 56 05 AM" src="https://user-images.githubusercontent.com/9246015/64604211-9d4a3a80-d376-11e9-9899-e6b2aacdbacb.png">
<img width="1039" alt="Screen Shot 2019-09-10 at 2 55 25 AM" src="https://user-images.githubusercontent.com/9246015/64604234-a5a27580-d376-11e9-9379-808083d302bb.png">
