### PR TITLE
Set https by default when copying from share functionality

### DIFF
--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -100,9 +100,11 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
     : null;
 
   function handleShareItemClick(option) {
-    const linkLocation = `${_.get(window, "location.origin", "")}/cards/${
-      cardMeta.slug
-    }`;
+    const linkLocation = `https://${_.get(
+      window,
+      "location.hostname",
+      ""
+    )}/cards/${cardMeta.slug}`;
     const scrOutput = document.querySelector("#scr-only");
 
     if (option === "link") {

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFullWithDescriptions.js
@@ -114,9 +114,11 @@ function CivicCardLayoutFullWithDescriptions({ isLoading, data, cardMeta }) {
   }`;
 
   function handleShareItemClick(option) {
-    const linkLocation = `${_.get(window, "location.origin", "")}/cards/${
-      cardMeta.slug
-    }`;
+    const linkLocation = `https://${_.get(
+      window,
+      "location.hostname",
+      ""
+    )}/cards/${cardMeta.slug}`;
 
     if (option === "link") {
       copy(linkLocation);


### PR DESCRIPTION
### Changes  
* All share links for cards are now using https:// by default. 

Resolves issue #1204 