### PR TITLE
Update react-router to 3.2.4 for new React feature support

### DIFF
--- a/_templates/package-generator/with-prompt/package.ejs.t
+++ b/_templates/package-generator/with-prompt/package.ejs.t
@@ -52,7 +52,7 @@ to: packages/<%=year%>-<%=packageTitle%>/package.json
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2017/package.json
+++ b/packages/2017/package.json
@@ -45,7 +45,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "react-typekit": "^1.1.3",
     "redux": "^4.0.1",

--- a/packages/2018-disaster-resilience/package.json
+++ b/packages/2018-disaster-resilience/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^16.8.4",
     "react-mathjax": "^1.0.1",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2018-example-farmers-markets/package.json
+++ b/packages/2018-example-farmers-markets/package.json
@@ -45,7 +45,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2018-housing-affordability/package.json
+++ b/packages/2018-housing-affordability/package.json
@@ -47,7 +47,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2018-local-elections/package.json
+++ b/packages/2018-local-elections/package.json
@@ -47,7 +47,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2018-neighborhood-development/package.json
+++ b/packages/2018-neighborhood-development/package.json
@@ -48,7 +48,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2018-transportation-systems/package.json
+++ b/packages/2018-transportation-systems/package.json
@@ -46,7 +46,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2018/package.json
+++ b/packages/2018/package.json
@@ -51,7 +51,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "react-typekit": "^1.1.3",
     "redux": "^4.0.1",

--- a/packages/2019-education/package.json
+++ b/packages/2019-education/package.json
@@ -49,7 +49,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2019-elections/package.json
+++ b/packages/2019-elections/package.json
@@ -48,7 +48,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2019-housing/package.json
+++ b/packages/2019-housing/package.json
@@ -50,7 +50,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2019-template/package.json
+++ b/packages/2019-template/package.json
@@ -47,7 +47,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/2019-transportation/package.json
+++ b/packages/2019-transportation/package.json
@@ -50,7 +50,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/budget/package.json
+++ b/packages/budget/package.json
@@ -48,7 +48,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "react-select": "^1.0.0-rc.3",
     "react-sticky": "^5.0.8",

--- a/packages/civic-sandbox/package.json
+++ b/packages/civic-sandbox/package.json
@@ -45,7 +45,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-form": "^8.1.0",

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -113,7 +113,7 @@
     "viewport-mercator-project": "^6.2.0"
   },
   "peerDependencies": {
-    "react-router": "^3.0.0"
+    "react-router": "^3.2.4"
   },
   "gitHead": "b50f7a7fca617964ade5a3ecb5225fee17b20fe4"
 }

--- a/packages/emergency-response/package.json
+++ b/packages/emergency-response/package.json
@@ -47,7 +47,7 @@
     "react-fontawesome": "^1.6.1",
     "react-player": "^0.15.0",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-devtools": "^3.3.2",

--- a/packages/homelessness/package.json
+++ b/packages/homelessness/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^16.8.4",
     "react-helmet": "^5.0.3",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-dom": "^4.1.1",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",

--- a/packages/housing/package.json
+++ b/packages/housing/package.json
@@ -53,7 +53,7 @@
     "react-dom": "^16.8.4",
     "react-helmet": "^5.0.3",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-dom": "^4.1.1",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",

--- a/packages/mock-wrapper/package.json
+++ b/packages/mock-wrapper/package.json
@@ -29,7 +29,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-thunk": "^2.1.0"

--- a/packages/project-disaster-trail/package.json
+++ b/packages/project-disaster-trail/package.json
@@ -53,7 +53,7 @@
     "react-circular-progressbar": "^2.0.1",
     "react-dom": "^16.8.4",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-dom": "^5.0.1",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",

--- a/packages/transportation/package.json
+++ b/packages/transportation/package.json
@@ -48,7 +48,7 @@
     "react-fontawesome": "^1.6.1",
     "react-player": "^0.15.0",
     "react-redux": "^6.0.1",
-    "react-router": "^3.0.0",
+    "react-router": "^3.2.4",
     "react-router-redux": "^4.0.8",
     "redux": "^4.0.1",
     "redux-devtools": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13488,16 +13488,18 @@ react-router@5.0.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.1.tgz#b9a3279962bdfbe684c8bd0482b81ef288f0f244"
+react-router@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.4.tgz#fdd415a062982e0c943f814efde506eae1418d0e"
+  integrity sha512-5kIJXV1Yx+FYk0lDJoPQnt+qFf7HxS6XrIm2aCw0r3XQTxixFd0HSVlHenYRWKmSHlcvSQ7bpYWgdRwJGXWPKw==
   dependencies:
     create-react-class "^15.5.1"
     history "^3.0.0"
     hoist-non-react-statics "^2.3.1"
     invariant "^2.2.1"
     loose-envify "^1.2.0"
-    prop-types "^15.5.6"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
     warning "^3.0.0"
 
 react-router@^4.3.1:


### PR DESCRIPTION
Per https://github.com/hackoregon/civic/issues/637#issuecomment-532546430 -- we were blocked by react-router from using some of the latest React and Redux features, but this release of react-router unblocks us.

After this upgrade, we should be able to update to Redux 7.1 for Redux hooks and use new React features such as React.Suspense and React.Memo.

