### PR TITLE
Upgrade mapbox-gl

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -98,7 +98,7 @@
     "emotion-theming": "^10.0.14",
     "global": "^4.3.2",
     "lodash": "^4.17.11",
-    "mapbox-gl": "^0.53.1",
+    "mapbox-gl": "^1.5.0",
     "prop-types": "^15.7.2",
     "rc-slider": "^7.0.2",
     "react": "^16.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6802,7 +6802,7 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-earcut@^2.0.6, earcut@^2.1.5:
+earcut@^2.0.6:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.5.tgz#829280a9a3a0f5fee0529f0a47c3e4eff09b21e4"
 
@@ -7358,10 +7358,6 @@ eslint@^5.15.1:
     strip-json-comments "^2.0.1"
     table "^5.2.3"
     text-table "^0.2.0"
-
-esm@^3.0.84:
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.22.tgz#5062c2e22fee3ccfee4e8f20da768330da90d6e3"
 
 espree@^5.0.1:
   version "5.0.1"
@@ -10930,36 +10926,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@^0.53.1:
-  version "0.53.1"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.53.1.tgz#08a956d8da54b04bc7f29ab1319bddb9c97ddedf"
-  dependencies:
-    "@mapbox/geojson-rewind" "^0.4.0"
-    "@mapbox/geojson-types" "^1.0.2"
-    "@mapbox/jsonlint-lines-primitives" "^2.0.2"
-    "@mapbox/mapbox-gl-supported" "^1.4.0"
-    "@mapbox/point-geometry" "^0.1.0"
-    "@mapbox/tiny-sdf" "^1.1.0"
-    "@mapbox/unitbezier" "^0.0.0"
-    "@mapbox/vector-tile" "^1.3.1"
-    "@mapbox/whoots-js" "^3.1.0"
-    csscolorparser "~1.0.2"
-    earcut "^2.1.5"
-    esm "^3.0.84"
-    geojson-vt "^3.2.1"
-    gl-matrix "^3.0.0"
-    grid-index "^1.1.0"
-    minimist "0.0.8"
-    murmurhash-js "^1.0.0"
-    pbf "^3.0.5"
-    potpack "^1.0.1"
-    quickselect "^2.0.0"
-    rw "^1.3.3"
-    supercluster "^6.0.1"
-    tinyqueue "^2.0.0"
-    vt-pbf "^3.1.1"
-
-mapbox-gl@^1.0.0:
+mapbox-gl@^1.0.0, mapbox-gl@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.5.0.tgz#d531dcecc01b4e209466f03ffd3d0209fe248123"
   integrity sha512-seTQUttE7XaL93on+zfLv06HmROsIdTh3riEPrBdbylSirLmBRnofG+iV873ZbJQElf+d2USyHpWAJm37RehEQ==


### PR DESCRIPTION
This is a thing that needs to be done regardless, but it especially needed to be done to address a video memory leak that would occur after prolonged play of the Earthquake Heroes game.

Continued play of the Earthquake Heroes game would result in a slow climb of video memory usage that would eventually crash the GPU, which would flush vram, and result in a `WEBGL_CONTEXT_LOST` error. 

Cursory tests show that this dependency upgrade has fixed that memory leak.