### PR TITLE
Sandbox dashboard improvements

### DIFF
--- a/packages/civic-sandbox/src/components/Packages/index.js
+++ b/packages/civic-sandbox/src/components/Packages/index.js
@@ -1,16 +1,16 @@
-/* eslint-disable no-unused-vars */
 /* eslint-disable import/no-extraneous-dependencies */
 
-/* TODO: Remove no-unused-vars if tracking dashboard open status isn't needed */
+/**
+ * Note, this component doesn't really do much at this point other than render the SandboxComponent
+ * If package selector is added back mapIsOpen could be useful again
+ */
+
 import React from "react";
 import { connect } from "react-redux";
 import { css } from "emotion";
 import { bool, func, shape } from "prop-types";
 
-import {
-  PackageSelectorBox,
-  CivicSandboxDashboard
-} from "@hackoregon/component-library";
+import { PackageSelectorBox } from "@hackoregon/component-library";
 import SandboxComponent from "../Sandbox";
 import { fetchSandbox, setPackage } from "../../state/sandbox/actions";
 import {
@@ -30,8 +30,7 @@ export class Packages extends React.Component {
   constructor() {
     super();
     this.state = {
-      mapIsOpen: false,
-      dashboardIsOpen: false
+      mapIsOpen: false
     };
   }
 
@@ -47,30 +46,7 @@ export class Packages extends React.Component {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ mapIsOpen: true });
     }
-
-    const { selectedFoundationDatum: previousSelectedFoundation } = prevProps;
-    const { selectedFoundationDatum: currentSelectedFoundation } = this.props;
-
-    const previousID =
-      previousSelectedFoundation && previousSelectedFoundation.id
-        ? previousSelectedFoundation.id
-        : null;
-    const currentID =
-      currentSelectedFoundation && currentSelectedFoundation.id
-        ? currentSelectedFoundation.id
-        : null;
-
-    if (previousID !== currentID) {
-      this.toggleDashboardOpen();
-    }
-    if (previousID !== null && currentID === null) {
-      this.toggleDashboardClose();
-    }
   }
-
-  closeMap = () => {
-    this.setState({ mapIsOpen: false });
-  };
 
   handlePackageSelection = selectedPackage => {
     const { setPackage: hpsSetPackage } = this.props;
@@ -78,24 +54,10 @@ export class Packages extends React.Component {
     this.setState({ mapIsOpen: true });
   };
 
-  toggleDashboard = () => {
-    this.setState(prevState => ({
-      dashboardIsOpen: !prevState.dashboardIsOpen
-    }));
-  };
-
-  toggleDashboardOpen = () => {
-    this.setState({ dashboardIsOpen: true });
-  };
-
-  toggleDashboardClose = () => {
-    this.setState({ dashboardIsOpen: false });
-  };
-
   render() {
-    const { isError, sandbox, selectedFoundationDatum } = this.props;
+    const { isError, sandbox } = this.props;
 
-    const { mapIsOpen, dashboardIsOpen } = this.state;
+    const { mapIsOpen } = this.state;
 
     const packages = sandbox.packages
       ? sandbox.packages.map(p => ({
@@ -187,6 +149,5 @@ Packages.propTypes = {
   fetchSandbox: func,
   isLoading: bool,
   setPackage: func,
-  isError: bool,
-  selectedFoundationDatum: shape({})
+  isError: bool
 };

--- a/packages/civic-sandbox/src/components/Sandbox/index.js
+++ b/packages/civic-sandbox/src/components/Sandbox/index.js
@@ -73,8 +73,28 @@ class SandboxComponent extends React.Component {
       selectedPackage,
       selectedSlide,
       selectedSlidesData,
-      fetchLayers: cduFetchLayers
+      fetchLayers: cduFetchLayers,
+      selectedFoundationDatum: currentSelectedFoundation
     } = this.props;
+
+    const { drawerVisualization } = this.state;
+    const { selectedFoundationDatum: previousSelectedFoundation } = prevProps;
+
+    const previousID =
+      previousSelectedFoundation && previousSelectedFoundation.id
+        ? previousSelectedFoundation.id
+        : null;
+    const currentID =
+      currentSelectedFoundation && currentSelectedFoundation.id
+        ? currentSelectedFoundation.id
+        : null;
+
+    if (previousID !== currentID && currentID !== null) {
+      this.toggleDrawerVisualization();
+    }
+    if (previousID !== null && currentID === null && drawerVisualization) {
+      this.toggleDrawerLayerSelector();
+    }
 
     if (
       equals(selectedPackage, prevProps.selectedPackage) &&

--- a/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
+++ b/packages/component-library/src/CivicSandboxDashboard/CivicSandboxDashboard.js
@@ -199,8 +199,8 @@ const createLineViz = (
           feature={feature}
           stroke={VisualizationColors.categorical.pink.hex}
           strokeWidth={30}
-          svgCss={css(`height: 1.125rem;`)}
-          padding={30}
+          svgCss={css(`height: 2.25rem;`)}
+          padding={45}
         />
         {title}
       </h3>

--- a/packages/component-library/src/Sandbox/SandboxDrawer.js
+++ b/packages/component-library/src/Sandbox/SandboxDrawer.js
@@ -107,8 +107,8 @@ const SandboxDrawer = props => {
 
   const allVectorTileLayers =
     !areSlidesLoading && allSlides
-      ? !foundationData.every(slide =>
-          ["vtChoroplethMap", "vtScatterPlotMap"].includes(slide)
+      ? foundationData.every(slide =>
+          ["vtChoroplethMap", "vtScatterPlotMap"].includes(slide.mapType)
         )
       : true;
 


### PR DESCRIPTION
This PR is mostly focused on improvements to the Sandbox dashboard, specifically the data details tab.

Improvements are as follows (by commit):
- Correctly enables and disables the data details tab
- Enlarges the polygon preview
- Opens that tab on the selection of a polygon with data
- Cleans up the code