### PR TITLE
Constrain zoom level

### DIFF
--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -174,9 +174,30 @@ class BaseMap extends Component {
   };
 
   onViewportChange = viewport => {
-    this.setState(prevState => ({
-      viewport: { ...prevState.viewport, ...viewport }
-    }));
+    const { minZoom, maxZoom } = this.props;
+    const { zoom } = viewport;
+    if (zoom >= minZoom && zoom <= maxZoom) {
+      this.setState(prevState => ({
+        viewport: {
+          ...prevState.viewport,
+          ...viewport
+        }
+      }));
+    } else if (zoom < minZoom) {
+      this.setState(prevState => ({
+        viewport: {
+          ...prevState.viewport,
+          zoom: minZoom
+        }
+      }));
+    } else if (zoom > maxZoom) {
+      this.setState(prevState => ({
+        viewport: {
+          ...prevState.viewport,
+          zoom: maxZoom
+        }
+      }));
+    }
   };
 
   render() {

--- a/packages/component-library/stories/BaseMap.story.js
+++ b/packages/component-library/stories/BaseMap.story.js
@@ -84,7 +84,7 @@ export default () =>
           "CIVIC Map Styles:",
           MAP_STYLE_OPTIONS,
           MAP_STYLE_OPTIONS["Hack Oregon Dark"],
-          GROUP_IDS.DESIGN
+          GROUP_IDS.CUSTOM
         );
 
         const initialLongitude = number(


### PR DESCRIPTION
This fixes the bug in #1048.

It clamps the zoom level so that the `minZoom` and `maxZoom` are respected.




