### PR TITLE
remove component library from changeset

### DIFF
--- a/.changeset/sweet-pumas-float.md
+++ b/.changeset/sweet-pumas-float.md
@@ -1,5 +1,4 @@
 ---
-"@hackoregon/component-library": patch
 "@hackoregon/mock-wrapper": patch
 "@hackoregon/ui-brand": patch
 "@hackoregon/ui-cards": patch


### PR DESCRIPTION
Currently the component-library package is deprecated, so rather than pushing a potentially breaking patch, I'm excluding it from the changeset.
﻿
