### PR TITLE
Add ScreenGrid tooltip, implement in building damage map

### DIFF
--- a/packages/2018-disaster-resilience/src/components/EarthquakeDamageEstimatesForBuildingsInTillamookCounty/EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization.js
+++ b/packages/2018-disaster-resilience/src/components/EarthquakeDamageEstimatesForBuildingsInTillamookCounty/EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization.js
@@ -9,7 +9,9 @@ import {
   VisualizationColors,
   RadioButtonGroup,
   ScreenGridMap,
-  ChartContainer
+  MapTooltip,
+  ChartContainer,
+  civicFormat
 } from "@hackoregon/component-library";
 
 const EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization = ({
@@ -76,14 +78,37 @@ const EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization = ({
               civicMapStyle={mapStyles[dataType].map}
             >
               <ScreenGridMap
-                data={data.damageEstimates.value}
+                data={data.damageEstimates.value.filter(
+                  feature => feature.properties[mapStyles[dataType].field]
+                )}
                 getPosition={f => f.geometry && f.geometry.coordinates}
                 opacity={mapStyles[dataType].opacity}
-                getWeight={f => f.properties[mapStyles[dataType].field] || 0}
+                getWeight={f => f.properties[mapStyles[dataType].field]}
                 getSize={() => 15}
                 colorRange={VisualizationColors.sequential.thermal}
                 getCursor={() => "default"}
-              />
+                aggregation="SUM"
+              >
+                <MapTooltip
+                  tooltipDataArray={[
+                    {
+                      name: `Number of ${
+                        mapStyles[dataType].buildingType
+                      } buildings`,
+                      field: "cellCount",
+                      formatField: civicFormat.numeric
+                    },
+                    {
+                      name: `Average loss ratio`,
+                      field: "cellWeight",
+                      totalField: "cellCount",
+                      formatField: civicFormat.percentage
+                    }
+                  ]}
+                  isScreenGrid
+                  wide
+                />
+              </ScreenGridMap>
             </BaseMap>
             <Link to="/sandbox">See more in the Civic Sandbox</Link>
           </>

--- a/packages/2018-disaster-resilience/src/components/EarthquakeDamageEstimatesForBuildingsInTillamookCounty/EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization.js
+++ b/packages/2018-disaster-resilience/src/components/EarthquakeDamageEstimatesForBuildingsInTillamookCounty/EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization.js
@@ -6,7 +6,6 @@ import { Link } from "react-router";
 
 import {
   BaseMap,
-  VisualizationColors,
   RadioButtonGroup,
   ScreenGridMap,
   MapTooltip,
@@ -85,24 +84,35 @@ const EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization = ({
                 opacity={mapStyles[dataType].opacity}
                 getWeight={f => f.properties[mapStyles[dataType].field]}
                 getSize={() => 15}
-                colorRange={VisualizationColors.sequential.thermal}
+                colorRange={
+                  /* temporary implementation until #1152 is resolved */
+
+                  [
+                    [255, 255, 178],
+                    [254, 217, 118],
+                    [254, 178, 76],
+                    [253, 141, 60],
+                    [240, 59, 32],
+                    [189, 0, 38]
+                  ]
+                }
+                colorDomain={[0, 1]}
                 getCursor={() => "default"}
-                aggregation="SUM"
+                aggregation="MEAN"
               >
                 <MapTooltip
                   tooltipDataArray={[
+                    {
+                      name: `Average loss ratio`,
+                      field: "cellWeight",
+                      formatField: civicFormat.percentage
+                    },
                     {
                       name: `Number of ${
                         mapStyles[dataType].buildingType
                       } buildings`,
                       field: "cellCount",
                       formatField: civicFormat.numeric
-                    },
-                    {
-                      name: `Average loss ratio`,
-                      field: "cellWeight",
-                      totalField: "cellCount",
-                      formatField: civicFormat.percentage
                     }
                   ]}
                   isScreenGrid

--- a/packages/2018-disaster-resilience/src/components/EarthquakeDamageEstimatesForBuildingsInTillamookCounty/EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization.js
+++ b/packages/2018-disaster-resilience/src/components/EarthquakeDamageEstimatesForBuildingsInTillamookCounty/EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization.js
@@ -37,7 +37,7 @@ const EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization = ({
   return (
     <>
       <RadioButtonGroup
-        grpLabel="Type"
+        grpLabel="Building Type"
         labels={Object.keys(mapStyles)}
         value={dataType}
         onChange={event => {
@@ -48,8 +48,8 @@ const EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization = ({
       <p>
         {hasLoaded ? (
           <small>
-            Zoom for more granular details. A brighter color indicates more
-            costly damage.
+            Zoom for more granular details. A darker color indicates a greater
+            proportion of financial losses.
           </small>
         ) : (
           <small>
@@ -61,7 +61,7 @@ const EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization = ({
       <ChartContainer
         loading={!hasLoaded}
         title="Building Impact of a 9.0 Cascadia Earthquake"
-        subtitle={`Estimated financial damage to ${
+        subtitle={`Projected financial damage to ${
           mapStyles[dataType].buildingType
         } buildings in a Cascadia 9.0 earthquake.`}
       >

--- a/packages/2018-disaster-resilience/src/components/EarthquakeDamageEstimatesForBuildingsInTillamookCounty/earthquakeDamageEstimatesForBuildingsInTillamookCountyMeta.js
+++ b/packages/2018-disaster-resilience/src/components/EarthquakeDamageEstimatesForBuildingsInTillamookCounty/earthquakeDamageEstimatesForBuildingsInTillamookCountyMeta.js
@@ -9,8 +9,8 @@ const EarthquakeDamageEstimatesForBuildingsInTillamookCountyMeta = (/* data */) 
   introText: (
     <p>
       The severity of building damage from an earthquake varies depending on
-      building type. This card highlights opportunities for mitigation actions
-      that may reduce damages in residential and commercial structures.
+      building type. This visualization highlights opportunities for mitigation
+      actions that may reduce damages in residential and commercial structures.
     </p>
   ),
   visualization: EarthquakeDamageEstimatesForBuildingsInTillamookCountyVisualization, // data, isLoading are passed to this as props
@@ -25,7 +25,7 @@ const EarthquakeDamageEstimatesForBuildingsInTillamookCountyMeta = (/* data */) 
     </p>
   ),
   shareText:
-    "A Cascadia 9.0 earthquake event would likely produce devastating destruction of buildings in the Tillamook County area. We provide an interactive visualization of the projected financial damage to buildings as a loss ratio after such an event. The loss ratio of a building is the dollar cost of likely damages sustained during an earthquake divided by the total value of the building.",
+    "A Cascadia 9.0 earthquake event would likely produce devastating destruction of buildings in the Tillamook County area. This visualization shows projected financial damage to buildings in this scenario as a loss ratio — the dollar cost of damage divided by the total value of the building.",
   tags: [
     "Disaster Resilience",
     "Earthquake",

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -172,6 +172,7 @@ class BaseMap extends Component {
   }
 
   onHover = ({ object, x, y }) => {
+    console.log(object, x, y);
     this.setState({
       tooltipInfo: object,
       x,

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -172,7 +172,6 @@ class BaseMap extends Component {
   }
 
   onHover = ({ object, x, y }) => {
-    console.log(object, x, y);
     this.setState({
       tooltipInfo: object,
       x,

--- a/packages/component-library/src/MapTooltip/MapTooltip.js
+++ b/packages/component-library/src/MapTooltip/MapTooltip.js
@@ -11,6 +11,7 @@ const MapTooltip = props => {
     formatPrimaryField,
     formatSecondaryField,
     isHex,
+    isScreenGrid,
     primaryName,
     primaryField,
     secondaryName,
@@ -38,7 +39,7 @@ const MapTooltip = props => {
     x < get(window, "innerWidth", 1000) * 0.66
       ? x
       : x - get(window, "innerWidth", 1000) * 0.1;
-  const yPostition = y < 375 ? y : y - 50;
+  const yPosition = y < 375 ? y : y - 50;
 
   const getProperty = (property, formatFunction) => {
     if (formatFunction) {
@@ -52,7 +53,7 @@ const MapTooltip = props => {
       css={tooltip}
       style={{
         left: xPosition,
-        top: yPostition
+        top: yPosition
       }}
     >
       {primaryName && (
@@ -73,12 +74,26 @@ const MapTooltip = props => {
           )}
         </div>
       )}
-      {tooltipDataArray.map(el => (
-        <div key={el.name}>
-          <strong>{`${el.name}: `}</strong>
-          {getProperty(tooltipInfo.properties[el.field], el.formatField)}
-        </div>
-      ))}
+      {!isScreenGrid &&
+        tooltipDataArray.map(el => (
+          <div key={el.name}>
+            <strong>{`${el.name}: `}</strong>
+            {getProperty(tooltipInfo.properties[el.field], el.formatField)}
+          </div>
+        ))}
+      {isScreenGrid &&
+        tooltipDataArray.map(el => (
+          <div key={el.name}>
+            <strong>{`${el.name}: `}</strong>
+            {!el.totalField &&
+              getProperty(tooltipInfo[el.field], el.formatField)}
+            {el.totalField &&
+              getProperty(
+                tooltipInfo[el.field] / tooltipInfo[el.totalField],
+                el.formatField
+              )}
+          </div>
+        ))}
       {isHex && (
         <div>
           <div>elevation: {tooltipInfo.elevationValue}</div>
@@ -103,10 +118,12 @@ MapTooltip.propTypes = {
     PropTypes.shape({
       name: PropTypes.string.isRequired,
       field: PropTypes.string.isRequired,
+      totalField: PropTypes.string,
       formatField: PropTypes.func
     })
   ),
   isHex: PropTypes.bool,
+  isScreenGrid: PropTypes.bool,
   wide: PropTypes.bool
 };
 

--- a/packages/component-library/src/ScreenGridMap/ScreenGridMap.js
+++ b/packages/component-library/src/ScreenGridMap/ScreenGridMap.js
@@ -17,8 +17,23 @@ const ScreenGridMap = props => {
     getSize,
     getWeight,
     getCursor,
-    onHover
+    aggregation,
+    tooltipInfo,
+    x,
+    y,
+    onHover,
+    children
   } = props;
+
+  const tooltip = React.Children.map(children, child => {
+    return React.cloneElement(child, {
+      tooltipInfo,
+      x,
+      y
+    });
+  });
+
+  const tooltipRender = tooltipInfo && x && y ? tooltip : null;
 
   return (
     <div>
@@ -40,8 +55,10 @@ const ScreenGridMap = props => {
           getSize={getSize}
           getWeight={getWeight}
           onHover={onHover}
+          aggregation={aggregation}
         />
       </DeckGL>
+      {tooltipRender}
     </div>
   );
 };
@@ -60,7 +77,12 @@ ScreenGridMap.propTypes = {
   getSize: PropTypes.func,
   getWeight: PropTypes.func,
   getCursor: PropTypes.func,
-  onHover: PropTypes.func
+  aggregation: PropTypes.oneOf(["SUM", "MIN", "MEAN", "MAX"]),
+  tooltipInfo: PropTypes.shape({}),
+  x: PropTypes.number,
+  y: PropTypes.number,
+  onHover: PropTypes.func,
+  children: PropTypes.node
 };
 
 ScreenGridMap.defaultProps = {
@@ -73,7 +95,8 @@ ScreenGridMap.defaultProps = {
   gpuAggregation: false,
   getSize: () => 1,
   getWeight: () => 1,
-  getCursor: () => "crosshair"
+  getCursor: () => "crosshair",
+  aggregation: "SUM"
 };
 
 export default ScreenGridMap;

--- a/packages/component-library/src/ScreenGridMap/ScreenGridMap.js
+++ b/packages/component-library/src/ScreenGridMap/ScreenGridMap.js
@@ -8,6 +8,7 @@ const ScreenGridMap = props => {
     data,
     getPosition,
     opacity,
+    colorDomain,
     colorRange,
     cellSizePixels,
     autoHighlight,
@@ -45,6 +46,7 @@ const ScreenGridMap = props => {
           data={data}
           getPosition={getPosition}
           opacity={opacity}
+          colorDomain={colorDomain}
           colorRange={colorRange}
           cellSizePixels={cellSizePixels}
           autoHighlight={autoHighlight}
@@ -68,6 +70,7 @@ ScreenGridMap.propTypes = {
   data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   getPosition: PropTypes.func,
   opacity: PropTypes.number,
+  colorDomain: PropTypes.arrayOf(PropTypes.number),
   colorRange: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
   cellSizePixels: PropTypes.number,
   autoHighlight: PropTypes.bool,


### PR DESCRIPTION
Implements a ScreenGrid tooltip for `cards/earthquake-damage-estimates-for-buildings-in-tillamook-county`.

![trimmed](https://user-images.githubusercontent.com/7065695/68629452-d008d000-0498-11ea-9d06-547cc876b2c7.gif)
