### PR TITLE
Offline tile server support for Earthquake Heroes

### DIFF
--- a/packages/2019-disaster-game/server/dev.js
+++ b/packages/2019-disaster-game/server/dev.js
@@ -1,1 +1,2 @@
-require("@hackoregon/dev-server")();
+const { TILESERVER } = process.env;
+require("@hackoregon/dev-server")(TILESERVER ? { TILESERVER } : {});

--- a/packages/2019-disaster-game/server/index.js
+++ b/packages/2019-disaster-game/server/index.js
@@ -8,6 +8,11 @@ const app = express();
 const isProd = process.env.NODE_ENV === "production";
 const outputPath = resolve(process.cwd(), isProd ? "dist" : "build");
 
+const config = {};
+if (process.env.TILESERVER) {
+  config.TILESERVER = process.env.TILESERVER;
+}
+
 // eslint-disable-next-line no-console
 console.log(chalk.gray("\nStarting the production server..."));
 
@@ -33,6 +38,9 @@ app.get(
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta charset="utf-8"/>
+    <meta name="config/environment" content="${encodeURIComponent(
+      JSON.stringify(config)
+    )}">
     <style>html, body { padding: 0; margin: 0; }</style>
     <!-- FontAwesome -->
     <script src="https://use.fontawesome.com/031ebbe0c7.js"></script>

--- a/packages/2019-disaster-game/src/components/Game/TaskScreen/VoteMapScreen.js
+++ b/packages/2019-disaster-game/src/components/Game/TaskScreen/VoteMapScreen.js
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 import { useEffect, useState, useCallback } from "react";
 import { BaseMap, IconMap } from "@hackoregon/component-library";
 import { getTaskLocations } from "../../../state/tasks";
+import { getTileServerApi } from "../../../state/settings";
 
 import {
   poiIconMapping,
@@ -30,6 +31,7 @@ const VoteMapScreen = ({
   activeTaskId,
   taskLocations,
   taskVotes,
+  tileServerApi,
   mapTransitionDuration
 }) => {
   const [longitude, setLongitude] = useState(initialLon);
@@ -37,6 +39,12 @@ const VoteMapScreen = ({
   const [data, setData] = useState(asGeoJSON(taskLocations));
 
   const getIcon = d => d.properties.id;
+
+  const offlineMapboxOptions = {};
+  if (tileServerApi) {
+    offlineMapboxOptions.mapboxApiUrl = tileServerApi;
+    offlineMapboxOptions.mapStyle = "mapbox://styles/disaster";
+  }
 
   // Returns a location that hasn't been completed if possible
   const getActiveTaskLocation = useCallback(
@@ -115,7 +123,8 @@ const VoteMapScreen = ({
           doubleClickZoom: false,
           touchZoom: false,
           touchRotate: false,
-          keyboard: false
+          keyboard: false,
+          ...offlineMapboxOptions
         }}
         animate
         animationDuration={mapTransitionDuration * 1000}
@@ -153,11 +162,13 @@ VoteMapScreen.propTypes = {
     mostVotesTotal: PropTypes.number,
     totalVotes: PropTypes.number
   }),
+  tileServerApi: PropTypes.string,
   mapTransitionDuration: PropTypes.number
 };
 
 const mapStateToProps = state => ({
-  taskLocations: getTaskLocations(state)
+  taskLocations: getTaskLocations(state),
+  tileServerApi: getTileServerApi(state)
 });
 
 export default connect(mapStateToProps)(VoteMapScreen);

--- a/packages/2019-disaster-game/src/constants/env.js
+++ b/packages/2019-disaster-game/src/constants/env.js
@@ -1,0 +1,18 @@
+// Static site configuration as set in the environment of the server
+// TODO: This is currently written under the assumption that this module
+// will be lazy-evaluated after the DOM is ready. This isn't necessarily
+// true and could lead to some bewildering debugging.
+const env = {};
+
+const configMetaEl = document.head.querySelector('[name="config/environment"]');
+if (configMetaEl) {
+  try {
+    Object.assign(env, JSON.parse(decodeURIComponent(configMetaEl.content)));
+  } catch (err) {
+    console.warn(
+      `Could not parse config/environment as JSON:\n\n${configMetaEl.content}`
+    );
+  }
+}
+
+export default env;

--- a/packages/2019-disaster-game/src/state/factories/SettingsFactory.js
+++ b/packages/2019-disaster-game/src/state/factories/SettingsFactory.js
@@ -1,5 +1,6 @@
 import * as SCREENS from "../../constants/screens";
 import * as MODES from "../../constants/modes";
+import ENV from "../../constants/env";
 
 class SETTINGS_FACTORY {}
 
@@ -18,6 +19,7 @@ SETTINGS_FACTORY.getInitialSettings = () => {
     maxVelocityX: -2,
     minVelocityY: 0,
     maxVelocityY: 0,
+    tileServerApi: ENV.TILESERVER,
     mode
   };
 

--- a/packages/2019-disaster-game/src/state/settings.js
+++ b/packages/2019-disaster-game/src/state/settings.js
@@ -45,3 +45,8 @@ export const getVelocityRange = createSelector(
     minVelocityX, minVelocityY, maxVelocityX, maxVelocityY;
   }
 );
+
+export const getTileServerApi = createSelector(
+  ["settings.tileServerApi"],
+  api => api
+);

--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -16,12 +16,21 @@ const hotMiddleware = require("webpack-hot-middleware");
 // eslint-disable-next-line import/no-dynamic-require
 const config = require(resolve(process.cwd(), "webpack.config.js"));
 
-module.exports = () => {
+module.exports = (localEnv = {}) => {
   console.log(
     chalk.yellow(
       `\nStarting the ${isProd ? `PRODUCTION` : `DEVELOPMENT`} server...`
     )
   );
+
+  // Static configuration that gets passed into the SPA via the
+  // config/environment meta element
+  const staticSiteConfig = Object.assign({}, localEnv);
+
+  if (Object.keys(staticSiteConfig).length) {
+    console.log(chalk.yellow(`\n\nStatic Site Config:`));
+    console.log(chalk.yellow(JSON.stringify(staticSiteConfig, null, 2)));
+  }
 
   const openBrowser = () =>
     isProd
@@ -73,6 +82,9 @@ module.exports = () => {
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <meta name="viewport" content="width=device-width,initial-scale=1">
       <meta charset="utf-8"/>
+      <meta name="config/environment" content="${encodeURIComponent(
+        JSON.stringify(staticSiteConfig)
+      )}">
       <style>html, body { padding: 0; margin: 0; }</style>
       <!-- FontAwesome -->
       <script src="https://use.fontawesome.com/031ebbe0c7.js"></script>


### PR DESCRIPTION
This adds conditional support for using a custom tileserver api. 

It's implemented in a manner that is optional and non-breaking. After this merges, running the game locally or at http://disastergame.civicplatform.org/ will continue to work as it always has been.

However, if you run the game with `TILESERVER` set in your environment, this value will be appended to the index.html file via the express server and made accessible via a selector in `state/settings`.

Example for local use:

```sh
$ TILESERVER=http://localhost:3456/tiles yarn start
```

You can also see how this will be used [on site at OMSI over here](https://github.com/hackoregon/earthquake-heroes-offline/blob/master/docker-compose.yml).