### PR TITLE
Feature/ui tweaks

### DIFF
--- a/packages/2019-disaster-game/src/components/Game/BetweenScreen/KitOutro.js
+++ b/packages/2019-disaster-game/src/components/Game/BetweenScreen/KitOutro.js
@@ -58,7 +58,6 @@ const messageStyle = css`
 `;
 
 const forgottenItem = css`
-  color: ${palette.purple};
   font-weight: 500;
   text-decoration: underline;
 `;

--- a/packages/2019-disaster-game/src/components/Game/KitScreen/index.js
+++ b/packages/2019-disaster-game/src/components/Game/KitScreen/index.js
@@ -99,7 +99,7 @@ const KitScreen = ({
       chapterTimer.reset();
       addPreparerBadge("prepared", "preparerBadge");
       setDisplayBadge(true);
-      chapterTimer.setDuration(9);
+      chapterTimer.setDuration(8);
       chapterTimer.addCompleteCallback(() => endChapter());
       chapterTimer.start();
     }

--- a/packages/2019-disaster-game/src/components/Game/TaskScreen/index.js
+++ b/packages/2019-disaster-game/src/components/Game/TaskScreen/index.js
@@ -232,7 +232,7 @@ const TaskScreenContainer = ({
     }
     if (earnedFinalBadge) {
       setDisplayedFinalBadge(true);
-      startTimer(5, false);
+      startTimer(8, false);
     }
   }, [
     endChapter,

--- a/packages/2019-disaster-game/src/components/atoms/NewBadge.js
+++ b/packages/2019-disaster-game/src/components/atoms/NewBadge.js
@@ -63,7 +63,7 @@ const NewBadge = ({ type, badges }) => {
     setBadgeInfo(badges[type]);
     const hideBadgeTimeout = setTimeout(() => {
       setHideBadge(true);
-    }, 4000);
+    }, 8000);
 
     return () => {
       clearTimeout(hideBadgeTimeout);

--- a/packages/2019-disaster-game/src/constants/style.js
+++ b/packages/2019-disaster-game/src/constants/style.js
@@ -1,6 +1,6 @@
 export const palette = {
   blue: "#068FB2",
-  blueRGBA: "rgba(6, 143, 178, 0.6)",
+  blueRGBA: "rgba(6, 143, 178, 0.8)",
   lightBlue: "#64CAE5",
   darkBlue: "#004366",
   gold: "#FBD403",


### PR DESCRIPTION
Displays badges for longer.

Makes modal background more opaque: 

<img width="812" alt="Screen Shot 2019-11-10 at 3 31 05 PM" src="https://user-images.githubusercontent.com/10056079/68552926-873a1400-03d1-11ea-9bdf-526ae0a78173.png">


Uses one font color in this message

<img width="809" alt="Screen Shot 2019-11-10 at 3 30 29 PM" src="https://user-images.githubusercontent.com/10056079/68552929-8a350480-03d1-11ea-996d-d5ee3b637007.png">
