### PR TITLE
Add NODE_AUTH_TOKEN for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publishing canary releases to npm registry
         if: steps.changesets.outputs.published != 'true'


### PR DESCRIPTION
Currently release is failing to publish new packages. NPM isn't being especially helpful in the errors that it is returning, but it looks like an auth issue. (https://github.com/hackoregon/civic/runs/1440736362?check_suite_focus=true)

This comment indicates that adding a NODE_AUTH_TOKEN may solve this issue.
https://github.com/changesets/action/issues/58#issuecomment-728353474