### PR TITLE
Fix production build of the disaster game

### DIFF
--- a/packages/2019-disaster-game/src/components/Game/KitScreen/index.js
+++ b/packages/2019-disaster-game/src/components/Game/KitScreen/index.js
@@ -91,6 +91,7 @@ const KitScreen = ({
         <div css={[bg, bg2]} />
         <div css={[bg, bg3]} />
         <Kit />
+        {/* somehow adding this comment fixes the production build -- it's related to @babel/plugin-transform-react-constant-elements */}
       </MapStyle>
       <MatchLockInterface
         possibleItems={possibleItems}


### PR DESCRIPTION
Something was going on with the production build of the disaster game, and it was weird. But, this fixes it.

Removing @babel/plugin-transform-react-constant-elements also would resolve this, at a significant hit to performance.

I would *love* to know what's happening here, but it took me forever to track down this issue, and I should move on to other thing.