### PR TITLE
Add distribution to sandbox legend

### DIFF
--- a/packages/civic-sandbox/src/state/sandbox/index.js
+++ b/packages/civic-sandbox/src/state/sandbox/index.js
@@ -102,23 +102,11 @@ const reducer = (state = INITIAL_STATE, action) => {
         slidesError: null
       };
     case SLIDES_SUCCESS: {
-      console.log("a-SLIDES_SUCCESS");
-      // console.log("a-SLIDES_SUCCESS-state.slidesData:", state.slidesData);
-      // console.log("a-SLIDES_SUCCESS-payload:", action.payload);
       return {
         ...state,
         slidesPending: false,
         slidesError: null,
         slidesSuccess: true,
-        // slidesData: state.slidesData.length
-        //   ? [
-        //       ...state.slidesData.map(d => {
-        //         return d.displayName === action.payload[0].displayName
-        //           ? action.payload[0]
-        //           : d;
-        //       })
-        //     ]
-        //   : [...state.slidesData, ...action.payload]
         slidesData: [...action.payload]
       };
     }

--- a/packages/component-library/src/Sandbox/Sandbox.js
+++ b/packages/component-library/src/Sandbox/Sandbox.js
@@ -17,10 +17,15 @@ import SandboxDrawer from "./SandboxDrawer";
 
 const baseMapWrapper = css(`
   height: 80vh;
-  min-height: 700px;
+  min-height: 650px;
   @media (max-width: 850px) {
-    height: 65vh;
-    min-height: 550px;
+    height: 80vh;
+    min-height: 600px;
+  }
+  @media (max-width: 500px) {
+    width: 100%;
+    height: 75vh;
+    min-height: 390px;
   }
 `);
 
@@ -68,11 +73,16 @@ const Sandbox = ({
           padding: 0;
           margin: 0;
           width: 100%;
-          height: 75vh;
-          min-height: 600px;
+          height: 80vh;
+          min-height: 650px;
           @media (max-width: 850px) {
-            height: 60vh;
-            min-height: 500px;
+            height: 80vh;
+            min-height: 600px;
+          }
+          @media (max-width: 500px) {
+            width: 100%;
+            height: 75vh;
+            min-height: 390px;
           }
         `}
       >

--- a/packages/component-library/src/Sandbox/SandboxDrawer.js
+++ b/packages/component-library/src/Sandbox/SandboxDrawer.js
@@ -16,19 +16,20 @@ const menuOpen = css(`
   position: absolute;
   top: 0;
   right: 0;
-  height: 75vh;
+  height: 78vh;
+  min-height: 640px;
   width: 33%;
   z-index: 5;
   transition: 0.5s;
   @media (max-width: 850px) {
     width: 95%;
-    height: 64vh;
-    min-height: 550px;
+    height: 78vh;
+    min-height: 590px;
   }
   @media (max-width: 500px) {
     width: 100%;
-    height: 64vh;
-    min-height: 550px;
+    height: 75vh;
+    min-height: 390px;
   }
 `);
 


### PR DESCRIPTION
This improves the legend for the maps by displaying the distribution of the color categories.

![Screenshot_2019-09-10-1](https://user-images.githubusercontent.com/9361258/64661134-4dac5300-d3f8-11e9-89ab-82b305d57782.png)

