### PR TITLE
Civic Sandbox Dashboard Chart Animation

### DIFF
--- a/packages/civic-sandbox/src/components/Packages/index.js
+++ b/packages/civic-sandbox/src/components/Packages/index.js
@@ -40,7 +40,7 @@ export class Packages extends React.Component {
   componentDidUpdate(prevProps) {
     const { isLoading, sandbox, setPackage: cduSetPackage } = this.props;
     if (!isLoading && prevProps.isLoading) {
-      cduSetPackage(sandbox.packages[0]);
+      cduSetPackage(sandbox.packages[10]);
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ mapIsOpen: true });
     }
@@ -49,16 +49,12 @@ export class Packages extends React.Component {
     const { selectedFoundationDatum: currentSelectedFoundation } = this.props;
 
     const previousID =
-      previousSelectedFoundation &&
-      previousSelectedFoundation.feature &&
-      previousSelectedFoundation.feature.object
-        ? previousSelectedFoundation.feature.object.id
+      previousSelectedFoundation && previousSelectedFoundation.id
+        ? previousSelectedFoundation.id
         : null;
     const currentID =
-      currentSelectedFoundation &&
-      currentSelectedFoundation.feature &&
-      currentSelectedFoundation.feature.object
-        ? currentSelectedFoundation.feature.object.id
+      currentSelectedFoundation && currentSelectedFoundation.id
+        ? currentSelectedFoundation.id
         : null;
 
     if (previousID !== currentID) {

--- a/packages/civic-sandbox/src/state/sandbox/selectors.js
+++ b/packages/civic-sandbox/src/state/sandbox/selectors.js
@@ -180,9 +180,9 @@ export const getSelectedFoundationDatum = createSelector(
   getSelectedSlideKey,
   ({ selectedFoundationDatum }, slides, selectedSlides) => {
     if (!selectedFoundationDatum) {
-      return;
+      return null;
     }
-    const { index } = selectedFoundationDatum;
+    const { index, feature: selectedFeature } = selectedFoundationDatum;
 
     const activeLayerName = selectedSlides[index];
 
@@ -190,13 +190,36 @@ export const getSelectedFoundationDatum = createSelector(
       return s.displayName === activeLayerName;
     });
 
-    if (!activeLayer || !activeLayer.visualization) return;
+    if (!activeLayer || !activeLayer.visualization) return null;
 
-    if (activeLayer.visualization.map.mapType !== "ChoroplethMap") return;
-    // eslint-disable-next-line consistent-return
+    if (activeLayer.visualization.map.mapType !== "ChoroplethMap") return null;
+
+    const id =
+      selectedFeature && selectedFeature.object && selectedFeature.object.id;
+    const featureProperties =
+      selectedFeature &&
+      selectedFeature.object &&
+      selectedFeature.object.properties;
+
+    const { displayName } = activeLayer;
+
+    const { visualization: vizProperties } = activeLayer;
+
+    const { map: mapProperties } = vizProperties;
+    const colorKey = mapProperties.fieldName && mapProperties.fieldName.color;
+
+    const { tooltip: tooltipProperties } = vizProperties;
+    const primaryFormat =
+      tooltipProperties &&
+      tooltipProperties.primary &&
+      tooltipProperties.primary.format;
+
     return {
-      ...selectedFoundationDatum,
-      ...activeLayer
+      id,
+      displayName,
+      featureProperties,
+      colorKey,
+      primaryFormat
     };
   }
 );

--- a/packages/component-library/src/MultiLayerMap/MultiChoroplethMap.js
+++ b/packages/component-library/src/MultiLayerMap/MultiChoroplethMap.js
@@ -69,12 +69,8 @@ const MultiChoroplethMap = props => {
   };
 
   const getLineColor = f => {
-    if (
-      selectedFoundationDatum &&
-      selectedFoundationDatum.feature &&
-      selectedFoundationDatum.feature.object
-    ) {
-      const selectedId = selectedFoundationDatum.feature.object.id;
+    if (selectedFoundationDatum) {
+      const selectedId = selectedFoundationDatum.id;
       const featureId = f.id;
       return featureId === selectedId ? [255, 178, 31, 255] : polygonLineColor;
     }
@@ -82,12 +78,8 @@ const MultiChoroplethMap = props => {
   };
 
   const getLineWidth = f => {
-    if (
-      selectedFoundationDatum &&
-      selectedFoundationDatum.feature &&
-      selectedFoundationDatum.feature.object
-    ) {
-      const selectedId = selectedFoundationDatum.feature.object.id;
+    if (selectedFoundationDatum) {
+      const selectedId = selectedFoundationDatum.id;
       const featureId = f.id;
       return featureId === selectedId ? 125 : lineWidth;
     }
@@ -153,7 +145,13 @@ MultiChoroplethMap.propTypes = {
   dataRange: arrayOf(string),
   colorRange: arrayOf(arrayOf(number)),
   index: number,
-  selectedFoundationDatum: shape({})
+  selectedFoundationDatum: shape({
+    id: number,
+    displayName: string,
+    featureProperties: shape({}),
+    colorKey: string,
+    primaryFormat: string
+  })
 };
 
 export default MultiChoroplethMap;

--- a/packages/component-library/src/Sandbox/Sandbox.js
+++ b/packages/component-library/src/Sandbox/Sandbox.js
@@ -185,14 +185,13 @@ Sandbox.propTypes = {
       slideId: oneOfType([string, number])
     })
   ).isRequired,
-  selectedFoundationDatum: arrayOf(
-    shape({
-      data: oneOfType([arrayOf(shape({})), number, string]),
-      id: oneOfType([number, string]),
-      title: string,
-      visualizationType: string
-    })
-  ),
+  selectedFoundationDatum: shape({
+    id: number,
+    displayName: string,
+    featureProperties: shape({}),
+    colorKey: string,
+    primaryFormat: string
+  }),
   areSlidesLoading: bool,
   updateSlideKey: func,
   errors: bool


### PR DESCRIPTION
This PR fixes issue #1153.

The chart in the dashboard now no longer reanimates when the map rerenders. 

This has been solved by:
- Simplifying the props being passed to the dashboard
- Implementing `React.memo()` to prevent the dashboard from re-rendering when the props haven't changed
- Using the feature id as a key for the chart, since shortid was creating a new key every time the dashboard rendered

An `animate` prop can still be created for the chart components if we want the chart to not animated at all.

