### PR TITLE
Updated storycard demo

### DIFF
--- a/packages/2019-housing/package.json
+++ b/packages/2019-housing/package.json
@@ -37,6 +37,7 @@
     "@hackoregon/dev-server": "^3.0.0",
     "@hackoregon/mock-wrapper": "^3.0.0",
     "@hackoregon/webpack-common": "^3.0.0",
+    "@material-ui/data-grid": "^4.0.0-alpha.28",
     "axios": "^0.18.0",
     "compression": "^1.6.2",
     "cross-env": "^5.2.0",

--- a/packages/2019-housing/src/components/HousingDisplacement/About.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/About.js
@@ -5,8 +5,12 @@ import StorageIcon from "@material-ui/icons/Storage";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import { makeStyles } from "@material-ui/core/styles";
-import { BrandColors, Collapsable, Logo } from "@hackoregon/component-library";
-import { string } from "prop-types";
+import {
+  BrandColors,
+  VisualizationColors,
+  Collapsable
+} from "@hackoregon/component-library";
+import { oneOf, string } from "prop-types";
 import AccordianContentContainer from "./AccordianContentContainer";
 
 const useProjectStyles = makeStyles({
@@ -19,11 +23,19 @@ const useProjectStyles = makeStyles({
 });
 
 const datasets = [
-  { title: "Dataset A", link: "https://www.civicdatalibrary.org/" },
-  { title: "Dataset B", link: "https://www.civicdatalibrary.org/" }
+  {
+    title: "Dataset A",
+    link: "https://www.civicdatalibrary.org/",
+    color: "green"
+  },
+  {
+    title: "Dataset B",
+    link: "https://www.civicdatalibrary.org/",
+    color: "yellow"
+  }
 ];
 
-const Dataset = ({ title, link }) => {
+const Dataset = ({ title, link, color }) => {
   const classes = useProjectStyles();
 
   return (
@@ -54,10 +66,10 @@ const Dataset = ({ title, link }) => {
                   `}
                 >
                   <StorageIcon
-                    color="secondary"
                     fontSize="small"
                     css={css`
-                      margin: 1.25rem 1rem 0 1rem;
+                      margin: 1.25rem 0.5rem 0 1rem;
+                      color: ${VisualizationColors.categorical[color].hex}};
                     `}
                   />
                   <h4
@@ -68,25 +80,6 @@ const Dataset = ({ title, link }) => {
                     {title}
                   </h4>
                 </div>
-                <h4
-                  css={css`
-                    color: ${BrandColors.background.hex};
-                    margin-right: 1rem;
-                  `}
-                >
-                  <div
-                    css={css`
-                      display: inline;
-                      img {
-                        height: 1.25rem !important;
-                        margin-right: 0.5px;
-                      }
-                    `}
-                  >
-                    <Logo type="standardLogoInverted" />
-                  </div>{" "}
-                  Context
-                </h4>
               </div>
             </Collapsable.Section>
 
@@ -106,7 +99,8 @@ const Dataset = ({ title, link }) => {
 
 Dataset.propTypes = {
   title: string,
-  link: string
+  link: string,
+  color: oneOf(["pink", "green", "blue", "yellow", "purple"]).isRequired
 };
 
 const About = () => (
@@ -118,7 +112,11 @@ const About = () => (
       `}
     >
       {datasets.map(dataset => (
-        <Dataset title={dataset.title} />
+        <Dataset
+          title={dataset.title}
+          link={dataset.link}
+          color={dataset.color}
+        />
       ))}
     </div>
   </AccordianContentContainer>

--- a/packages/2019-housing/src/components/HousingDisplacement/About.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/About.js
@@ -1,0 +1,127 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import StorageIcon from "@material-ui/icons/Storage";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import { makeStyles } from "@material-ui/core/styles";
+import { BrandColors, Collapsable, Logo } from "@hackoregon/component-library";
+import { string } from "prop-types";
+import AccordianContentContainer from "./AccordianContentContainer";
+
+const useProjectStyles = makeStyles({
+  card: {
+    "&:hover": {
+      boxShadow:
+        "0px 2px 6px 0px rgba(0,0,0,0.2), 0px 2px 2px 0px rgba(0,0,0,0.14), 0px 4px 2px -1px rgba(0,0,0,0.12)"
+    }
+  }
+});
+
+const datasets = [
+  { title: "Dataset A", link: "https://www.civicdatalibrary.org/" },
+  { title: "Dataset B", link: "https://www.civicdatalibrary.org/" }
+];
+
+const Dataset = ({ title, link }) => {
+  const classes = useProjectStyles();
+
+  return (
+    <a
+      href={link}
+      target="_blank"
+      rel="noopener noreferrer"
+      css={css`
+        margin: 0 1rem;
+        width: 1000px;
+      `}
+    >
+      <Card className={classes.card}>
+        <CardContent>
+          <Collapsable>
+            <Collapsable.Section>
+              <div
+                css={css`
+                  display: flex;
+                  justify-content: space-between;
+                  background-color: ${BrandColors.tertiary.hex};
+                  margin: -1rem;
+                `}
+              >
+                <div
+                  css={css`
+                    display: flex;
+                  `}
+                >
+                  <StorageIcon
+                    color="secondary"
+                    fontSize="small"
+                    css={css`
+                      margin: 1.25rem 1rem 0 1rem;
+                    `}
+                  />
+                  <h4
+                    css={css`
+                      color: ${BrandColors.background.hex};
+                    `}
+                  >
+                    {title}
+                  </h4>
+                </div>
+                <h4
+                  css={css`
+                    color: ${BrandColors.background.hex};
+                    margin-right: 1rem;
+                  `}
+                >
+                  <div
+                    css={css`
+                      display: inline;
+                      img {
+                        height: 1.25rem !important;
+                        margin-right: 0.5px;
+                      }
+                    `}
+                  >
+                    <Logo type="standardLogoInverted" />
+                  </div>{" "}
+                  Context
+                </h4>
+              </div>
+            </Collapsable.Section>
+
+            <Collapsable.Section>
+              <h5>Description</h5>
+              <p>
+                The description of the dataset is simple summary readable by any
+                community member. It should be precise, clear, and not too long.
+              </p>
+            </Collapsable.Section>
+          </Collapsable>
+        </CardContent>
+      </Card>
+    </a>
+  );
+};
+
+Dataset.propTypes = {
+  title: string,
+  link: string
+};
+
+const About = () => (
+  <AccordianContentContainer>
+    <h3>Datasets used</h3>
+    <div
+      css={css`
+        display: flex;
+      `}
+    >
+      {datasets.map(dataset => (
+        <Dataset title={dataset.title} />
+      ))}
+    </div>
+  </AccordianContentContainer>
+);
+
+export default About;

--- a/packages/2019-housing/src/components/HousingDisplacement/Access.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Access.js
@@ -2,22 +2,53 @@
 import { jsx } from "@emotion/core";
 import AccordianContentContainer from "./AccordianContentContainer";
 import DataTabs from "./DataTabs";
+import Checkbox from "./Checkbox";
 
 const DatasetA = () => (
   <div>
     <h3>Permissions, Protocols, and Requests</h3>
-    <h3>Machine Accessibility</h3>
-    <h3>Data Storage/Format</h3>
-    <h3>Data Integration</h3>
+    <p>
+      <em>
+        This is where information about permissions and formal protocols for
+        dataset and analysis use are recorded. Information about how to submit
+        requests for further information and other dataset and analysis use
+        cases are also recorded here
+      </em>
+    </p>
+    <h3>Accessibility</h3>
+    <p>
+      <Checkbox checked /> Machine-readable format
+    </p>
+    <p>
+      <Checkbox checked /> Human-readable format
+    </p>
+    <p>
+      <Checkbox /> Publicly accessible
+    </p>
   </div>
 );
 
 const DatasetB = () => (
   <div>
     <h3>Permissions, Protocols, and Requests</h3>
-    <h3>Machine Accessibility</h3>
-    <h3>Data Storage/Format</h3>
-    <h3>Data Integration</h3>
+    <p>
+      <em>
+        This is where information about permissions and formal protocols for
+        dataset and analysis use are recorded. Information about how to submit
+        requests for further information and other dataset and analysis use
+        cases are also recorded here
+      </em>
+    </p>
+    <h3>Accessibility</h3>
+    <p>
+      <Checkbox checked /> Machine-readable format
+    </p>
+    <p>
+      <Checkbox /> Human-readable format
+    </p>
+    <p>
+      <Checkbox checked /> Publicly accessible
+    </p>
   </div>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/Access.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Access.js
@@ -1,10 +1,29 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
 import AccordianContentContainer from "./AccordianContentContainer";
+import DataTabs from "./DataTabs";
+
+const DatasetA = () => (
+  <div>
+    <h3>Permissions, Protocols, and Requests</h3>
+    <h3>Machine Accessibility</h3>
+    <h3>Data Storage/Format</h3>
+    <h3>Data Integration</h3>
+  </div>
+);
+
+const DatasetB = () => (
+  <div>
+    <h3>Permissions, Protocols, and Requests</h3>
+    <h3>Machine Accessibility</h3>
+    <h3>Data Storage/Format</h3>
+    <h3>Data Integration</h3>
+  </div>
+);
 
 const Access = () => (
   <AccordianContentContainer>
-    <h3>dataset a | dataset b</h3>
+    <DataTabs DatasetA={DatasetA} DatasetB={DatasetB} />
   </AccordianContentContainer>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/Access.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Access.js
@@ -1,0 +1,11 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import AccordianContentContainer from "./AccordianContentContainer";
+
+const Access = () => (
+  <AccordianContentContainer>
+    <h3>dataset a | dataset b</h3>
+  </AccordianContentContainer>
+);
+
+export default Access;

--- a/packages/2019-housing/src/components/HousingDisplacement/AccordianContentContainer.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/AccordianContentContainer.js
@@ -1,0 +1,19 @@
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import { node } from "prop-types";
+
+const AccordianContentContainer = ({ children }) => (
+  <div
+    css={css`
+      margin: 0 1rem;
+    `}
+  >
+    {children}
+  </div>
+);
+
+AccordianContentContainer.propTypes = {
+  children: node
+};
+
+export default AccordianContentContainer;

--- a/packages/2019-housing/src/components/HousingDisplacement/Attribution.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Attribution.js
@@ -1,10 +1,42 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
+import { Fragment } from "react";
 import AccordianContentContainer from "./AccordianContentContainer";
+import DataTabs from "./DataTabs";
+
+const ContentStorycard = () => (
+  <Fragment>
+    <h3>Data Point of Contact</h3>
+    <h3>Project Team</h3>
+    <h3>Context Team</h3>
+    <h3>Contributing Specialists</h3>
+  </Fragment>
+);
+const ContentA = () => (
+  <Fragment>
+    <h3>Data Point of Contact</h3>
+    <h3>Project Team</h3>
+    <h3>Context Team</h3>
+    <h3>Contributing Specialists</h3>
+  </Fragment>
+);
+const ContentB = () => (
+  <Fragment>
+    <h3>Data Point of Contact</h3>
+    <h3>Project Team</h3>
+    <h3>Context Team</h3>
+    <h3>Contributing Specialists</h3>
+  </Fragment>
+);
 
 const Attribution = () => (
   <AccordianContentContainer>
-    <h3>storycard | dataset a | dataset b</h3>
+    <DataTabs
+      Storycard={ContentStorycard}
+      DatasetA={ContentA}
+      DatasetB={ContentB}
+    />
   </AccordianContentContainer>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/Attribution.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Attribution.js
@@ -1,0 +1,11 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import AccordianContentContainer from "./AccordianContentContainer";
+
+const Attribution = () => (
+  <AccordianContentContainer>
+    <h3>storycard | dataset a | dataset b</h3>
+  </AccordianContentContainer>
+);
+
+export default Attribution;

--- a/packages/2019-housing/src/components/HousingDisplacement/Attribution.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Attribution.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
@@ -8,9 +9,35 @@ import DataTabs from "./DataTabs";
 const ContentStorycard = () => (
   <Fragment>
     <h3>Data Point of Contact</h3>
+    <ul>
+      <li>
+        <a href="">Contact Name</a>, Organization Name
+      </li>
+    </ul>
     <h3>Project Team</h3>
+    <ul>
+      <li>Project Team Member</li>
+      <li>Project Team Member</li>
+      <li>Project Team Member</li>
+      <li>Project Team Member</li>
+    </ul>
     <h3>Context Team</h3>
+    <ul>
+      <li>Context Team Member</li>
+      <li>Context Team Member</li>
+      <li>Context Team Member</li>
+      <li>Context Team Member</li>
+      <li>Context Team Member</li>
+      <li>Context Team Member</li>
+      <li>Context Team Member</li>
+      <li>Context Team Member</li>
+    </ul>
     <h3>Contributing Specialists</h3>
+    <ul>
+      <li>Specialist Contributor</li>
+      <li>Specialist Contributor</li>
+      <li>Specialist Contributor</li>
+    </ul>
   </Fragment>
 );
 const ContentA = () => (

--- a/packages/2019-housing/src/components/HousingDisplacement/Checkbox.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Checkbox.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import CheckBoxIcon from "@material-ui/icons/CheckBox";
+import CheckBoxOutlineBlankIcon from "@material-ui/icons/CheckBoxOutlineBlank";
+import { bool } from "prop-types";
+
+const Checkbox = ({ checked }) => {
+  return checked ? (
+    <CheckBoxIcon fontSize="small" />
+  ) : (
+    <CheckBoxOutlineBlankIcon fontSize="small" />
+  );
+};
+
+Checkbox.propTypes = {
+  checked: bool
+};
+
+export default Checkbox;

--- a/packages/2019-housing/src/components/HousingDisplacement/Checkbox.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Checkbox.js
@@ -1,15 +1,25 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
-import { jsx } from "@emotion/core";
+import { jsx, css } from "@emotion/core";
 import CheckBoxIcon from "@material-ui/icons/CheckBox";
 import CheckBoxOutlineBlankIcon from "@material-ui/icons/CheckBoxOutlineBlank";
 import { bool } from "prop-types";
 
 const Checkbox = ({ checked }) => {
   return checked ? (
-    <CheckBoxIcon fontSize="small" />
+    <CheckBoxIcon
+      fontSize="small"
+      css={css`
+        vertical-align: text-top;
+      `}
+    />
   ) : (
-    <CheckBoxOutlineBlankIcon fontSize="small" />
+    <CheckBoxOutlineBlankIcon
+      fontSize="small"
+      css={css`
+        vertical-align: text-top;
+      `}
+    />
   );
 };
 

--- a/packages/2019-housing/src/components/HousingDisplacement/Constituents.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Constituents.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
@@ -8,7 +9,11 @@ import DataTabs from "./DataTabs";
 
 const ContentStorycard = () => (
   <Fragment>
-    <p>Data constituent engagement definition</p>
+    <p>
+      This analysis would not have been possible, much less equitable, without
+      the contribution of data constituents’ lived experiences, insights, and
+      skills. <a href="">Read more about our engagement process.</a>
+    </p>
     <Placeholder>
       <h2>Multimedia format here</h2>
     </Placeholder>
@@ -16,7 +21,11 @@ const ContentStorycard = () => (
 );
 const ContentA = () => (
   <Fragment>
-    <p>Data constituent engagement definition</p>
+    <p>
+      This analysis would not have been possible, much less equitable, without
+      the contribution of data constituents’ lived experiences, insights, and
+      skills. <a href="">Read more about our engagement process.</a>
+    </p>{" "}
     <Placeholder>
       <h2>Multimedia format here</h2>
     </Placeholder>
@@ -24,7 +33,11 @@ const ContentA = () => (
 );
 const ContentB = () => (
   <Fragment>
-    <p>Data constituent engagement definition</p>
+    <p>
+      This analysis would not have been possible, much less equitable, without
+      the contribution of data constituents’ lived experiences, insights, and
+      skills. <a href="">Read more about our engagement process.</a>
+    </p>{" "}
     <Placeholder>
       <h2>Multimedia format here</h2>
     </Placeholder>

--- a/packages/2019-housing/src/components/HousingDisplacement/Constituents.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Constituents.js
@@ -1,0 +1,11 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import AccordianContentContainer from "./AccordianContentContainer";
+
+const Constituents = () => (
+  <AccordianContentContainer>
+    <h3>storycard | dataset a | dataset b</h3>
+  </AccordianContentContainer>
+);
+
+export default Constituents;

--- a/packages/2019-housing/src/components/HousingDisplacement/Constituents.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Constituents.js
@@ -1,10 +1,43 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
+import { Placeholder } from "@hackoregon/component-library";
+import { Fragment } from "react";
 import AccordianContentContainer from "./AccordianContentContainer";
+import DataTabs from "./DataTabs";
+
+const ContentStorycard = () => (
+  <Fragment>
+    <p>Data constituent engagement definition</p>
+    <Placeholder>
+      <h2>Multimedia format here</h2>
+    </Placeholder>
+  </Fragment>
+);
+const ContentA = () => (
+  <Fragment>
+    <p>Data constituent engagement definition</p>
+    <Placeholder>
+      <h2>Multimedia format here</h2>
+    </Placeholder>
+  </Fragment>
+);
+const ContentB = () => (
+  <Fragment>
+    <p>Data constituent engagement definition</p>
+    <Placeholder>
+      <h2>Multimedia format here</h2>
+    </Placeholder>
+  </Fragment>
+);
 
 const Constituents = () => (
   <AccordianContentContainer>
-    <h3>storycard | dataset a | dataset b</h3>
+    <DataTabs
+      Storycard={ContentStorycard}
+      DatasetA={ContentA}
+      DatasetB={ContentB}
+    />
   </AccordianContentContainer>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/Context.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Context.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
-import { jsx } from "@emotion/core";
+import { jsx, css } from "@emotion/core";
 import { Fragment } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Accordion from "@material-ui/core/Accordion";
@@ -38,7 +38,31 @@ function ContextAccordion() {
           aria-controls="panel1a-content"
           id="panel1a-header"
         >
-          <h2>About this data</h2>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              css={css`
+                height: 1.5rem;
+                margin-right: 0.5rem;
+              `}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
+              />
+            </svg>
+            <h2>About this data</h2>
+          </div>
         </AccordionSummary>
         <AccordionDetails>
           <About />
@@ -50,7 +74,31 @@ function ContextAccordion() {
           aria-controls="panel2a-content"
           id="panel2a-header"
         >
-          <h2>Data Lineage</h2>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              css={css`
+                height: 1.5rem;
+                margin-right: 0.5rem;
+              `}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4"
+              />
+            </svg>
+            <h2>Lineage</h2>
+          </div>
         </AccordionSummary>
         <AccordionDetails>
           <Lineage />
@@ -62,7 +110,31 @@ function ContextAccordion() {
           aria-controls="panel3a-content"
           id="panel3a-header"
         >
-          <h2>Methodology</h2>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              css={css`
+                height: 1.5rem;
+                margin-right: 0.5rem;
+              `}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M7 11.5V14m0-2.5v-6a1.5 1.5 0 113 0m-3 6a1.5 1.5 0 00-3 0v2a7.5 7.5 0 0015 0v-5a1.5 1.5 0 00-3 0m-6-3V11m0-5.5v-1a1.5 1.5 0 013 0v1m0 0V11m0-5.5a1.5 1.5 0 013 0v3m0 0V11"
+              />
+            </svg>
+            <h2>Methodology</h2>
+          </div>
         </AccordionSummary>
         <AccordionDetails>
           <Methodology />
@@ -74,7 +146,31 @@ function ContextAccordion() {
           aria-controls="panel4a-content"
           id="panel4a-header"
         >
-          <h2>Governance</h2>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              css={css`
+                height: 1.5rem;
+                margin-right: 0.5rem;
+              `}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"
+              />
+            </svg>
+            <h2>Governance</h2>
+          </div>
         </AccordionSummary>
         <AccordionDetails>
           <Governance />
@@ -86,7 +182,31 @@ function ContextAccordion() {
           aria-controls="panel5a-content"
           id="panel5a-header"
         >
-          <h2>Data Access</h2>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              css={css`
+                height: 1.5rem;
+                margin-right: 0.5rem;
+              `}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+              />
+            </svg>
+            <h2>Data Access</h2>
+          </div>
         </AccordionSummary>
         <AccordionDetails>
           <Access />
@@ -98,7 +218,31 @@ function ContextAccordion() {
           aria-controls="panel6a-content"
           id="panel6a-header"
         >
-          <h2>Privacy & Security</h2>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              css={css`
+                height: 1.5rem;
+                margin-right: 0.5rem;
+              `}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+              />
+            </svg>
+            <h2>Privacy & Security</h2>
+          </div>
         </AccordionSummary>
         <AccordionDetails>
           <PrivacySecurity />
@@ -110,7 +254,31 @@ function ContextAccordion() {
           aria-controls="panel7a-content"
           id="panel7a-header"
         >
-          <h2>Data Constituent Engagement</h2>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              css={css`
+                height: 1.5rem;
+                margin-right: 0.5rem;
+              `}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"
+              />
+            </svg>
+            <h2>Data Constituent Engagement</h2>
+          </div>
         </AccordionSummary>
         <AccordionDetails>
           <Constituents />
@@ -122,7 +290,31 @@ function ContextAccordion() {
           aria-controls="panel8a-content"
           id="panel8a-header"
         >
-          <h2>Attribution</h2>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              css={css`
+                height: 1.5rem;
+                margin-right: 0.5rem;
+              `}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+              />
+            </svg>
+            <h2>Attribution</h2>
+          </div>
         </AccordionSummary>
         <AccordionDetails>
           <Attribution />
@@ -134,7 +326,31 @@ function ContextAccordion() {
           aria-controls="panel9a-content"
           id="panel9a-header"
         >
-          <h2>Links & Resources</h2>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              css={css`
+                height: 1.5rem;
+                margin-right: 0.5rem;
+              `}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M16 4v12l-4-2-4 2V4M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+            <h2>Links & Resources</h2>
+          </div>
         </AccordionSummary>
         <AccordionDetails>
           <LinksResources />

--- a/packages/2019-housing/src/components/HousingDisplacement/Context.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Context.js
@@ -1,0 +1,153 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { Fragment } from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Accordion from "@material-ui/core/Accordion";
+import AccordionSummary from "@material-ui/core/AccordionSummary";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import Access from "./Access";
+import Attribution from "./Attribution";
+import Lineage from "./Lineage";
+import Methodology from "./Methodology";
+import PrivacySecurity from "./PrivacySecurity";
+import Governance from "./Governance";
+import About from "./About";
+import Constituents from "./Constituents";
+import LinksResources from "./LinksResources";
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    width: "100%"
+  },
+  heading: {
+    fontSize: theme.typography.pxToRem(15),
+    fontWeight: theme.typography.fontWeightRegular
+  }
+}));
+
+function ContextAccordion() {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel1a-content"
+          id="panel1a-header"
+        >
+          <h2>About this data</h2>
+        </AccordionSummary>
+        <AccordionDetails>
+          <About />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel2a-content"
+          id="panel2a-header"
+        >
+          <h2>Data Lineage</h2>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Lineage />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel3a-content"
+          id="panel3a-header"
+        >
+          <h2>Methodology</h2>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Methodology />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel4a-content"
+          id="panel4a-header"
+        >
+          <h2>Governance</h2>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Governance />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel5a-content"
+          id="panel5a-header"
+        >
+          <h2>Data Access</h2>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Access />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel6a-content"
+          id="panel6a-header"
+        >
+          <h2>Privacy & Security</h2>
+        </AccordionSummary>
+        <AccordionDetails>
+          <PrivacySecurity />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel7a-content"
+          id="panel7a-header"
+        >
+          <h2>Data Constituent Engagement</h2>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Constituents />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel8a-content"
+          id="panel8a-header"
+        >
+          <h2>Attribution</h2>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Attribution />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel9a-content"
+          id="panel9a-header"
+        >
+          <h2>Links & Resources</h2>
+        </AccordionSummary>
+        <AccordionDetails>
+          <LinksResources />
+        </AccordionDetails>
+      </Accordion>
+    </div>
+  );
+}
+
+const Context = () => (
+  <Fragment>
+    <ContextAccordion />
+  </Fragment>
+);
+
+export default Context;

--- a/packages/2019-housing/src/components/HousingDisplacement/DataTabs.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/DataTabs.js
@@ -1,0 +1,142 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable react/forbid-prop-types */
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import PropTypes from "prop-types";
+import { makeStyles } from "@material-ui/core/styles";
+import AppBar from "@material-ui/core/AppBar";
+import Tabs from "@material-ui/core/Tabs";
+import Tab from "@material-ui/core/Tab";
+import Typography from "@material-ui/core/Typography";
+import Box from "@material-ui/core/Box";
+import StorageIcon from "@material-ui/icons/Storage";
+import AssessmentIcon from "@material-ui/icons/Assessment";
+import { useState } from "react";
+import VisualizationColors from "@hackoregon/component-library/dist/_Themes/VisualizationColors";
+
+function TabPanel(props) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box p={3}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+TabPanel.propTypes = {
+  children: PropTypes.node,
+  index: PropTypes.any.isRequired,
+  value: PropTypes.any.isRequired
+};
+
+function a11yProps(index) {
+  return {
+    id: `simple-tab-${index}`,
+    "aria-controls": `simple-tabpanel-${index}`
+  };
+}
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    flexGrow: 1,
+    backgroundColor: theme.palette.background.paper
+  }
+}));
+
+export default function DataTabs({ Storycard, DatasetA, DatasetB }) {
+  const classes = useStyles();
+  const [value, setValue] = useState(0);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  const card = !!Storycard;
+
+  return (
+    <div className={classes.root}>
+      <AppBar position="static">
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          aria-label="simple tabs example"
+        >
+          {card && (
+            <Tab
+              label="Story Card"
+              icon={
+                <AssessmentIcon
+                  fontSize="small"
+                  css={css`
+                    color: ${VisualizationColors.categorical.pink.hex}};
+                  `}
+                />
+              }
+              {...a11yProps(0)}
+            />
+          )}
+          {DatasetA && (
+            <Tab
+              label="Dataset A"
+              icon={
+                <StorageIcon
+                  fontSize="small"
+                  css={css`
+                    color: ${VisualizationColors.categorical.green.hex}};
+                  `}
+                />
+              }
+              {...a11yProps(0 + (card ? 1 : 0))}
+            />
+          )}
+          {DatasetB && (
+            <Tab
+              label="Dataset B"
+              icon={
+                <StorageIcon
+                  fontSize="small"
+                  css={css`
+                    color: ${VisualizationColors.categorical.yellow.hex}};
+                  `}
+                />
+              }
+              {...a11yProps(1 + (card ? 1 : 0))}
+            />
+          )}
+        </Tabs>
+      </AppBar>
+      {card && (
+        <TabPanel value={value} index={0}>
+          <Storycard />
+        </TabPanel>
+      )}
+      {DatasetA && (
+        <TabPanel value={value} index={0 + (card ? 1 : 0)}>
+          <DatasetA />
+        </TabPanel>
+      )}
+      {DatasetB && (
+        <TabPanel value={value} index={1 + (card ? 1 : 0)}>
+          <DatasetB />
+        </TabPanel>
+      )}
+    </div>
+  );
+}
+
+DataTabs.propTypes = {
+  Storycard: PropTypes.node,
+  DatasetA: PropTypes.node.isRequired,
+  DatasetB: PropTypes.node.isRequired
+};

--- a/packages/2019-housing/src/components/HousingDisplacement/DataTabs.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/DataTabs.js
@@ -71,6 +71,7 @@ export default function DataTabs({ Storycard, DatasetA, DatasetB }) {
           value={value}
           onChange={handleChange}
           aria-label="simple tabs example"
+          centered
         >
           {card && (
             <Tab

--- a/packages/2019-housing/src/components/HousingDisplacement/Governance.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Governance.js
@@ -1,32 +1,114 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
-import { jsx } from "@emotion/core";
+import { jsx, css } from "@emotion/core";
 import { Fragment } from "react";
+import WarningIcon from "@material-ui/icons/Warning";
+import { BrandColors } from "@hackoregon/component-library";
 import AccordianContentContainer from "./AccordianContentContainer";
 import DataTabs from "./DataTabs";
 
 const ContentStorycard = () => (
   <Fragment>
-    <h3>Key warnings</h3>
-    <h3>Risks</h3>
-    <h3>Opportunities</h3>
-    <h3>Guidelines</h3>
+    <h3>Data use guidelines</h3>
+    <div
+      css={css`
+        display: flex;
+      `}
+    >
+      <WarningIcon
+        fontSize="small"
+        css={css`
+          margin: 1.25rem 0.5rem 0 1rem;
+          color: ${BrandColors.error.hex};
+        `}
+      />
+      <h4>
+        This analysis combines datasets that use differing indicators for race
+        which can result in under-counting people of multiple and marginalized
+        ethnicities.
+      </h4>
+    </div>
+    <h3>Governance report</h3>
+    <p>
+      <em>
+        A synthesis of risks, opportunities, and guidelines in the use of this
+        analysis
+      </em>
+    </p>
+    <p>
+      This analysis makes it possible for Portland residents to see the loss of
+      historically black communities. It creates a data-informed foundation to
+      support the lived experiences of current and former residents and opens up
+      the conversation for how to better invest in these communities.
+    </p>
+    <h4>
+      <a href="#">Read full report</a>
+    </h4>
   </Fragment>
 );
 const ContentA = () => (
   <Fragment>
-    <h3>Key warnings</h3>
-    <h3>Risks</h3>
-    <h3>Opportunities</h3>
-    <h3>Guidelines</h3>
+    <h3>Data use guidelines</h3>
+    <div
+      css={css`
+        display: flex;
+      `}
+    >
+      <WarningIcon
+        fontSize="small"
+        css={css`
+          margin: 1.25rem 0.5rem 0 1rem;
+          color: ${BrandColors.error.hex};
+        `}
+      />
+      <h4>
+        This dataset records people of multiple ethnicities as “biracial”
+        resulting in under-counting of minority or marginalized ethnicities.
+      </h4>
+    </div>
+    <h3>Governance report</h3>
+    <p>
+      <em>
+        A synthesis of risks, opportunities, and guidelines in the use of this
+        analysis
+      </em>
+    </p>
+    <h4>
+      <a href="#">Read full report</a>
+    </h4>
   </Fragment>
 );
 const ContentB = () => (
   <Fragment>
-    <h3>Key warnings</h3>
-    <h3>Risks</h3>
-    <h3>Opportunities</h3>
-    <h3>Guidelines</h3>
+    <h3>Data use guidelines</h3>
+    <div
+      css={css`
+        display: flex;
+      `}
+    >
+      <WarningIcon
+        fontSize="small"
+        css={css`
+          margin: 1.25rem 0.5rem 0 1rem;
+          color: ${BrandColors.error.hex};
+        `}
+      />
+      <h4>
+        This dataset is the result of data integration between two datasets that
+        are not publicly accessible
+      </h4>
+    </div>
+    <h3>Governance report</h3>
+    <p>
+      <em>
+        A synthesis of risks, opportunities, and guidelines in the use of this
+        analysis
+      </em>
+    </p>
+    <h4>
+      <a href="#">Read full report</a>
+    </h4>
   </Fragment>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/Governance.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Governance.js
@@ -1,0 +1,11 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import AccordianContentContainer from "./AccordianContentContainer";
+
+const Governance = () => (
+  <AccordianContentContainer>
+    <h3>storycard | dataset a | dataset b</h3>
+  </AccordianContentContainer>
+);
+
+export default Governance;

--- a/packages/2019-housing/src/components/HousingDisplacement/Governance.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Governance.js
@@ -1,10 +1,42 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
+import { Fragment } from "react";
 import AccordianContentContainer from "./AccordianContentContainer";
+import DataTabs from "./DataTabs";
+
+const ContentStorycard = () => (
+  <Fragment>
+    <h3>Key warnings</h3>
+    <h3>Risks</h3>
+    <h3>Opportunities</h3>
+    <h3>Guidelines</h3>
+  </Fragment>
+);
+const ContentA = () => (
+  <Fragment>
+    <h3>Key warnings</h3>
+    <h3>Risks</h3>
+    <h3>Opportunities</h3>
+    <h3>Guidelines</h3>
+  </Fragment>
+);
+const ContentB = () => (
+  <Fragment>
+    <h3>Key warnings</h3>
+    <h3>Risks</h3>
+    <h3>Opportunities</h3>
+    <h3>Guidelines</h3>
+  </Fragment>
+);
 
 const Governance = () => (
   <AccordianContentContainer>
-    <h3>storycard | dataset a | dataset b</h3>
+    <DataTabs
+      Storycard={ContentStorycard}
+      DatasetA={ContentA}
+      DatasetB={ContentB}
+    />
   </AccordianContentContainer>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/Lineage.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Lineage.js
@@ -1,74 +1,30 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
-import { css, jsx } from "@emotion/core";
+import { jsx } from "@emotion/core";
 import { Fragment } from "react";
-import { string } from "prop-types";
-import StorageIcon from "@material-ui/icons/Storage";
-import { BrandColors } from "@hackoregon/component-library";
 import AccordianContentContainer from "./AccordianContentContainer";
+import DataTabs from "./DataTabs";
 
-const datasets = [
-  { title: "Dataset A", link: "https://www.civicdatalibrary.org/" },
-  { title: "Dataset B", link: "https://www.civicdatalibrary.org/" }
-];
-
-const Dataset = ({ title }) => {
-  return (
-    <Fragment>
-      <div
-        css={css`
-          display: flex;
-          background-color: ${BrandColors.subdued.hex};
-          margin: 1rem;
-        `}
-      >
-        <StorageIcon
-          color="secondary"
-          fontSize="small"
-          css={css`
-            margin: 1.25rem 1rem 0 1rem;
-          `}
-        />
-        <h4
-          css={css`
-            margin-right: 1rem;
-          `}
-        >
-          {title}
-        </h4>
-      </div>
-    </Fragment>
-  );
-};
-
-Dataset.propTypes = {
-  title: string
-};
+const ContentA = () => (
+  <Fragment>
+    <h3>Sources</h3>
+    <h3>Definitions</h3>
+    <h3>Variables</h3>
+    <h3>Assumptions</h3>
+  </Fragment>
+);
+const ContentB = () => (
+  <Fragment>
+    <h3>Sources</h3>
+    <h3>Definitions</h3>
+    <h3>Variables</h3>
+    <h3>Assumptions</h3>
+  </Fragment>
+);
 
 const Lineage = () => (
   <AccordianContentContainer>
-    <div
-      css={css`
-        display: flex;
-      `}
-    >
-      {datasets.map(dataset => (
-        <Dataset title={dataset.title} />
-      ))}
-    </div>
-    <h5>Description</h5>
-    <p>
-      The description of the dataset is simple summary readable by any community
-      member. It should be precise, clear, and not too long.
-    </p>
-    <h5>Purpose</h5>
-    <p>
-      The purpose of a dataset states the rationale for a dataset and explains
-      why the data were collected and why the dataset is of value. The rationale
-      for all steps of the data lifecycle should be included. Existing purpose
-      statements or needs statements used for funding-related purposes should be
-      documented.
-    </p>
+    <DataTabs DatasetA={ContentA} DatasetB={ContentB} />
   </AccordianContentContainer>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/Lineage.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Lineage.js
@@ -1,0 +1,75 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { Fragment } from "react";
+import { string } from "prop-types";
+import StorageIcon from "@material-ui/icons/Storage";
+import { BrandColors } from "@hackoregon/component-library";
+import AccordianContentContainer from "./AccordianContentContainer";
+
+const datasets = [
+  { title: "Dataset A", link: "https://www.civicdatalibrary.org/" },
+  { title: "Dataset B", link: "https://www.civicdatalibrary.org/" }
+];
+
+const Dataset = ({ title }) => {
+  return (
+    <Fragment>
+      <div
+        css={css`
+          display: flex;
+          background-color: ${BrandColors.subdued.hex};
+          margin: 1rem;
+        `}
+      >
+        <StorageIcon
+          color="secondary"
+          fontSize="small"
+          css={css`
+            margin: 1.25rem 1rem 0 1rem;
+          `}
+        />
+        <h4
+          css={css`
+            margin-right: 1rem;
+          `}
+        >
+          {title}
+        </h4>
+      </div>
+    </Fragment>
+  );
+};
+
+Dataset.propTypes = {
+  title: string
+};
+
+const Lineage = () => (
+  <AccordianContentContainer>
+    <div
+      css={css`
+        display: flex;
+      `}
+    >
+      {datasets.map(dataset => (
+        <Dataset title={dataset.title} />
+      ))}
+    </div>
+    <h5>Description</h5>
+    <p>
+      The description of the dataset is simple summary readable by any community
+      member. It should be precise, clear, and not too long.
+    </p>
+    <h5>Purpose</h5>
+    <p>
+      The purpose of a dataset states the rationale for a dataset and explains
+      why the data were collected and why the dataset is of value. The rationale
+      for all steps of the data lifecycle should be included. Existing purpose
+      statements or needs statements used for funding-related purposes should be
+      documented.
+    </p>
+  </AccordianContentContainer>
+);
+
+export default Lineage;

--- a/packages/2019-housing/src/components/HousingDisplacement/Lineage.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Lineage.js
@@ -1,24 +1,146 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
-import { jsx } from "@emotion/core";
+import { jsx, css } from "@emotion/core";
 import { Fragment } from "react";
+import { DataGrid } from "@material-ui/data-grid";
 import AccordianContentContainer from "./AccordianContentContainer";
 import DataTabs from "./DataTabs";
 
+const variablesColumns = [
+  { field: "field", headerName: "Field", width: 150 },
+  { field: "name", headerName: "Name", width: 100 },
+  { field: "type", headerName: "Type", width: 100 },
+  { field: "description", headerName: "Description", width: 800 }
+];
+
+const variablesRows = [
+  {
+    id: 1,
+    field: "sample_a_count",
+    name: "Sample A",
+    type: "Count",
+    description:
+      "A count of sample A, with a brief description of that clarifies how sample A was counted"
+  },
+  {
+    id: 2,
+    field: "sample_b_count",
+    name: "Sample B",
+    type: "Count",
+    description:
+      "A count of sample B, with a brief description of that clarifies how sample B was counted"
+  },
+  {
+    id: 3,
+    field: "sample_c_average",
+    name: "Sample B",
+    type: "Average",
+    description:
+      "An average of sample B, with a brief description of that clarifies how sample C was averaged"
+  }
+];
+
+function VariablesTable() {
+  return (
+    <div
+      css={css`
+        width: 100%;
+      `}
+    >
+      <DataGrid
+        rows={variablesRows}
+        columns={variablesColumns}
+        autoHeight
+        hideFooter
+      />
+    </div>
+  );
+}
+
+const definitionsColumns = [
+  { field: "term", headerName: "Term", width: 150 },
+  { field: "definition", headerName: "Definition", width: 800 }
+];
+
+const definitionsRows = [
+  {
+    id: 1,
+    term: "Sample term",
+    definition:
+      "A count of sample A, with a brief description of that clarifies how sample A was counted"
+  },
+  {
+    id: 2,
+    term: "Sample term B",
+    definition:
+      "A count of sample B, with a brief description of that clarifies how sample B was counted"
+  }
+];
+
+function DefinitionsTable() {
+  return (
+    <div
+      css={css`
+        width: 100%;
+      `}
+    >
+      <DataGrid
+        rows={definitionsRows}
+        columns={definitionsColumns}
+        autoHeight
+        hideFooter
+      />
+    </div>
+  );
+}
+
 const ContentA = () => (
   <Fragment>
-    <h3>Sources</h3>
-    <h3>Definitions</h3>
-    <h3>Variables</h3>
+    <h3>Key Definitions</h3>
+    <DefinitionsTable />
+    <h4>
+      <a href="#">See full dataset documentation</a>
+    </h4>
+    <h3>Key Variables</h3>
+    <VariablesTable />
+    <h4>
+      <a href="#">See full dataset documentation</a>
+    </h4>
     <h3>Assumptions</h3>
+    <h3>Sources</h3>
+    <ul>
+      <li>
+        <a href="#">Source dataset from sample organization A</a>
+      </li>
+      <li>
+        <a href="#">Source dataset from sample organization B</a>
+      </li>
+    </ul>
   </Fragment>
 );
 const ContentB = () => (
   <Fragment>
-    <h3>Sources</h3>
-    <h3>Definitions</h3>
-    <h3>Variables</h3>
+    <h3>Key Definitions</h3>
+    <DefinitionsTable />
+    <h4>
+      <a href="#">See full dataset documentation</a>
+    </h4>
+    <h3>Key Variables</h3>
+    <VariablesTable />
+    <h4>
+      <a href="#">See full dataset documentation</a>
+    </h4>
     <h3>Assumptions</h3>
+    <h3>Sources</h3>
+    <ul>
+      <li>
+        <a href="#">Source dataset from sample organization A</a>
+      </li>
+      <li>
+        <a href="#">Source dataset from sample organization B</a>
+      </li>
+    </ul>
   </Fragment>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/LinksResources.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/LinksResources.js
@@ -10,7 +10,7 @@ import DataTabs from "./DataTabs";
 
 const resources = [
   {
-    heading: "Organizations",
+    heading: "Resources",
     items: [
       {
         link:
@@ -32,13 +32,25 @@ const resources = [
       {
         link: "https://www.census.gov/topics/population/race/about.html",
         description: "Official Census race category definitions"
+      }
+    ]
+  },
+  {
+    heading: "Organizations",
+    items: [
+      { link: "https://www.census.gov/", description: "U.S. Census Bureau" },
+      {
+        link: "https://www.jchs.harvard.edu/",
+        description: "The Harvard Joint Center for Housing Studies"
       },
-      { link: "https://www.hackoregon.org", description: "Hack Oregon" },
+      {
+        link: "https://www.imagineblack.org/",
+        description: "Imagine Black"
+      },
       {
         link: "https://www.civicsoftwarefoundation.org",
         description: "Civic Software Foundation"
-      },
-      { link: "https://www.civicplatform.org", description: "Civic Platform" }
+      }
     ]
   }
 ];

--- a/packages/2019-housing/src/components/HousingDisplacement/LinksResources.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/LinksResources.js
@@ -6,6 +6,7 @@ import { PropTypes } from "prop-types";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { generate } from "shortid";
 import AccordianContentContainer from "./AccordianContentContainer";
+import DataTabs from "./DataTabs";
 
 const resources = [
   {
@@ -69,15 +70,39 @@ Resource.propTypes = {
   })
 };
 
+const ContentCard = () => (
+  <CollapsableSection
+    description="resources"
+    items={resources.map(item => (
+      <Resource section={item} key={generate()} />
+    ))}
+    collapseAfter={7}
+  />
+);
+
+const ContentA = () => (
+  <CollapsableSection
+    description="resources"
+    items={resources.map(item => (
+      <Resource section={item} key={generate()} />
+    ))}
+    collapseAfter={7}
+  />
+);
+
+const ContentB = () => (
+  <CollapsableSection
+    description="resources"
+    items={resources.map(item => (
+      <Resource section={item} key={generate()} />
+    ))}
+    collapseAfter={7}
+  />
+);
+
 const LinksResources = () => (
   <AccordianContentContainer>
-    <CollapsableSection
-      description="resources"
-      items={resources.map(item => (
-        <Resource section={item} key={generate()} />
-      ))}
-      collapseAfter={7}
-    />
+    <DataTabs Storycard={ContentCard} DatasetA={ContentA} DatasetB={ContentB} />
   </AccordianContentContainer>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/LinksResources.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/LinksResources.js
@@ -1,0 +1,84 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { CollapsableSection } from "@hackoregon/component-library/dist/CivicCard/LayoutComponents";
+import { Fragment } from "react";
+import { PropTypes } from "prop-types";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { generate } from "shortid";
+import AccordianContentContainer from "./AccordianContentContainer";
+
+const resources = [
+  {
+    heading: "Organizations",
+    items: [
+      {
+        link:
+          "http://kingneighborhood.org/wp-content/uploads/2015/03/BLEEDING-ALBINA_-A-HISTORY-OF-COMMUNITY-DISINVESTMENT-1940%E2%80%932000.pdf",
+        description:
+          "Gibson, Karen. (2007). Bleeding Albina: A History of Community Disinvestment, 1940-2000."
+      },
+      {
+        link: "http://racebox.org/",
+        description:
+          "RaceBox - see how race and ethnicity has been asked on the Decennial census since 1790"
+      },
+      {
+        link:
+          "https://www.pewsocialtrends.org/interactives/multiracial-timeline/",
+        description:
+          "Pew Research Center - see a historical timeline of race categories defined by the census since 1790"
+      },
+      {
+        link: "https://www.census.gov/topics/population/race/about.html",
+        description: "Official Census race category definitions"
+      },
+      { link: "https://www.hackoregon.org", description: "Hack Oregon" },
+      {
+        link: "https://www.civicsoftwarefoundation.org",
+        description: "Civic Software Foundation"
+      },
+      { link: "https://www.civicplatform.org", description: "Civic Platform" }
+    ]
+  }
+];
+
+function Resource({ section }) {
+  return (
+    <Fragment>
+      <h3>{section.heading}</h3>
+      <ul>
+        {section.items.map(item => (
+          <li key={generate()}>
+            <a href={item.link}>{item.description}</a>
+          </li>
+        ))}
+      </ul>
+    </Fragment>
+  );
+}
+
+Resource.propTypes = {
+  section: PropTypes.shape({
+    heading: PropTypes.string,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        link: PropTypes.string,
+        description: PropTypes.string
+      })
+    )
+  })
+};
+
+const LinksResources = () => (
+  <AccordianContentContainer>
+    <CollapsableSection
+      description="resources"
+      items={resources.map(item => (
+        <Resource section={item} key={generate()} />
+      ))}
+      collapseAfter={7}
+    />
+  </AccordianContentContainer>
+);
+
+export default LinksResources;

--- a/packages/2019-housing/src/components/HousingDisplacement/Methodology.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Methodology.js
@@ -9,6 +9,7 @@ import DataTabs from "./DataTabs";
 
 const ContentCard = () => (
   <Fragment>
+    <h3>Summary</h3>
     <p>
       This analysis aggregates tract-level population data by race from NCDB
       across the 4-county Portland region (Multnomah, Washington, Clackamas and
@@ -16,6 +17,8 @@ const ContentCard = () => (
       have 1990 black populations shares above an adjustable threshold - ranging
       from 10% to 60%.
     </p>
+    <h3>Documentation</h3>
+    <p>Resources that support reproducability of these results</p>
     <NotebookPreview link="https://github.com/hackoregon/2019-disaster-resilience-data-science/blob/master/notebooks/AEBM_Casualties_Analysis.ipynb" />
     <h3>Key calculations</h3>
     <p

--- a/packages/2019-housing/src/components/HousingDisplacement/Methodology.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Methodology.js
@@ -1,0 +1,45 @@
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import { NotebookPreview } from "@hackoregon/component-library";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import MathJax from "react-mathjax";
+import AccordianContentContainer from "./AccordianContentContainer";
+
+const Methodology = () => (
+  <AccordianContentContainer>
+    <p>
+      This analysis aggregates tract-level population data by race from NCDB
+      across the 4-county Portland region (Multnomah, Washington, Clackamas and
+      Clark, WA); and across a subset of tracts in this case defined by those
+      have 1990 black populations shares above an adjustable threshold - ranging
+      from 10% to 60%.
+    </p>
+    <NotebookPreview link="https://github.com/hackoregon/2019-disaster-resilience-data-science/blob/master/notebooks/AEBM_Casualties_Analysis.ipynb" />
+    <h3>Key calculations</h3>
+    <p
+      css={css`
+        line-height: 1.6;
+      `}
+    >
+      <MathJax.Provider>
+        <MathJax.Node
+          block
+          formula="SL_{ENDOi} = N_{DO} \times P(S_i|Col)P(Col|PSTR_5) \times PSTR_5"
+        />
+        Where:
+        <br />
+        <MathJax.Node inline formula="SL_{ENDOi}" /> = Some variable
+        <br />
+        <MathJax.Node inline formula="P(S_i|Col)" /> = Some probability
+        <br />
+        <MathJax.Node inline formula="P(Col|PSTR_5)" /> = Some other probability
+        <br />
+        <MathJax.Node inline formula="PSTR5" /> = Even another probability
+        <br />
+        <MathJax.Node inline formula="N_{DO}" /> = A number of some kind
+      </MathJax.Provider>
+    </p>
+  </AccordianContentContainer>
+);
+
+export default Methodology;

--- a/packages/2019-housing/src/components/HousingDisplacement/Methodology.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/Methodology.js
@@ -1,12 +1,14 @@
 /** @jsx jsx */
 import { jsx, css } from "@emotion/core";
 import { NotebookPreview } from "@hackoregon/component-library";
+import { Fragment } from "react";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import MathJax from "react-mathjax";
 import AccordianContentContainer from "./AccordianContentContainer";
+import DataTabs from "./DataTabs";
 
-const Methodology = () => (
-  <AccordianContentContainer>
+const ContentCard = () => (
+  <Fragment>
     <p>
       This analysis aggregates tract-level population data by race from NCDB
       across the 4-county Portland region (Multnomah, Washington, Clackamas and
@@ -39,6 +41,12 @@ const Methodology = () => (
         <MathJax.Node inline formula="N_{DO}" /> = A number of some kind
       </MathJax.Provider>
     </p>
+  </Fragment>
+);
+
+const Methodology = () => (
+  <AccordianContentContainer>
+    <DataTabs Storycard={ContentCard} />
   </AccordianContentContainer>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/PrivacySecurity.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/PrivacySecurity.js
@@ -1,24 +1,81 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
 import AccordianContentContainer from "./AccordianContentContainer";
+import Checkbox from "./Checkbox";
 import DataTabs from "./DataTabs";
 
 const DatasetA = () => (
   <div>
     <h3>Risk Management</h3>
-    <h4>Existing Security Protocols</h4>
-    <h4>Audit Trails</h4>
+    <p>
+      <Checkbox checked /> Conforms to relevant security protocols.{" "}
+      <a href="#">Read more</a>
+    </p>
+    <p>
+      <Checkbox checked /> Audit trails. <a href="#">Read more</a>
+    </p>
     <h3>Data Disclosure</h3>
+    <p>
+      <Checkbox /> Has standardized data disclosure protocol that is publicly
+      accessible. <a href="#">Read more</a>
+    </p>
     <h3>Data Protection</h3>
+    <p>
+      <em>
+        This refers to rules and practices surrounding how data are safeguarded
+        and/or anonymized.
+      </em>
+    </p>
+    <p>
+      <Checkbox checked /> Data access complies with data protection protocols
+      in place for this dataset
+    </p>
+    <p>
+      <Checkbox checked /> Data use complies with data protection protocols in
+      place for this dataset
+    </p>
+    <p>
+      <Checkbox /> Data are anonymized
+    </p>
   </div>
 );
 
 const DatasetB = () => (
   <div>
-    <h3>Permissions, Protocols, and Requests</h3>
-    <h3>Machine Accessibility</h3>
-    <h3>Data Storage/Format</h3>
-    <h3>Data Integration</h3>
+    <div>
+      <h3>Risk Management</h3>
+      <p>
+        <Checkbox /> Conforms to relevant security protocols.{" "}
+        <a href="#">Read more</a>
+      </p>
+      <p>
+        <Checkbox checked /> Audit trails. <a href="#">Read more</a>
+      </p>
+      <h3>Data Disclosure</h3>
+      <p>
+        <Checkbox checked /> Has standardized data disclosure protocol that is
+        publicly accessible. <a href="#">Read more</a>
+      </p>
+      <h3>Data Protection</h3>
+      <p>
+        <em>
+          This refers to rules and practices surrounding how data are
+          safeguarded and/or anonymized.
+        </em>
+      </p>
+      <p>
+        <Checkbox /> Data access complies with data protection protocols in
+        place for this dataset
+      </p>
+      <p>
+        <Checkbox checked /> Data use complies with data protection protocols in
+        place for this dataset
+      </p>
+      <p>
+        <Checkbox /> Data are anonymized
+      </p>
+    </div>
   </div>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/PrivacySecurity.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/PrivacySecurity.js
@@ -1,0 +1,11 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import AccordianContentContainer from "./AccordianContentContainer";
+
+const PrivacySecurity = () => (
+  <AccordianContentContainer>
+    <h3>dataset a | dataset b</h3>
+  </AccordianContentContainer>
+);
+
+export default PrivacySecurity;

--- a/packages/2019-housing/src/components/HousingDisplacement/PrivacySecurity.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/PrivacySecurity.js
@@ -1,10 +1,30 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
 import AccordianContentContainer from "./AccordianContentContainer";
+import DataTabs from "./DataTabs";
+
+const DatasetA = () => (
+  <div>
+    <h3>Risk Management</h3>
+    <h4>Existing Security Protocols</h4>
+    <h4>Audit Trails</h4>
+    <h3>Data Disclosure</h3>
+    <h3>Data Protection</h3>
+  </div>
+);
+
+const DatasetB = () => (
+  <div>
+    <h3>Permissions, Protocols, and Requests</h3>
+    <h3>Machine Accessibility</h3>
+    <h3>Data Storage/Format</h3>
+    <h3>Data Integration</h3>
+  </div>
+);
 
 const PrivacySecurity = () => (
   <AccordianContentContainer>
-    <h3>dataset a | dataset b</h3>
+    <DataTabs DatasetA={DatasetA} DatasetB={DatasetB} />
   </AccordianContentContainer>
 );
 

--- a/packages/2019-housing/src/components/HousingDisplacement/housingDisplacementMeta.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/housingDisplacementMeta.js
@@ -1,8 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /** @jsx jsx */
-import { jsx, css } from "@emotion/core";
-import { Collapsable, NotebookPreview } from "@hackoregon/component-library";
-import MathJax from "react-mathjax";
+import { jsx } from "@emotion/core";
+import Context from "./Context";
 
 import HousingDisplacementVisualization from "./HousingDisplacementVisualization";
 
@@ -36,82 +35,11 @@ const HousingDisplacementMeta = (/* data */) => ({
     "Historically Black Portland Neighborhoods Lost 12,000 Black Residents Since 1990",
   tags: ["Housing", "Race", "Portland", "Oregon", "Chart"],
   selector: null,
-  analysis: (
-    <Collapsable>
-      <Collapsable.Section>
-        <p>
-          This analysis aggregates tract-level population data by race from NCDB
-          across the 4-county Portland region (Multnomah, Washington, Clackamas
-          and Clark, WA); and across a subset of tracts in this case defined by
-          those have 1990 black populations shares above an adjustable threshold
-          - ranging from 10% to 60%.
-        </p>
-        <NotebookPreview link="https://github.com/hackoregon/2019-disaster-resilience-data-science/blob/master/notebooks/AEBM_Casualties_Analysis.ipynb" />
-        <h3>Key calculations</h3>
-        <p
-          css={css`
-            line-height: 1.6;
-          `}
-        >
-          <MathJax.Provider>
-            <MathJax.Node
-              block
-              formula="SL_{ENDOi} = N_{DO} \times P(S_i|Col)P(Col|PSTR_5) \times PSTR_5"
-            />
-            Where:
-            <br />
-            <MathJax.Node inline formula="SL_{ENDOi}" /> = Some variable
-            <br />
-            <MathJax.Node inline formula="P(S_i|Col)" /> = Some probability
-            <br />
-            <MathJax.Node inline formula="P(Col|PSTR_5)" /> = Some other
-            probability
-            <br />
-            <MathJax.Node inline formula="PSTR5" /> = Even another probability
-            <br />
-            <MathJax.Node inline formula="N_{DO}" /> = A number of some kind
-          </MathJax.Provider>
-        </p>
-      </Collapsable.Section>
-    </Collapsable>
-  ),
-  context: <div>Context here</div>,
+  analysis: null,
+  context: <Context />,
   metadata: null,
   metadataQA: null,
-  resources: [
-    {
-      heading: "Organizations",
-      items: [
-        {
-          link:
-            "http://kingneighborhood.org/wp-content/uploads/2015/03/BLEEDING-ALBINA_-A-HISTORY-OF-COMMUNITY-DISINVESTMENT-1940%E2%80%932000.pdf",
-          description:
-            "Gibson, Karen. (2007). Bleeding Albina: A History of Community Disinvestment, 1940-2000."
-        },
-        {
-          link: "http://racebox.org/",
-          description:
-            "RaceBox - see how race and ethnicity has been asked on the Decennial census since 1790"
-        },
-        {
-          link:
-            "https://www.pewsocialtrends.org/interactives/multiracial-timeline/",
-          description:
-            "Pew Research Center - see a historical timeline of race categories defined by the census since 1790"
-        },
-        {
-          link: "https://www.census.gov/topics/population/race/about.html",
-          description: "Official Census race category definitions"
-        },
-        { link: "https://www.hackoregon.org", description: "Hack Oregon" },
-        {
-          link: "https://www.civicsoftwarefoundation.org",
-          description: "Civic Software Foundation"
-        },
-        { link: "https://www.civicplatform.org", description: "Civic Platform" }
-      ]
-    }
-  ],
+  resources: null,
   // authors likely an array of keys in the future
   authors: []
 });

--- a/packages/2019-housing/src/components/HousingDisplacement/housingDisplacementMeta.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/housingDisplacementMeta.js
@@ -1,5 +1,8 @@
-import React from "react";
-import { Collapsable } from "@hackoregon/component-library";
+/* eslint-disable import/no-extraneous-dependencies */
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import { Collapsable, NotebookPreview } from "@hackoregon/component-library";
+import MathJax from "react-mathjax";
 
 import HousingDisplacementVisualization from "./HousingDisplacementVisualization";
 
@@ -42,6 +45,32 @@ const HousingDisplacementMeta = (/* data */) => ({
           and Clark, WA); and across a subset of tracts in this case defined by
           those have 1990 black populations shares above an adjustable threshold
           - ranging from 10% to 60%.
+        </p>
+        <NotebookPreview link="https://github.com/hackoregon/2019-disaster-resilience-data-science/blob/master/notebooks/AEBM_Casualties_Analysis.ipynb" />
+        <h3>Key calculations</h3>
+        <p
+          css={css`
+            line-height: 1.6;
+          `}
+        >
+          <MathJax.Provider>
+            <MathJax.Node
+              block
+              formula="SL_{ENDOi} = N_{DO} \times P(S_i|Col)P(Col|PSTR_5) \times PSTR_5"
+            />
+            Where:
+            <br />
+            <MathJax.Node inline formula="SL_{ENDOi}" /> = Some variable
+            <br />
+            <MathJax.Node inline formula="P(S_i|Col)" /> = Some probability
+            <br />
+            <MathJax.Node inline formula="P(Col|PSTR_5)" /> = Some other
+            probability
+            <br />
+            <MathJax.Node inline formula="PSTR5" /> = Even another probability
+            <br />
+            <MathJax.Node inline formula="N_{DO}" /> = A number of some kind
+          </MathJax.Provider>
         </p>
       </Collapsable.Section>
     </Collapsable>

--- a/packages/2019-housing/src/components/HousingDisplacement/housingDisplacementMeta.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/housingDisplacementMeta.js
@@ -41,7 +41,8 @@ const HousingDisplacementMeta = (/* data */) => ({
   metadataQA: null,
   resources: null,
   // authors likely an array of keys in the future
-  authors: []
+  authors: [],
+  hideAuthors: true
 });
 
 export default HousingDisplacementMeta;

--- a/packages/2019-housing/src/components/HousingDisplacement/housingDisplacementMeta.js
+++ b/packages/2019-housing/src/components/HousingDisplacement/housingDisplacementMeta.js
@@ -46,8 +46,9 @@ const HousingDisplacementMeta = (/* data */) => ({
       </Collapsable.Section>
     </Collapsable>
   ),
+  context: <div>Context here</div>,
   metadata: null,
-  metadataQA: "median_household_income_by_race_1990_to_2017",
+  metadataQA: null,
   resources: [
     {
       heading: "Organizations",

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -266,9 +266,9 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
             css={[sectionMarginSmall, sectionMaxWidthSmall]}
             id="metadata"
           >
-            <h2>About this data</h2>
             {relatedMetadataQA ? (
               <Fragment>
+                <h2>About this data</h2>
                 {cardMeta.metadata}
                 <CollapsableSection
                   description="metadata questions"
@@ -284,19 +284,23 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
               </Fragment>
             ) : (
               cardMeta.context || (
-                <p>
-                  <em>This dataset is missing context documentation</em>
-                  <br />
-                  <br />
-                  Documenting how and why a dataset was created, what
-                  information it contains, its limitations, and possible ethical
-                  or legal concerns is paramount for data that informs decision
-                  making. If you’re an expert on this dataset, you can{" "}
-                  <a href="https://forms.gle/rggpgLGRtfaQDm5f7">
-                    add documentation
-                  </a>
-                  .
-                </p>
+                <Fragment>
+                  <h2>About this data</h2>
+                  <p>
+                    <em>This dataset is missing context documentation</em>
+                    <br />
+                    <br />
+                    Documenting how and why a dataset was created, what
+                    information it contains, its limitations, and possible
+                    ethical or legal concerns is paramount for data that informs
+                    decision making. If you’re an expert on this dataset, you
+                    can{" "}
+                    <a href="https://forms.gle/rggpgLGRtfaQDm5f7">
+                      add documentation
+                    </a>
+                    .
+                  </p>
+                </Fragment>
               )
             )}
           </section>

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -328,32 +328,34 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
             </section>
           </Fragment>
         )}
-        <Fragment>
-          <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
-          <section
-            css={[sectionMarginSmall, sectionMaxWidthSmall]}
-            id="authors"
-          >
-            <h2>Who made this?</h2>
-            {/* temporary implementation, length > 4 to exclude authors: "demo" */}
-            {cardMeta.authors && cardMeta.authors.length > 4 && (
-              <Fragment>
-                <h3>Primary Authors</h3>
-                <ul>
-                  {cardMeta.authors.map(author => (
-                    <li>{author}</li>
-                  ))}
-                </ul>
-              </Fragment>
-            )}
-            <h3>2019 Hack Oregon Team</h3>
-            <img
-              css={authorPhoto}
-              src={authorsSrc}
-              alt="Pictures of people who worked on this"
-            />
-          </section>
-        </Fragment>
+        {!cardMeta.hideAuthors && (
+          <Fragment>
+            <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
+            <section
+              css={[sectionMarginSmall, sectionMaxWidthSmall]}
+              id="authors"
+            >
+              <h2>Who made this?</h2>
+              {/* temporary implementation, length > 4 to exclude authors: "demo" */}
+              {cardMeta.authors && cardMeta.authors.length > 4 && (
+                <Fragment>
+                  <h3>Primary Authors</h3>
+                  <ul>
+                    {cardMeta.authors.map(author => (
+                      <li>{author}</li>
+                    ))}
+                  </ul>
+                </Fragment>
+              )}
+              <h3>2019 Hack Oregon Team</h3>
+              <img
+                css={authorPhoto}
+                src={authorsSrc}
+                alt="Pictures of people who worked on this"
+              />
+            </section>
+          </Fragment>
+        )}
         <hr css={[sectionMarginSmall, sectionMaxWidthSmall]} />
         <section css={[sectionMarginSmall, sectionMaxWidthSmall]} id="improve">
           <h2>Help make this better</h2>

--- a/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
+++ b/packages/component-library/src/CivicCard/CivicCardLayoutFull.js
@@ -283,19 +283,21 @@ function CivicCardLayoutFull({ isLoading, data, cardMeta }) {
                 />
               </Fragment>
             ) : (
-              <p>
-                <em>This dataset is missing context documentation</em>
-                <br />
-                <br />
-                Documenting how and why a dataset was created, what information
-                it contains, its limitations, and possible ethical or legal
-                concerns is paramount for data that informs decision making. If
-                you’re an expert on this dataset, you can{" "}
-                <a href="https://forms.gle/rggpgLGRtfaQDm5f7">
-                  add documentation
-                </a>
-                .
-              </p>
+              cardMeta.context || (
+                <p>
+                  <em>This dataset is missing context documentation</em>
+                  <br />
+                  <br />
+                  Documenting how and why a dataset was created, what
+                  information it contains, its limitations, and possible ethical
+                  or legal concerns is paramount for data that informs decision
+                  making. If you’re an expert on this dataset, you can{" "}
+                  <a href="https://forms.gle/rggpgLGRtfaQDm5f7">
+                    add documentation
+                  </a>
+                  .
+                </p>
+              )
             )}
           </section>
         </Fragment>

--- a/packages/component-library/src/Header/FullNav.js
+++ b/packages/component-library/src/Header/FullNav.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
 import { useState, useRef } from "react";
@@ -155,163 +156,13 @@ const FullNav = props => {
       <nav css={navStyle} aria-label="Site">
         <ul css={linkContainer}>
           <li css={listStyle}>
-            <Link to="/cards" css={linkStyle}>
-              EXPLORE CIVIC
-            </Link>
-          </li>
-          <li css={listStyle}>
-            <button
-              css={menuButton}
-              type="button"
-              ref={joinAnchorRef}
-              aria-controls="menu-list-grow"
-              aria-haspopup="true"
-              onClick={handleJoinToggle}
-            >
-              <p css={buttonText}>
-                JOIN THE MOVEMENT
-                <span>
-                  <img css={caratStyle} src={navCaret} alt="" />
-                </span>
-              </p>
-            </button>
-            <Popper
-              open={joinOpen}
-              anchorEl={joinAnchorRef.current}
-              transition
-              disablePortal
-            >
-              {({ TransitionProps, placement }) => (
-                <Grow
-                  {...TransitionProps}
-                  style={{
-                    transformOrigin:
-                      placement === "bottom" ? "center top" : "center bottom",
-                    ...dropdownStyles
-                  }}
-                >
-                  <Paper id="menu-list-grow" square>
-                    <div css={arrowUp} />
-                    <ClickAwayListener onClickAway={handleJoinClose}>
-                      <MenuList>
-                        <MenuItem
-                          onClick={handleJoinClose}
-                          style={optionText}
-                          dense
-                        >
-                          <Link
-                            to={{
-                              pathname: "/",
-                              hash: "#work-with-us"
-                            }}
-                            css={menuLink}
-                          >
-                            Work With Us
-                          </Link>
-                        </MenuItem>
-                        <MenuItem
-                          onClick={handleJoinClose}
-                          style={optionText}
-                          dense
-                        >
-                          <Link
-                            to={{
-                              pathname: "/",
-                              hash: "#become-a-contributor"
-                            }}
-                            css={menuLink}
-                          >
-                            Become a Contributor
-                          </Link>
-                        </MenuItem>
-                      </MenuList>
-                    </ClickAwayListener>
-                  </Paper>
-                </Grow>
-              )}
-            </Popper>
-          </li>
-          <li css={listStyle}>
-            <button
-              css={menuButton}
-              type="button"
-              ref={aboutAnchorRef}
-              aria-controls="menu-list-grow"
-              aria-haspopup="true"
-              onClick={handleAboutToggle}
-            >
-              <p css={buttonText}>
-                ABOUT
-                <span>
-                  <img css={caratStyle} src={navCaret} alt="" />
-                </span>
-              </p>
-            </button>
-            <Popper
-              open={aboutOpen}
-              anchorEl={aboutAnchorRef.current}
-              transition
-              disablePortal
-            >
-              {({ TransitionProps, placement }) => (
-                <Grow
-                  {...TransitionProps}
-                  style={{
-                    transformOrigin:
-                      placement === "bottom" ? "center top" : "center bottom",
-                    ...dropdownStyles
-                  }}
-                >
-                  <Paper id="menu-list-grow" square>
-                    <div css={arrowUp} />
-                    <ClickAwayListener onClickAway={handleAboutClose}>
-                      <MenuList>
-                        <MenuItem
-                          onClick={handleAboutClose}
-                          style={optionText}
-                          dense
-                        >
-                          <Link
-                            to={{
-                              pathname: "/",
-                              hash: "#civic-platform"
-                            }}
-                            css={menuLink}
-                          >
-                            Civic Platform
-                          </Link>
-                        </MenuItem>
-                        <MenuItem
-                          onClick={handleAboutClose}
-                          style={optionText}
-                          dense
-                        >
-                          <Link
-                            to={{
-                              pathname: "/",
-                              hash: "#civic-software-foundation"
-                            }}
-                            css={menuLink}
-                          >
-                            Civic Software Foundation
-                          </Link>
-                        </MenuItem>
-                      </MenuList>
-                    </ClickAwayListener>
-                  </Paper>
-                </Grow>
-              )}
-            </Popper>
-          </li>
-          <li css={listStyle}>
             <Link
               to={{
-                pathname: "/",
-                hash: "#contact-us"
+                hash: "#"
               }}
               css={linkStyle}
             >
-              CONTACT
+              DEMO ONLY
             </Link>
           </li>
         </ul>

--- a/packages/component-library/src/Header/FullNav.js
+++ b/packages/component-library/src/Header/FullNav.js
@@ -149,7 +149,7 @@ const FullNav = props => {
 
   return (
     <div css={contentWrapper(props)}>
-      <Link to="/">
+      <Link to="/cards/housing-displacement">
         <Logo alt="CIVIC home page" css={logoStyle} type="squareLogo" />
       </Link>
       <div />
@@ -158,11 +158,12 @@ const FullNav = props => {
           <li css={listStyle}>
             <Link
               to={{
+                pathname: "/cards/housing-displacement",
                 hash: "#"
               }}
               css={linkStyle}
             >
-              DEMO ONLY
+              THIS IS A DEMO
             </Link>
           </li>
         </ul>

--- a/packages/component-library/src/Header/SmallNav.js
+++ b/packages/component-library/src/Header/SmallNav.js
@@ -101,7 +101,7 @@ const SmallNav = () => {
             <img src={hamburgerMenu} alt="Close menu" />
           </button>
         </div>
-        <Link to="/" css={logoWrapper}>
+        <Link to="/cards/housing-displacement" css={logoWrapper}>
           <Logo type="squareLogo" css={logoStyle} />
         </Link>
         <div />
@@ -110,11 +110,12 @@ const SmallNav = () => {
         <ListItem>
           <Link
             to={{
+              pathname: "/cards/housing-displacement",
               hash: "#contact-us"
             }}
             css={subLinkStyle}
           >
-            <ListItemText primary="DEMO ONLY" />
+            <ListItemText primary="THIS IS A DEMO" />
           </Link>
         </ListItem>
       </List>

--- a/packages/component-library/src/Header/SmallNav.js
+++ b/packages/component-library/src/Header/SmallNav.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
 import { useState } from "react";
@@ -106,80 +107,14 @@ const SmallNav = () => {
         <div />
       </div>
       <List component="nav" style={{ paddingTop: 0 }}>
-        <Divider />
-        <ListItem>
-          <Link to="/cards" css={linkStyle}>
-            <ListItemText primary="EXPLORE CIVIC" />
-          </Link>
-        </ListItem>
-
-        <Divider />
-
-        <ListSubheader component="div" id="nested-list-subheader">
-          <p css={subHeaderStyle}>JOIN THE MOVEMENT</p>
-        </ListSubheader>
         <ListItem>
           <Link
             to={{
-              pathname: "/",
-              hash: "#work-with-us"
-            }}
-            css={subLinkStyle}
-          >
-            <ListItemText primary="Work With Us" />
-          </Link>
-        </ListItem>
-        <ListItem>
-          <Link
-            to={{
-              pathname: "/",
-              hash: "#become-a-contributor"
-            }}
-            css={subLinkStyle}
-          >
-            <ListItemText primary="Become a Contributor" />
-          </Link>
-        </ListItem>
-
-        <Divider />
-
-        <ListSubheader component="div" id="nested-list-subheader">
-          <p css={subHeaderStyle}>ABOUT</p>
-        </ListSubheader>
-        <ListItem>
-          <Link
-            to={{
-              pathname: "/",
-              hash: "#civic-platform"
-            }}
-            css={subLinkStyle}
-          >
-            <ListItemText primary="Civic Platform" />
-          </Link>
-        </ListItem>
-        <ListItem>
-          <Link
-            to={{
-              pathname: "/",
-              hash: "#civic-software-foundation"
-            }}
-            css={subLinkStyle}
-          >
-            <ListItemText primary="Civic Software Foundation" />
-          </Link>
-        </ListItem>
-
-        <Divider />
-
-        <ListItem>
-          <Link
-            to={{
-              pathname: "/",
               hash: "#contact-us"
             }}
             css={subLinkStyle}
           >
-            <ListItemText primary="CONTACT" />
+            <ListItemText primary="DEMO ONLY" />
           </Link>
         </ListItem>
       </List>

--- a/packages/component-library/src/_Themes/MaterialUI/MaterialUITheme.js
+++ b/packages/component-library/src/_Themes/MaterialUI/MaterialUITheme.js
@@ -89,8 +89,10 @@ const MaterialTheme = createMuiTheme({
       }
     },
     MuiDataGrid: {
-      colCellWrapper: {
-        fontWeight: 700
+      root: {
+        "& .MuiDataGrid-colCellTitle": {
+          fontWeight: 700
+        }
       }
     }
   }

--- a/packages/component-library/src/_Themes/MaterialUI/MaterialUITheme.js
+++ b/packages/component-library/src/_Themes/MaterialUI/MaterialUITheme.js
@@ -87,6 +87,11 @@ const MaterialTheme = createMuiTheme({
       root: {
         display: "unset"
       }
+    },
+    MuiDataGrid: {
+      colCellWrapper: {
+        fontWeight: 700
+      }
     }
   }
 });

--- a/packages/component-library/src/_Themes/MaterialUI/MaterialUITheme.js
+++ b/packages/component-library/src/_Themes/MaterialUI/MaterialUITheme.js
@@ -82,6 +82,11 @@ const MaterialTheme = createMuiTheme({
         minHeight: "unset",
         lineHeight: "unset"
       }
+    },
+    MuiAccordionDetails: {
+      root: {
+        display: "unset"
+      }
     }
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,6 +2772,15 @@
     react-is "^16.8.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/data-grid@^4.0.0-alpha.28":
+  version "4.0.0-alpha.28"
+  resolved "https://registry.npmjs.org/@material-ui/data-grid/-/data-grid-4.0.0-alpha.28.tgz#a82f0e382c8abffa7e7d50d31a4706f8c30215e9"
+  integrity sha512-a6xZj0pMIX2uGsyMMZP/kZISo7MKS43+hHApoHeije82yMAPKhTXV7/SCuAFoF9qye14XeSclwmwOkN2AJRAPg==
+  dependencies:
+    "@material-ui/utils" "^5.0.0-alpha.14"
+    prop-types "^15.7.2"
+    reselect "^4.0.0"
+
 "@material-ui/icons@^4.4.1", "@material-ui/icons@^4.5.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.9.1.tgz#fdeadf8cb3d89208945b33dbc50c7c616d0bd665"
@@ -2824,6 +2833,17 @@
     "@babel/runtime" "^7.4.4"
     prop-types "^15.7.2"
     react-is "^16.8.0"
+
+"@material-ui/utils@^5.0.0-alpha.14":
+  version "5.0.0-alpha.33"
+  resolved "https://registry.npmjs.org/@material-ui/utils/-/utils-5.0.0-alpha.33.tgz#ed2961ce9e700cb3af1a7e663af67d33e8455fdb"
+  integrity sha512-jzXUtTntCC7fumvXvT+scHj6t/A+qUKJ3XM/C1ZtPmPg4dA5+XmhD8uU9wZU3IuaDb66LJdZnfnhRD72052k+Q==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@types/prop-types" "^15.7.3"
+    "@types/react-is" "^16.7.1 || ^17.0.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.0"
 
 "@mdx-js/loader@^1.5.1":
   version "1.6.19"
@@ -4436,7 +4456,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.7.3":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
@@ -4474,6 +4494,13 @@
   dependencies:
     "@types/react" "*"
     "@types/reactcss" "*"
+
+"@types/react-is@^16.7.1 || ^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.0.tgz#6b60190ae60591ae0c83d6f3854e61e08f5a7976"
+  integrity sha512-A0DQ1YWZ0RG2+PV7neAotNCIh8gZ3z7tQnDJyS2xRPDNtAtSPcJ9YyfMP8be36Ha0kQRzbZCrrTMznA4blqO5g==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-syntax-highlighter@11.0.4":
   version "11.0.4"
@@ -17205,7 +17232,7 @@ react-dock@^0.2.4:
     lodash.debounce "^3.1.1"
     prop-types "^15.5.8"
 
-react-dom@^16.0.0, react-dom@^16.13.1, react-dom@^16.8.3, react-dom@^16.8.4:
+react-dom@^16.0.0, react-dom@^16.8.3, react-dom@^16.8.4:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -17321,6 +17348,11 @@ react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.4.2, react
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.0:
+  version "17.0.2"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-json-tree@^0.11.0:
   version "0.11.2"
@@ -17649,7 +17681,7 @@ react-virtualized-auto-sizer@^1.0.2:
   resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
   integrity sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg==
 
-react@^16.0.0, react@^16.13.1, react@^16.8.3, react@^16.8.4, react@^16.9.17:
+react@^16.0.0, react@^16.8.3, react@^16.8.4, react@^16.9.17:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
This is a sample implementation showing how context could look more deeply incorporated into a CIVIC Card. 

It is not intended to be merged, it's just a demo

- minimal addition of context section
- add math and notebook preview
- update civic card layout for optional context prop
- stub accordian and initial design work
- add hideAuthors to full card layout
- update accordian and sections
