### PR TITLE
Restructure Vector Tiles Map Component

### DIFF
--- a/packages/civic-sandbox/src/components/Packages/index.js
+++ b/packages/civic-sandbox/src/components/Packages/index.js
@@ -40,7 +40,7 @@ export class Packages extends React.Component {
   componentDidUpdate(prevProps) {
     const { isLoading, sandbox, setPackage: cduSetPackage } = this.props;
     if (!isLoading && prevProps.isLoading) {
-      cduSetPackage(sandbox.packages[6]);
+      cduSetPackage(sandbox.packages[0]);
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ mapIsOpen: true });
     }

--- a/packages/civic-sandbox/src/state/sandbox/actions.js
+++ b/packages/civic-sandbox/src/state/sandbox/actions.js
@@ -43,7 +43,7 @@ export const SlideFailure = actionEmitter(SLIDE_FAILURE);
 
 // Thunk actions
 export const fetchSandbox = fetchAdapter(
-  "http://service.civicpdx.org/sandbox/api/package_info/",
+  "https://service.civicpdx.org/sandbox/api/package_info/",
   {
     start: SandboxStart,
     success: SandboxSuccess,

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -104,7 +104,7 @@
     "react": "^16.8.4",
     "react-dimensions": "^1.3.1",
     "react-dom": "^16.8.4",
-    "react-map-gl": "4.1.4",
+    "react-map-gl": "5.1.2",
     "react-map-gl-geocoder": "^1.7.0",
     "react-select": "^1.0.0-rc.3",
     "react-share": "^2.2.0",

--- a/packages/component-library/src/MultiLayerMap/MultiChoroplethMap.js
+++ b/packages/component-library/src/MultiLayerMap/MultiChoroplethMap.js
@@ -94,12 +94,16 @@ const MultiChoroplethMap = props => {
     return lineWidth;
   };
 
+  const noNullGeometryData = data.filter(
+    d => d.geometry && d.geometry.coordinates.length
+  );
+
   return (
     <GeoJsonLayer
       key={shortid.generate()}
       id={id}
       pickable={pickable}
-      data={data}
+      data={noNullGeometryData}
       opacity={opacity}
       getPolygon={getPolygon}
       filled={filled}

--- a/packages/component-library/src/MultiLayerMap/MultiLayerMap.js
+++ b/packages/component-library/src/MultiLayerMap/MultiLayerMap.js
@@ -23,52 +23,48 @@ const MultiLayerMap = props => {
   console.log("MLM-props:", props);
   const renderMaps = mapLayers.map((layerData, index) => {
     const { mapType } = layerData;
-    return mapType === "PathMap"
-      ? MultiPathMap({
-          ...layerData,
-          index,
-          onHoverSlide
-        })
-      : mapType === "ScatterPlotMap"
-      ? MultiScatterPlotMap({
-          ...layerData,
-          index,
-          onHoverSlide
-        })
-      : mapType === "ScreenGridMap"
-      ? MultiScreenGridMap({
-          ...layerData,
-          index
-        })
-      : mapType === "IconMap"
-      ? MultiIconMap({
-          ...layerData,
-          index,
-          onHoverSlide,
-          viewport
-        })
-      : mapType === "SmallPolygonMap"
-      ? MultiSmallPolygonMap({
-          ...layerData,
-          index,
-          onHoverSlide,
-          viewport
-        })
-      : mapType === "ChoroplethMap"
-      ? MultiChoroplethMap({
-          ...layerData,
-          index,
-          onHoverSlide,
-          onLayerClick,
-          selectedFoundationDatum
-        })
-      : mapType === "VectorTilesMap"
-      ? VectorTilesMap({
-          ...layerData,
-          index,
-          onHoverSlide
-        })
-      : null;
+    return mapType === "PathMap" ? (
+      MultiPathMap({
+        ...layerData,
+        index,
+        onHoverSlide
+      })
+    ) : mapType === "ScatterPlotMap" ? (
+      MultiScatterPlotMap({
+        ...layerData,
+        index,
+        onHoverSlide
+      })
+    ) : mapType === "ScreenGridMap" ? (
+      MultiScreenGridMap({
+        ...layerData,
+        index
+      })
+    ) : mapType === "IconMap" ? (
+      MultiIconMap({
+        ...layerData,
+        index,
+        onHoverSlide,
+        viewport
+      })
+    ) : mapType === "SmallPolygonMap" ? (
+      MultiSmallPolygonMap({
+        ...layerData,
+        index,
+        onHoverSlide,
+        viewport
+      })
+    ) : mapType === "ChoroplethMap" ? (
+      MultiChoroplethMap({
+        ...layerData,
+        index,
+        onHoverSlide,
+        onLayerClick,
+        selectedFoundationDatum
+      })
+    ) : mapType === "VectorTilesMap" ? (
+      <VectorTilesMap {...layerData} />
+    ) : null;
   });
   console.log("renderMaps:", renderMaps);
   return (

--- a/packages/component-library/src/MultiLayerMap/MultiLayerMap.js
+++ b/packages/component-library/src/MultiLayerMap/MultiLayerMap.js
@@ -20,7 +20,7 @@ const MultiLayerMap = props => {
     onLayerClick,
     selectedFoundationDatum
   } = props;
-  console.log("MLM-props:", props);
+
   const renderMaps = mapLayers.map((layerData, index) => {
     const { mapType } = layerData;
     return mapType === "PathMap" ? (
@@ -63,10 +63,10 @@ const MultiLayerMap = props => {
         selectedFoundationDatum
       })
     ) : mapType === "VectorTilesMap" ? (
-      <VectorTilesMap {...layerData} />
+      <VectorTilesMap {...layerData} key={layerData.vectorTilesID} />
     ) : null;
   });
-  console.log("renderMaps:", renderMaps);
+
   return (
     <DeckGL className="DeckGL-Map-Layer" getCursor={getCursor} {...viewport}>
       {renderMaps}

--- a/packages/component-library/src/MultiLayerMap/MultiLayerMap.js
+++ b/packages/component-library/src/MultiLayerMap/MultiLayerMap.js
@@ -8,6 +8,7 @@ import MultiScreenGridMap from "./MultiScreenGridMap";
 import MultiIconMap from "./MultiIconMap";
 import MultiSmallPolygonMap from "./MultiSmallPolygonMap";
 import MultiChoroplethMap from "./MultiChoroplethMap";
+import VectorTilesMap from "../VectorTilesMap/VectorTilesMap";
 
 const MultiLayerMap = props => {
   const {
@@ -19,7 +20,7 @@ const MultiLayerMap = props => {
     onLayerClick,
     selectedFoundationDatum
   } = props;
-
+  console.log("MLM-props:", props);
   const renderMaps = mapLayers.map((layerData, index) => {
     const { mapType } = layerData;
     return mapType === "PathMap"
@@ -61,9 +62,15 @@ const MultiLayerMap = props => {
           onLayerClick,
           selectedFoundationDatum
         })
+      : mapType === "VectorTilesMap"
+      ? VectorTilesMap({
+          ...layerData,
+          index,
+          onHoverSlide
+        })
       : null;
   });
-
+  console.log("renderMaps:", renderMaps);
   return (
     <DeckGL className="DeckGL-Map-Layer" getCursor={getCursor} {...viewport}>
       {renderMaps}
@@ -77,11 +84,13 @@ MultiLayerMap.propTypes = {
   mapLayers: arrayOf(shape({})).isRequired,
   onHoverSlide: func,
   onLayerClick: func,
-  getCursor: () => "crosshair",
+  getCursor: func,
   children: node,
   selectedFoundationDatum: shape({})
 };
 
-MultiLayerMap.defaultProps = {};
+MultiLayerMap.defaultProps = {
+  getCursor: () => "crosshair"
+};
 
 export default MultiLayerMap;

--- a/packages/component-library/src/Sandbox/SandboxDrawer.js
+++ b/packages/component-library/src/Sandbox/SandboxDrawer.js
@@ -251,7 +251,9 @@ const SandboxDrawer = props => {
                   "2000-2017",
                   "2010-2017"
                 ];
-                const keySelector = matchFound && (
+                const notYear =
+                  keyAllOptions[0] && keyAllOptions[0].search(/[0-9]/) > -1;
+                const keySelector = matchFound && notYear && (
                   <Dropdown
                     value={foundationData[dataIndex].fieldName.color}
                     options={

--- a/packages/component-library/src/VectorTilesMap/VectorTilesMap.js
+++ b/packages/component-library/src/VectorTilesMap/VectorTilesMap.js
@@ -1,9 +1,9 @@
 import React from "react";
+import { Source, Layer } from "react-map-gl";
 import { string, shape } from "prop-types";
 
 const VectorTilesMap = props => {
   const {
-    mapboxMap,
     vectorTilesID,
     vectorTilesURL,
     layerID,
@@ -12,58 +12,22 @@ const VectorTilesMap = props => {
     paint,
     layerPosition
   } = props;
-
-  const [mapStyle, setMapStyle] = React.useState(mapboxMap.getStyle().name);
-
-  mapboxMap.on("styledata", () => {
-    const nextStyle = mapboxMap.getStyle().name;
-    const currentStyle = mapStyle;
-    if (nextStyle !== currentStyle) {
-      setMapStyle(mapboxMap.getStyle().name);
-    }
-  });
-
-  React.useEffect(() => {
-    if (mapboxMap.getLayer(layerID)) {
-      mapboxMap.removeLayer(layerID);
-    }
-
-    if (mapboxMap.getSource(vectorTilesID)) {
-      mapboxMap.removeSource(vectorTilesID);
-    }
-
-    if (!mapboxMap.getSource(vectorTilesID)) {
-      mapboxMap.addSource(vectorTilesID, {
-        type: "vector",
-        url: vectorTilesURL
-      });
-    }
-
-    if (!mapboxMap.getLayer(layerID)) {
-      mapboxMap.addLayer(
-        {
-          id: layerID,
-          type: layerType,
-          source: vectorTilesID,
-          "source-layer": sourceLayer,
-          paint
-        },
-        layerPosition
-      );
-    }
-  }, [
-    layerID,
-    layerType,
-    vectorTilesID,
-    vectorTilesURL,
-    sourceLayer,
-    paint,
-    layerPosition,
-    mapboxMap,
-    mapStyle
-  ]);
-
-  return null;
+  console.log("VT-PROPS:", props);
+  const sourceLayerProp = {
+    "source-layer": sourceLayer
+  };
+  return (
+    <Source type="vector" id={vectorTilesID} url={vectorTilesURL}>
+      <Layer
+        beforeId={layerPosition}
+        id={layerID}
+        type={layerType}
+        source={vectorTilesID}
+        paint={paint}
+        {...sourceLayerProp}
+      />
+    </Source>
+  );
 };
 
 VectorTilesMap.propTypes = {

--- a/packages/component-library/src/VectorTilesMap/VectorTilesMap.js
+++ b/packages/component-library/src/VectorTilesMap/VectorTilesMap.js
@@ -12,10 +12,11 @@ const VectorTilesMap = React.memo(props => {
     paint,
     layerPosition
   } = props;
-  console.log("VT-PROPS:", props);
+
   const sourceLayerProp = {
     "source-layer": sourceLayer
   };
+
   return (
     <Source
       type="vector"

--- a/packages/component-library/src/VectorTilesMap/VectorTilesMap.js
+++ b/packages/component-library/src/VectorTilesMap/VectorTilesMap.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Source, Layer } from "react-map-gl";
 import { string, shape } from "prop-types";
 
-const VectorTilesMap = props => {
+const VectorTilesMap = React.memo(props => {
   const {
     vectorTilesID,
     vectorTilesURL,
@@ -17,7 +17,12 @@ const VectorTilesMap = props => {
     "source-layer": sourceLayer
   };
   return (
-    <Source type="vector" id={vectorTilesID} url={vectorTilesURL}>
+    <Source
+      type="vector"
+      id={vectorTilesID}
+      url={vectorTilesURL}
+      key={vectorTilesID}
+    >
       <Layer
         beforeId={layerPosition}
         id={layerID}
@@ -28,7 +33,7 @@ const VectorTilesMap = props => {
       />
     </Source>
   );
-};
+});
 
 VectorTilesMap.propTypes = {
   vectorTilesURL: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6806,6 +6806,11 @@ earcut@^2.0.6, earcut@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.5.tgz#829280a9a3a0f5fee0529f0a47c3e4eff09b21e4"
 
+earcut@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.1.tgz#3bae0b1b6fec41853b56b126f03a42a34b28f1d5"
+  integrity sha512-5jIMi2RB3HtGPHcYd9Yyl0cczo84y+48lgKPxMijliNQaKAHEZJbdzLmKmdxG/mCdS/YD9DQ1gihL8mxzR0F9w==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -10925,7 +10930,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@^0.53.1, mapbox-gl@~0.53.0:
+mapbox-gl@^0.53.1:
   version "0.53.1"
   resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.53.1.tgz#08a956d8da54b04bc7f29ab1319bddb9c97ddedf"
   dependencies:
@@ -10947,6 +10952,35 @@ mapbox-gl@^0.53.1, mapbox-gl@~0.53.0:
     minimist "0.0.8"
     murmurhash-js "^1.0.0"
     pbf "^3.0.5"
+    potpack "^1.0.1"
+    quickselect "^2.0.0"
+    rw "^1.3.3"
+    supercluster "^6.0.1"
+    tinyqueue "^2.0.0"
+    vt-pbf "^3.1.1"
+
+mapbox-gl@^1.0.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.5.0.tgz#d531dcecc01b4e209466f03ffd3d0209fe248123"
+  integrity sha512-seTQUttE7XaL93on+zfLv06HmROsIdTh3riEPrBdbylSirLmBRnofG+iV873ZbJQElf+d2USyHpWAJm37RehEQ==
+  dependencies:
+    "@mapbox/geojson-rewind" "^0.4.0"
+    "@mapbox/geojson-types" "^1.0.2"
+    "@mapbox/jsonlint-lines-primitives" "^2.0.2"
+    "@mapbox/mapbox-gl-supported" "^1.4.0"
+    "@mapbox/point-geometry" "^0.1.0"
+    "@mapbox/tiny-sdf" "^1.1.0"
+    "@mapbox/unitbezier" "^0.0.0"
+    "@mapbox/vector-tile" "^1.3.1"
+    "@mapbox/whoots-js" "^3.1.0"
+    csscolorparser "~1.0.2"
+    earcut "^2.2.0"
+    geojson-vt "^3.2.1"
+    gl-matrix "^3.0.0"
+    grid-index "^1.1.0"
+    minimist "0.0.8"
+    murmurhash-js "^1.0.0"
+    pbf "^3.2.1"
     potpack "^1.0.1"
     quickselect "^2.0.0"
     rw "^1.3.3"
@@ -11319,9 +11353,17 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mjolnir.js@^2.0.3, mjolnir.js@^2.1.0:
+mjolnir.js@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-2.1.0.tgz#e8a4727e86d8f9352d6b6fe9cdc6faab0dcff15e"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    hammerjs "^2.0.8"
+
+mjolnir.js@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-2.2.1.tgz#84fc2352ff2ec58b061b0dab1a5ec67f3d2ad966"
+  integrity sha512-bUTP/NbwOfdrN4TKMjUcarfGmWU5yN6aHFR1ek7BNuFOwHk4PslUZjKzdOp1jwx2m0uCoRa5lG+x82l8Vii7Ng==
   dependencies:
     "@babel/runtime" "^7.0.0"
     hammerjs "^2.0.8"
@@ -12514,6 +12556,14 @@ pbf@^3.0.5:
     ieee754 "^1.1.12"
     resolve-protobuf-schema "^2.1.0"
 
+pbf@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.2.1.tgz#b4c1b9e72af966cd82c6531691115cc0409ffe2a"
+  integrity sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==
+  dependencies:
+    ieee754 "^1.1.12"
+    resolve-protobuf-schema "^2.1.0"
+
 pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
@@ -13405,17 +13455,17 @@ react-map-gl-geocoder@^1.7.0:
     prop-types "^15.6.2"
     viewport-mercator-project "6.1.1"
 
-react-map-gl@4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-4.1.4.tgz#544a734ee30ab858a9fc303d358a5bdf5969f842"
-  integrity sha512-rkS551WTCM0Pq2DyBAebMvCEO3cny98fkulVkxmWZN83ygcBQj6RzdAwEjWA51/CHvr2g0q24qooa28PLAtgEg==
+react-map-gl@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-5.1.2.tgz#45f4be0fb8f9cb3810752c2203b22a70e1177c96"
+  integrity sha512-bskZCUhyc+SgvtMIF6xB5IOvrlwc7RVRUKW4VcapOPTtpgVHpLS0H+nPqI5Drr4A0dr0oJMAWHDqGn/LmS4dMw==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    mapbox-gl "~0.53.0"
-    mjolnir.js "^2.1.0"
-    prop-types "^15.5.7"
+    mapbox-gl "^1.0.0"
+    mjolnir.js "^2.2.0"
+    prop-types "^15.7.2"
     react-virtualized-auto-sizer "^1.0.2"
-    viewport-mercator-project "^6.1.0"
+    viewport-mercator-project "^6.2.1"
 
 react-mathjax@^1.0.1:
   version "1.0.1"
@@ -16481,6 +16531,14 @@ viewport-mercator-project@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.2.0.tgz#46e6795551efb3376b88ff3fc6ad05b0a6e532ff"
   integrity sha512-eXELMJmYPnMaqnd4fbye9wZlHZ4c5ktzgxSuIhqzFijP1qbT3/cMyVgyEq5glQS8GPc8HFYhHvdpAdNG+SxK6w==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    gl-matrix "^3.0.0"
+
+viewport-mercator-project@^6.2.1:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.2.2.tgz#f524819ad53fcc009b46136a59f73461bfcf1604"
+  integrity sha512-vs9pjDZxDwoiEqr+GgdpRAUogEQRoZ9D9COVLSr4+h/WdcUWhYN36SQr3n5jaTKrl/wlfdRj+TYU8wTk05grbg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     gl-matrix "^3.0.0"


### PR DESCRIPTION
This PR restructures the way the Vector Tiles Map Component works. The previous implementation wasn't compatible with the Sandbox. 

This new implementation uses the `Source` and `Layer` components from `react-map-gl`. This required updating `react-map-gl` from `4.1.4` to `5.1.2`. All the Vector Tiles Map component props are the same and the Storybook examples all still work the same.