### PR TITLE
Fix Geocoder event propagation

### DIFF
--- a/packages/civic-sandbox/src/components/Packages/index.js
+++ b/packages/civic-sandbox/src/components/Packages/index.js
@@ -40,7 +40,7 @@ export class Packages extends React.Component {
   componentDidUpdate(prevProps) {
     const { isLoading, sandbox, setPackage: cduSetPackage } = this.props;
     if (!isLoading && prevProps.isLoading) {
-      cduSetPackage(sandbox.packages[10]);
+      cduSetPackage(sandbox.packages[0]);
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ mapIsOpen: true });
     }

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -29,6 +29,7 @@ const {
 } = MapGLResources;
 
 const mapWrapper = css`
+  position: relative;
   margin: 0 auto;
   padding: 0;
   width: 100%;
@@ -41,10 +42,29 @@ const navControl = css`
   z-index: 1;
 `;
 
-const geoCoderContainer = css`
+const geoCoderWrapper = css`
   position: absolute;
-  left: 5px;
-  height: 15px;
+  margin: 5px 25px 35px 45px;
+`;
+
+const topRight = css`
+  top: 0;
+  right: 0;
+`;
+
+const topLeft = css`
+  top: 0;
+  left: 0;
+`;
+
+const bottomLeft = css`
+  bottom: 0;
+  left: 0;
+`;
+
+const bottomRight = css`
+  bottom: 0;
+  right: 0;
 `;
 
 class BaseMap extends Component {
@@ -237,6 +257,7 @@ class BaseMap extends Component {
       locationMarker,
       geocoderOptions,
       geocoderOnChange,
+      geocoderPosition,
       mapGLOptions,
       children,
       useContainerHeight,
@@ -329,9 +350,19 @@ class BaseMap extends Component {
         }
       : viewport;
 
+    const geocoderPositions = {
+      "top-left": topLeft,
+      "top-right": topRight,
+      "bottom-left": bottomLeft,
+      "bottom-right": bottomRight
+    };
+
     return (
       <div css={mapWrapper}>
-        <div ref={this.geocoderContainerRef} css={geoCoderContainer} />
+        <div
+          ref={this.geocoderContainerRef}
+          css={[geoCoderWrapper, geocoderPositions[geocoderPosition]]}
+        />
         <MapGL
           className="MapGL"
           {...finalViewport}
@@ -429,6 +460,12 @@ BaseMap.propTypes = {
   geocoder: PropTypes.bool,
   geocoderOptions: PropTypes.shape({}),
   geocoderOnChange: PropTypes.func,
+  geocoderPosition: PropTypes.oneOf([
+    "top-left",
+    "top-right",
+    "bottom-left",
+    "bottom-right"
+  ]),
   mapGLOptions: PropTypes.shape({}),
   children: PropTypes.node,
   useContainerHeight: PropTypes.bool,
@@ -463,6 +500,7 @@ BaseMap.defaultProps = {
   mapboxToken: MAPBOX_TOKEN,
   navigation: true,
   geocoder: false,
+  geocoderPosition: "top-right",
   useContainerHeight: false,
   updateViewport: true,
   animate: false,

--- a/packages/component-library/src/BaseMap/BaseMap.js
+++ b/packages/component-library/src/BaseMap/BaseMap.js
@@ -41,6 +41,12 @@ const navControl = css`
   z-index: 1;
 `;
 
+const geoCoderContainer = css`
+  position: absolute;
+  left: 5px;
+  height: 15px;
+`;
+
 class BaseMap extends Component {
   constructor(props) {
     super(props);
@@ -60,6 +66,7 @@ class BaseMap extends Component {
       mounted: false
     };
     this.mapRef = createRef();
+    this.geocoderContainerRef = createRef();
   }
 
   componentDidMount() {
@@ -324,6 +331,7 @@ class BaseMap extends Component {
 
     return (
       <div css={mapWrapper}>
+        <div ref={this.geocoderContainerRef} css={geoCoderContainer} />
         <MapGL
           className="MapGL"
           {...finalViewport}
@@ -377,6 +385,7 @@ class BaseMap extends Component {
           {geocoder && mounted && (
             <Geocoder
               mapRef={{ current: this.mapRef.current }}
+              containerRef={this.geocoderContainerRef}
               mapboxApiAccessToken={mapboxToken}
               onViewportChange={newViewport => {
                 this.onViewportChange(newViewport);

--- a/packages/component-library/src/MultiLayerMap/MultiLayerMap.js
+++ b/packages/component-library/src/MultiLayerMap/MultiLayerMap.js
@@ -69,7 +69,9 @@ const MultiLayerMap = props => {
         onLayerClick,
         selectedFoundationDatum
       })
-    ) : mapType === "VectorTilesMap" ? (
+    ) : mapType === "VectorTilesMap" ||
+      mapType === "vtChoroplethMap" ||
+      mapType === "vtScatterPlotMap" ? (
       <VectorTilesMap
         {...layerData}
         key={layerData.vectorTilesID}


### PR DESCRIPTION
This resolves #1164 by moving the geocoder outside the `MapGL` component so that the search field no longer zooms the Base Map.