### PR TITLE
Fix getWeight default prop

### DIFF
--- a/packages/component-library/src/ScreenGridMap/ScreenGridMap.js
+++ b/packages/component-library/src/ScreenGridMap/ScreenGridMap.js
@@ -72,7 +72,7 @@ ScreenGridMap.defaultProps = {
   visible: true,
   gpuAggregation: false,
   getSize: () => 1,
-  getWeight: null,
+  getWeight: () => 1,
   getCursor: () => "crosshair"
 };
 


### PR DESCRIPTION
The [ScreenGridMap story](https://hackoregon.github.io/civic/?path=/story/component-lib-maps-screen-grid-map--standard) throws the following error:
```
deck: error while initializing ScreenGridLayer({id: 'screengrid-layer'})
 TypeError: "this.props.getWeight is not a function"
```

This fixes that by setting changing the default value for `getWeight` to `() => 1`.
