### PR TITLE
Fix distribution chart on chrome

### DIFF
--- a/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
+++ b/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
@@ -32,8 +32,9 @@ const container = css`
   border-radius: 2px;
   box-shadow: 5px 5px 15px -3px rgba(0, 0, 0, 0.2);
   @media (max-width: 900px) {
-    width: 92%;
-    left: 1%;
+    width: 90%;
+    bottom: 30px;
+    left: 8%;
   }
 `;
 
@@ -43,6 +44,9 @@ const dashboardOpen = css`
   overflow-x: hidden;
   opacity: 0.9;
   transition: height 750ms ease-out, opacity 1.5s ease-in;
+  @media (max-width: 500px) {
+    height: 265px;
+  }
 `;
 
 const dashboardClosed = css`
@@ -74,6 +78,7 @@ const toggleContainer = css`
 `;
 
 const toggleTitle = css`
+  font-size: 17px;
   flex: 3;
   margin auto 20px;
 `;
@@ -189,7 +194,7 @@ const createLineViz = (data, title, xLabel, yLabel, xFormat, yFormat) => {
   const yForm = yFormat === "percent" ? "percentage" : yFormat;
   return (
     <div css={viz} key={shortid.generate()}>
-      <h2>{title}</h2>
+      <h3>{title}</h3>
       <LineChart
         data={data}
         xLabel={xLabel}

--- a/packages/component-library/src/Sandbox/SandboxMapLegend.js
+++ b/packages/component-library/src/Sandbox/SandboxMapLegend.js
@@ -16,7 +16,7 @@ const legendHeight = 65;
 const legendContainer = css(`
   margin: 0.5rem 5% 1rem 5%;
   display: flex;
-  align-items: end;
+  align-items: baseline;
   flex-wrap: nowrap;
   height: ${legendHeight}px;
   width: 90%;


### PR DESCRIPTION
This addresses an issue with the distribution chart in the side menu. 

In chrome, the bars are point down:
![CIVIC_Platform](https://user-images.githubusercontent.com/9361258/64713245-63119380-d471-11e9-8619-76892b635ae2.png)

This fixes that and makes some adjustments to the dashboard.