### PR TITLE
add the year as the comparison map titles

### DIFF
--- a/packages/2019-transportation/src/components/DisturbanceStops/SoutheastHawthorneComparisonMap.js
+++ b/packages/2019-transportation/src/components/DisturbanceStops/SoutheastHawthorneComparisonMap.js
@@ -146,7 +146,11 @@ const SoutheastHawthorneComparisonMap = () => {
     <>
       <ComparisonMap
         leftMap={DisturbanceStopsMap2017}
+        leftMapTitle="2017"
+        leftTitleColor="black !important"
         rightMap={DisturbanceStopsMap2018}
+        rightMapTitle="2018"
+        rightTitleColor="white !important"
       />
     </>
   ) : null;

--- a/packages/2019-transportation/src/components/DisturbanceStops/SoutheastHawthorneComparisonMap.js
+++ b/packages/2019-transportation/src/components/DisturbanceStops/SoutheastHawthorneComparisonMap.js
@@ -143,7 +143,7 @@ const SoutheastHawthorneComparisonMap = () => {
   ) : null;
 
   return data.loaded ? (
-    <>
+    <div style={{ marginBottom: "16px" }}>
       <ComparisonMap
         height={500}
         leftMap={DisturbanceStopsMap2017}
@@ -153,7 +153,8 @@ const SoutheastHawthorneComparisonMap = () => {
         rightMapTitle="2018"
         rightTitleColor="white !important"
       />
-    </>
+      `
+    </div>
   ) : null;
 };
 

--- a/packages/2019-transportation/src/components/DisturbanceStops/SoutheastHawthorneComparisonMap.js
+++ b/packages/2019-transportation/src/components/DisturbanceStops/SoutheastHawthorneComparisonMap.js
@@ -145,6 +145,7 @@ const SoutheastHawthorneComparisonMap = () => {
   return data.loaded ? (
     <>
       <ComparisonMap
+        height={500}
         leftMap={DisturbanceStopsMap2017}
         leftMapTitle="2017"
         leftTitleColor="black !important"

--- a/packages/2019-transportation/src/components/NorthwestEverett/NorthwestEverettComparisonMap.js
+++ b/packages/2019-transportation/src/components/NorthwestEverett/NorthwestEverettComparisonMap.js
@@ -123,7 +123,7 @@ const NorthwestEverettComparisonMap = () => {
     );
   }, [disturbanceStops2019]);
 
-  const DisturbanceStopsMap2017 = disturbanceStops2018Extent.length ? (
+  const DisturbanceStopsMap2018 = disturbanceStops2018Extent.length ? (
     <BaseMap
       {...baseMapProps}
       civicMapStyle="light"
@@ -131,7 +131,7 @@ const NorthwestEverettComparisonMap = () => {
       mapboxLayerOptions={heatmapLayer2017}
     />
   ) : null;
-  const DisturbanceStopsMap2018 = disturbanceStops2019Extent.length ? (
+  const DisturbanceStopsMap2019 = disturbanceStops2019Extent.length ? (
     <BaseMap
       {...baseMapProps}
       civicMapStyle="dark"
@@ -143,8 +143,12 @@ const NorthwestEverettComparisonMap = () => {
   return data.loaded ? (
     <>
       <ComparisonMap
-        leftMap={DisturbanceStopsMap2017}
-        rightMap={DisturbanceStopsMap2018}
+        leftMap={DisturbanceStopsMap2018}
+        leftMapTitle="2018"
+        leftTitleColor="black !important"
+        rightMap={DisturbanceStopsMap2019}
+        rightMapTitle="2019"
+        rightTitleColor="white !important"
       />
     </>
   ) : null;

--- a/packages/2019-transportation/src/components/NorthwestEverett/NorthwestEverettComparisonMap.js
+++ b/packages/2019-transportation/src/components/NorthwestEverett/NorthwestEverettComparisonMap.js
@@ -143,6 +143,7 @@ const NorthwestEverettComparisonMap = () => {
   return data.loaded ? (
     <>
       <ComparisonMap
+        height={500}
         leftMap={DisturbanceStopsMap2018}
         leftMapTitle="2018"
         leftTitleColor="black !important"

--- a/packages/2019-transportation/src/components/NorthwestEverett/NorthwestEverettComparisonMap.js
+++ b/packages/2019-transportation/src/components/NorthwestEverett/NorthwestEverettComparisonMap.js
@@ -141,7 +141,7 @@ const NorthwestEverettComparisonMap = () => {
   ) : null;
 
   return data.loaded ? (
-    <>
+    <div style={{ marginBottom: "16px" }}>
       <ComparisonMap
         height={500}
         leftMap={DisturbanceStopsMap2018}
@@ -151,7 +151,7 @@ const NorthwestEverettComparisonMap = () => {
         rightMapTitle="2019"
         rightTitleColor="white !important"
       />
-    </>
+    </div>
   ) : null;
 };
 

--- a/packages/2019-transportation/src/components/SouthwestMadison/SouthwestMadisonComparisonMap.js
+++ b/packages/2019-transportation/src/components/SouthwestMadison/SouthwestMadisonComparisonMap.js
@@ -123,7 +123,7 @@ const SouthwestMadisonComparisonMap = () => {
     );
   }, [disturbanceStops2019]);
 
-  const DisturbanceStopsMap2017 = disturbanceStops2017Extent.length ? (
+  const DisturbanceStopsMap2018 = disturbanceStops2017Extent.length ? (
     <BaseMap
       {...baseMapProps}
       civicMapStyle="light"
@@ -131,7 +131,7 @@ const SouthwestMadisonComparisonMap = () => {
       mapboxLayerOptions={heatmapLayer2017}
     />
   ) : null;
-  const DisturbanceStopsMap2018 = disturbanceStops2018Extent.length ? (
+  const DisturbanceStopsMap2019 = disturbanceStops2018Extent.length ? (
     <BaseMap
       {...baseMapProps}
       civicMapStyle="dark"
@@ -143,8 +143,12 @@ const SouthwestMadisonComparisonMap = () => {
   return data.loaded ? (
     <>
       <ComparisonMap
-        leftMap={DisturbanceStopsMap2017}
-        rightMap={DisturbanceStopsMap2018}
+        leftMap={DisturbanceStopsMap2018}
+        leftMapTitle="2018"
+        leftTitleColor="black !important"
+        rightMap={DisturbanceStopsMap2019}
+        rightMapTitle="2019"
+        rightTitleColor="white !important"
       />
     </>
   ) : null;

--- a/packages/2019-transportation/src/components/SouthwestMadison/SouthwestMadisonComparisonMap.js
+++ b/packages/2019-transportation/src/components/SouthwestMadison/SouthwestMadisonComparisonMap.js
@@ -143,6 +143,7 @@ const SouthwestMadisonComparisonMap = () => {
   return data.loaded ? (
     <>
       <ComparisonMap
+        height={500}
         leftMap={DisturbanceStopsMap2018}
         leftMapTitle="2018"
         leftTitleColor="black !important"

--- a/packages/2019-transportation/src/components/SouthwestMadison/SouthwestMadisonComparisonMap.js
+++ b/packages/2019-transportation/src/components/SouthwestMadison/SouthwestMadisonComparisonMap.js
@@ -141,7 +141,7 @@ const SouthwestMadisonComparisonMap = () => {
   ) : null;
 
   return data.loaded ? (
-    <>
+    <div style={{ marginBottom: "16px" }}>
       <ComparisonMap
         height={500}
         leftMap={DisturbanceStopsMap2018}
@@ -151,7 +151,7 @@ const SouthwestMadisonComparisonMap = () => {
         rightMapTitle="2019"
         rightTitleColor="white !important"
       />
-    </>
+    </div>
   ) : null;
 };
 


### PR DESCRIPTION
i had to throw an important tag on these. CivicStoryCard's h2 style is more specific than the style defined in the comparison map, overriding it.