### PR TITLE
Add pie chart tooltip

### DIFF
--- a/packages/component-library/src/PieChart/PieChart.js
+++ b/packages/component-library/src/PieChart/PieChart.js
@@ -6,6 +6,7 @@ import { VictoryTheme } from "../_Themes/index";
 import SimpleLegend from "../SimpleLegend";
 import PieChartLabels from "./PieChartLabels";
 import DataChecker from "../utils/DataChecker";
+import { chartEvents } from "../utils/chartHelpers";
 
 const PieChart = props => {
   const {
@@ -80,6 +81,7 @@ const PieChart = props => {
               tooltip={tooltip}
             />
           }
+          events={chartEvents(theme, true)}
           containerComponent={
             <VictoryContainer height={adjustedHeight} width={width} />
           }

--- a/packages/component-library/src/PieChart/PieChart.js
+++ b/packages/component-library/src/PieChart/PieChart.js
@@ -1,9 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { VictoryPie, VictoryLabel, VictoryContainer } from "victory";
+import { VictoryPie, VictoryContainer } from "victory";
 import ChartContainer from "../ChartContainer";
 import { VictoryTheme } from "../_Themes/index";
 import SimpleLegend from "../SimpleLegend";
+import PieChartLabels from "./PieChartLabels";
 import DataChecker from "../utils/DataChecker";
 
 const PieChart = props => {
@@ -19,6 +20,7 @@ const PieChart = props => {
     error,
     halfDoughnut,
     useLegend,
+    tooltip,
     width,
     height,
     theme
@@ -32,9 +34,9 @@ const PieChart = props => {
   const legendProps = {};
   const colorScale = colors.length ? colors : theme.group.colorScale;
   const aspectRatio = halfDoughnut ? 650 / 175 : 650 / 350;
+  const totalValue = safeData.reduce((acc, datum) => acc + datum[dataValue], 0);
 
   if (useLegend) {
-    legendProps.labels = () => null;
     legendProps.padding = 25;
   }
 
@@ -68,11 +70,20 @@ const PieChart = props => {
           y={dataValue}
           startAngle={startAngle}
           endAngle={endAngle}
-          labelComponent={<VictoryLabel style={{ ...theme.pieLabel.style }} />}
-          {...legendProps}
+          labelComponent={
+            <PieChartLabels
+              dataLabel={dataLabel}
+              dataValue={dataValue}
+              totalValue={totalValue}
+              useLegend={useLegend}
+              theme={theme}
+              tooltip={tooltip}
+            />
+          }
           containerComponent={
             <VictoryContainer height={adjustedHeight} width={width} />
           }
+          {...legendProps}
         />
       </DataChecker>
     </ChartContainer>
@@ -96,6 +107,7 @@ PieChart.propTypes = {
   subtitle: PropTypes.string,
   title: PropTypes.string,
   useLegend: PropTypes.bool,
+  tooltip: PropTypes.bool,
   width: PropTypes.number,
   theme: PropTypes.shape({})
 };
@@ -104,7 +116,8 @@ PieChart.defaultProps = {
   dataLabel: "x",
   dataValue: "y",
   theme: VictoryTheme,
-  colors: []
+  colors: [],
+  tooltip: true
 };
 
 export default PieChart;

--- a/packages/component-library/src/PieChart/PieChart.js
+++ b/packages/component-library/src/PieChart/PieChart.js
@@ -81,7 +81,7 @@ const PieChart = props => {
               tooltip={tooltip}
             />
           }
-          events={chartEvents(theme, true)}
+          events={tooltip ? chartEvents(theme, true) : null}
           containerComponent={
             <VictoryContainer height={adjustedHeight} width={width} />
           }

--- a/packages/component-library/src/PieChart/PieChartLabels.js
+++ b/packages/component-library/src/PieChart/PieChartLabels.js
@@ -1,0 +1,46 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { VictoryLabel, VictoryTooltip } from "victory";
+import civicFormat from "../utils/civicFormat";
+
+const PieChartLabel = props => {
+  const { dataLabel, dataValue, totalValue, useLegend, tooltip, theme } = props;
+
+  return (
+    <g>
+      {tooltip ? (
+        <VictoryTooltip
+          {...props}
+          pointerLength={0}
+          cornerRadius={0}
+          theme={theme}
+          labelComponent={
+            <VictoryLabel
+              text={datum =>
+                `${datum[dataLabel]}: ${civicFormat.decimalToPercent(
+                  datum[dataValue] / totalValue
+                )}`
+              }
+            />
+          }
+        />
+      ) : null}
+      {!useLegend ? (
+        <VictoryLabel {...props} style={{ ...theme.pieLabel.style }} />
+      ) : null}
+    </g>
+  );
+};
+
+PieChartLabel.defaultEvents = VictoryTooltip.defaultEvents;
+
+PieChartLabel.propTypes = {
+  dataLabel: PropTypes.string,
+  dataValue: PropTypes.string,
+  totalValue: PropTypes.number,
+  useLegend: PropTypes.bool,
+  tooltip: PropTypes.bool,
+  theme: PropTypes.shape({})
+};
+
+export default PieChartLabel;

--- a/packages/component-library/src/_Themes/Victory/VictoryTheme.js
+++ b/packages/component-library/src/_Themes/Victory/VictoryTheme.js
@@ -6,7 +6,6 @@ const { victoryColors } = VisualizationColors;
 
 // Brand Colors
 const civicPrimary = BrandColors.primary.hex;
-const civicSecondary = BrandColors.secondary.hex;
 const civicTertiary = BrandColors.plumLight.hex; // keeping plumLight for bar fill
 const civicSecondaryLighter = BrandColors.medium.hex;
 const civicSecondaryLightest = BrandColors.subdued.hex;
@@ -283,11 +282,11 @@ export default {
           strokeWidth: 0
         },
         labels: centeredLabelStyles,
-        customHoverColor: civicSecondary
+        customHoverColor: civicPrimary
       },
       flyoutStyle: {
-        stroke: "transparent",
-        strokeWidth: 1,
+        stroke: civicPrimary,
+        strokeWidth: 0.25,
         fill: civicSecondaryLightest
       },
       flyoutProps: {

--- a/packages/component-library/src/utils/chartHelpers.js
+++ b/packages/component-library/src/utils/chartHelpers.js
@@ -1,7 +1,15 @@
 import { VictoryTheme } from "../_Themes/index";
 
-const chartEvents = (theme = VictoryTheme) => {
+const chartEvents = (theme = VictoryTheme, replaceMutationStyles) => {
   const tooltipColor = theme.tooltip.style.customHoverColor;
+  const defaultMutation = props => ({
+    style: Object.assign(props.style, { fill: tooltipColor })
+  });
+  const replaceStyleMutation = () => ({ style: { fill: tooltipColor } });
+  const tooltipMutation = replaceMutationStyles
+    ? replaceStyleMutation
+    : defaultMutation;
+
   return [
     {
       target: "data",
@@ -10,9 +18,7 @@ const chartEvents = (theme = VictoryTheme) => {
           return [
             {
               target: "data",
-              mutation: props => ({
-                style: Object.assign(props.style, { fill: tooltipColor })
-              })
+              mutation: tooltipMutation
             },
             {
               target: "labels",

--- a/packages/component-library/stories/PieChart.story.js
+++ b/packages/component-library/stories/PieChart.story.js
@@ -36,6 +36,7 @@ export default () =>
         );
         const halfDoughnut = boolean("Half doughnut", true, GROUP_IDS.DESIGN);
         const useLegend = boolean("Use legend", true, GROUP_IDS.DESIGN);
+        const tooltip = boolean("Tooltip", true, GROUP_IDS.DESIGN);
         const dataLabel = text("Data label", "x", GROUP_IDS.DATA);
         const dataValue = text("Data value", "y", GROUP_IDS.DATA);
         const sampleData = [
@@ -57,6 +58,7 @@ export default () =>
             height={350}
             halfDoughnut={halfDoughnut}
             useLegend={useLegend}
+            tooltip={tooltip}
           />
         );
       },
@@ -72,6 +74,7 @@ export default () =>
           GROUP_IDS.LABELS
         );
         const useLegend = boolean("Use legend", false, GROUP_IDS.DESIGN);
+        const tooltip = boolean("Tooltip", true, GROUP_IDS.DESIGN);
         const halfDoughnut = boolean("Half doughnut", true, GROUP_IDS.DESIGN);
         const sampleData = [
           { contributor: "Business entity", amount: 35 },
@@ -112,6 +115,7 @@ export default () =>
             innerRadius={innerRadius}
             halfDoughnut={halfDoughnut}
             useLegend={useLegend}
+            tooltip={tooltip}
             theme={(name => themes[name])(theme)}
             loading={loading}
           />

--- a/packages/component-library/stories/pieChart.notes.md
+++ b/packages/component-library/stories/pieChart.notes.md
@@ -9,6 +9,7 @@ These properties can be set in the Standard story:
 - Title
 - Subtitle
 - Use legend
+- Tooltip
 - Half doughnut
 - Data label
 - Data value


### PR DESCRIPTION
This adds a pie chart tooltip, with an eye towards https://github.com/hackoregon/openelections/issues/1014

It also includes some minor design tweaks to the tooltips:

- hover color from brand secondary to brand primary
- added a small border to tooltip