### PR TITLE
check if authors not null

### DIFF
--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -327,7 +327,7 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
           >
             <h2>Who made this?</h2>
             {/* temporary implementation, length > 4 to exclude authors: "demo" */}
-            {cardMeta.authors.length > 4 && (
+            {cardMeta.authors && cardMeta.authors.length > 4 && (
               <Fragment>
                 <h3>Primary Authors</h3>
                 <ul>


### PR DESCRIPTION
This fixes a bug that can be seen at http://civicplatform.org/cards/you-and-your-neighbors-in-the-earthquake